### PR TITLE
Initial ELF Loader

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,502 @@
+                  GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 2.1, February 1999
+
+ Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+ 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+ as the successor of the GNU Library Public License, version 2, hence
+ the version number 2.1.]
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+                  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+           How to Apply These Terms to Your New Libraries
+
+  If you develop a new library, and you want it to be of the greatest
+possible use to the public, we recommend making it free software that
+everyone can redistribute and change.  You can do so by permitting
+redistribution under these terms (or, alternatively, under the terms of the
+ordinary General Public License).
+
+  To apply these terms, attach the following notices to the library.  It is
+safest to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least the
+"copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the library's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Also add information on how to contact you by electronic and paper mail.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the library, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the
+  library `Frob' (a library for tweaking knobs) written by James Random Hacker.
+
+  <signature of Ty Coon>, 1 April 1990
+  Ty Coon, President of Vice
+
+That's all there is to it!

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Bareflank Hypervisor
 #
@@ -21,34 +19,14 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-set -e
+################################################################################
+# Subdirs
+################################################################################
 
-if [ $# -gt 0 ]; then
-    if [ $1 = "clean" ]; then
+SUBDIRS += elf_loader
 
-        rm -Rf ./tools/doxygen/osx/src
-        exit
-    fi
-fi
+################################################################################
+# Common
+################################################################################
 
-if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
-
-	pushd tools/doxygen/osx
-	rm -Rf src
-
-	git clone https://github.com/doxygen/doxygen.git src
-
-	cd src
-	mkdir build
-  	cd build
-  	cmake -G "Unix Makefiles" ../
-	make -j
-
-	popd
-fi
-
-rm -Rf doc
-mkdir doc
-
-cd doc
-../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt
+include ./common/common_subdir.mk

--- a/README.md
+++ b/README.md
@@ -7,7 +7,35 @@ The Bareflank Hypervisor aims to provide a platform for performing hypervisor re
 - Zero legacy support (e.g. requires 64bit)
 - Written in C++
 - Cross Platform
-- Few external dependencies 
+- Few external dependencies
+
+## Compilation Instructions
+
+Before you can compile, you must have a native GCC installer, as well as a
+GCC cross-compiler. For instructions on how to setup a GCC cross-compiler,
+please see the following:
+
+https://github.com/Bareflank/hypervisor/tree/master/doc/cross_compilers
+
+These instructions setup a cross-compiler for this project in
+~/opt/cross/bin/x86_64-elf-XXX. Assuming you followed these instructions,
+you should be able to run:
+
+```
+make
+make clean
+```
+
+If you placed the cross-compiler into a different directory, simply do the
+following (replace the path with yours);
+
+```
+export CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
+export CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+export CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+make -e
+make -e clean
+```
 
 ## Contributing
 
@@ -19,4 +47,4 @@ https://github.com/Bareflank/hypervisor/wiki/Contributing
 ## License
 
 The Bareflank Hypervisor is licensed under the GNU Lesser General Public License
-v2.1 (LGPL) library. 
+v2.1 (LGPL).

--- a/common/common_subdir.mk
+++ b/common/common_subdir.mk
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Bareflank Hypervisor
 #
@@ -21,34 +19,29 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-set -e
+################################################################################
+# Color
+################################################################################
 
-if [ $# -gt 0 ]; then
-    if [ $1 = "clean" ]; then
+CS='\033[1;34m'
+CE='\033[0m'
 
-        rm -Rf ./tools/doxygen/osx/src
-        exit
-    fi
-fi
+################################################################################
+# Targets
+################################################################################
 
-if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
+.PHONY: all
+.PHONY: clean
+.PHONY: custom_clean
 
-	pushd tools/doxygen/osx
-	rm -Rf src
+all:
+	@for dir in $(SUBDIRS); do \
+		echo $(CS)$(PWD)/$$dir$(CE); \
+		$(MAKE) -C $$dir; \
+	done
 
-	git clone https://github.com/doxygen/doxygen.git src
-
-	cd src
-	mkdir build
-  	cd build
-  	cmake -G "Unix Makefiles" ../
-	make -j
-
-	popd
-fi
-
-rm -Rf doc
-mkdir doc
-
-cd doc
-../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt
+clean: custom_clean
+	@for dir in $(SUBDIRS); do \
+		echo $(CS)$(PWD)/$$dir$(CE); \
+		$(MAKE) -C $$dir clean; \
+	done

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -1,0 +1,129 @@
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# Automated Sources
+################################################################################
+
+# The following provides us a place to handle OS specific logic.
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	BIN_EXT=
+	LIB_EXT=.so
+	LIB_PRE=lib
+else
+	ifeq ($(OS),Windows_NT)
+		BIN_EXT=.exe
+		LIB_EXT=.dll
+		LIB_PRE=
+	else
+		UNAME=$(shell uname -s)
+		ifeq ($(UNAME),Linux)
+			BIN_EXT=
+			LIB_EXT=.so
+			LIB_PRE=lib
+		endif
+		ifeq ($(UNAME),Darwin)
+			BIN_EXT=
+			LIB_EXT=.dylib
+			LIB_PRE=lib
+			ifeq ($(TARGET_TYPE),lib)
+				LDFLAGS += -undefined dynamic_lookup
+			endif
+		endif
+	endif
+endif
+
+# If we have a library, we need to compile the executable using -shared, and
+# -pic for the compilation stage. We also need to modify the target name as
+# libraries have very spcific names
+ifeq ($(TARGET_TYPE),lib)
+	CCFLAGS+=-fpic
+	CXXFLAGS+=-fpic
+	LDFLAGS+=-shared
+	TARGET=$(patsubst %,$(OUTDIR)/$(LIB_PRE)%$(LIB_EXT),$(TARGET_NAME))
+else
+	TARGET=$(patsubst %,$(OUTDIR)/%$(BIN_EXT),$(TARGET_NAME))
+endif
+
+# Get a list of C and CPP sources
+CC_SOURCES=$(filter %.c,$(SOURCES))
+CXX_SOURCES=$(filter %.cpp,$(SOURCES))
+
+# Create a list of object files to compile for C and CPP
+CC_OBJECTS=$(patsubst %.c,$(OBJDIR)/%.o,$(CC_SOURCES))
+CXX_OBJECTS=$(patsubst %.cpp,$(OBJDIR)/%.o,$(CXX_SOURCES))
+
+# Concat the object file list (we need both forms)
+OBJECTS+=$(CC_OBJECTS)
+OBJECTS+=$(CXX_OBJECTS)
+
+# Create a list of include files for C and CPP
+CC_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
+CXX_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
+
+# Create a list of lib files for C and CPP
+LD_FLAGS_LIBS=$(patsubst %,-l%,$(LIBS))
+LD_FLAGS_LIB_PATHS=$(patsubst %,-L%,$(LIB_PATHS))
+
+################################################################################
+# Dependency Auto-Genetaion
+################################################################################
+
+# http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
+
+DFLAGS=$(patsubst %,-D%,$(DEFINES))
+DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)/$*.Td
+POSTCOMPILE = @mv -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
+
+################################################################################
+# Targets
+################################################################################
+
+.PHONY: all
+.PHONY: clean
+.PHONY: custom_clean
+
+.DEFAULT_GOAL := all
+
+all: $(OBJDIR) $(OUTDIR) $(TARGET)
+
+$(OBJDIR):
+	@$(MD) $(OBJDIR)
+
+$(OUTDIR):
+	@$(MD) $(OUTDIR)
+
+$(OBJDIR)/%.o: %.c $(OBJDIR)/%.d
+	$(CC) $< -o $@ -c $(CCFLAGS) $(DFLAGS) $(DEPFLAGS) $(CC_FLAGS_INCLUDE_PATHS) $(INCLUDES)
+	$(POSTCOMPILE)
+
+$(OBJDIR)/%.o: %.cpp $(OBJDIR)/%.d
+	$(CXX) $< -o $@ -c $(CXXFLAGS) $(DFLAGS) $(DEPFLAGS) $(CXX_FLAGS_INCLUDE_PATHS) $(INCLUDES)
+	$(POSTCOMPILE)
+
+$(TARGET): $(OBJECTS)
+	$(LD) -o $@ $^ $(LDFLAGS) $(LD_FLAGS_LIB_PATHS) $(LD_FLAGS_LIBS)
+
+clean: custom_clean
+	$(RM) $(OBJDIR) $(TARGET)
+
+$(OBJDIR)/%.d: ;
+-include $(patsubst %,$(OBJDIR)/%.d,$(basename $(SOURCES)))

--- a/doc/roadmap/v1.0/bareflank_hypervisor_1.0_roadmap.md
+++ b/doc/roadmap/v1.0/bareflank_hypervisor_1.0_roadmap.md
@@ -28,7 +28,7 @@ Although support for clang / LLVM would be preferred, version 1.0 will be compil
 
 Unlike previous type 2 hypervisors, the Bareflank hypervisor will be cross-compiled as a separate ELF formatted binary. For this reason, the driver entry points for each host operating system will only contain the bare minimum needed to read the hypervisor from disk, load it into memory (using an ELF loader), and then begin execution of the hypervisor itself. The bulk of the driver entry points (including he ELF loader) will be written as cross-platform C code, which will be shared to reduce the overall differences between each host specific driver. 
 
-<figure><img src="https://raw.githubusercontent.com/rianquinn/hypervisor/master/doc/roadmap/v1.0/type2_init.png" alt=“type2_init”></figure>
+<figure><img src="https://raw.githubusercontent.com/Bareflank/hypervisor/master/doc/roadmap/v1.0/type2_init.png" alt=“type2_init”></figure>
 
 Since the hypervisor will be cross-compiled, it would be possible to compile the hypervisor on Windows, and use it on a Linux based host operating system. Once the hypervisor is loaded, it will perform the bootstrapping of the hypervisor itself which will include:
 

--- a/elf_loader/Makefile
+++ b/elf_loader/Makefile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Bareflank Hypervisor
 #
@@ -21,34 +19,18 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-set -e
+################################################################################
+# Subdirs
+################################################################################
 
-if [ $# -gt 0 ]; then
-    if [ $1 = "clean" ]; then
+SUBDIRS += dummy1
+SUBDIRS += dummy2
+SUBDIRS += dummy3
+SUBDIRS += src
+SUBDIRS += test
 
-        rm -Rf ./tools/doxygen/osx/src
-        exit
-    fi
-fi
+################################################################################
+# Common
+################################################################################
 
-if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
-
-	pushd tools/doxygen/osx
-	rm -Rf src
-
-	git clone https://github.com/doxygen/doxygen.git src
-
-	cd src
-	mkdir build
-  	cd build
-  	cmake -G "Unix Makefiles" ../
-	make -j
-
-	popd
-fi
-
-rm -Rf doc
-mkdir doc
-
-cd doc
-../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt
+include ../common/common_subdir.mk

--- a/elf_loader/dummy1/Makefile
+++ b/elf_loader/dummy1/Makefile
@@ -1,0 +1,65 @@
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# FLAGS
+################################################################################
+
+CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
+CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+
+CC=$(CROSS_CC)
+CXX=$(CROSS_CXX)
+LD=$(CROSS_LD)
+RM=rm -rf
+MD=mkdir -p
+
+CCFLAGS=
+CXXFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+################################################################################
+# Sources
+################################################################################
+
+TARGET_NAME=dummy1
+TARGET_TYPE=lib
+TARGET_CROSS_COMPILED=true
+
+OBJDIR=.build
+OUTDIR=../bin
+
+SOURCES=dummy1.c
+
+INCLUDES=
+LIBS=
+
+INCLUDE_PATHS=./ ../include/
+LIB_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../common/common_target.mk

--- a/elf_loader/dummy1/dummy1.cpp
+++ b/elf_loader/dummy1/dummy1.cpp
@@ -1,0 +1,37 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <dummy1.h>
+
+int g_dummy1 = 1;
+static int l_dummy1 = 1;
+
+int
+dummy1_mul1(int num)
+{
+    return num * g_dummy1;
+}
+
+int
+dummy1_add1(int num)
+{
+    return num + l_dummy1;
+}

--- a/elf_loader/dummy2/Makefile
+++ b/elf_loader/dummy2/Makefile
@@ -1,0 +1,65 @@
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# FLAGS
+################################################################################
+
+CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
+CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+
+CC=$(CROSS_CC)
+CXX=$(CROSS_CXX)
+LD=$(CROSS_LD)
+RM=rm -rf
+MD=mkdir -p
+
+CCFLAGS=
+CXXFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+################################################################################
+# Sources
+################################################################################
+
+TARGET_NAME=dummy2
+TARGET_TYPE=lib
+TARGET_CROSS_COMPILED=true
+
+OBJDIR=.build
+OUTDIR=../bin
+
+SOURCES=dummy2.c
+
+INCLUDES=
+LIBS=
+
+INCLUDE_PATHS=./ ../include/
+LIB_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../common/common_target.mk

--- a/elf_loader/dummy2/dummy2.cpp
+++ b/elf_loader/dummy2/dummy2.cpp
@@ -1,0 +1,41 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <dummy2.h>
+
+int dummy2::s_data = 2;
+
+dummy2::dummy2() :
+    m_data(2)
+{
+}
+
+int
+dummy2::dummy2_mul2(int num)
+{
+    return num * m_data;
+}
+
+int
+dummy2::dummy2_add2(int num)
+{
+    return num + s_data;
+}

--- a/elf_loader/dummy3/Makefile
+++ b/elf_loader/dummy3/Makefile
@@ -1,0 +1,65 @@
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# FLAGS
+################################################################################
+
+CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
+CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+
+CC=$(CROSS_CC)
+CXX=$(CROSS_CXX)
+LD=$(CROSS_LD)
+RM=rm -rf
+MD=mkdir -p
+
+CCFLAGS=
+CXXFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+################################################################################
+# Sources
+################################################################################
+
+TARGET_NAME=dummy3
+TARGET_TYPE=lib
+TARGET_CROSS_COMPILED=true
+
+OBJDIR=.build
+OUTDIR=../bin
+
+SOURCES=dummy3.c
+
+INCLUDES=
+LIBS=
+
+INCLUDE_PATHS=./ ../include/
+LIB_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../common/common_target.mk

--- a/elf_loader/dummy3/dummy3.cpp
+++ b/elf_loader/dummy3/dummy3.cpp
@@ -1,0 +1,65 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <dummy1.h>
+#include <dummy2.h>
+#include <dummy3.h>
+
+int g_my_glob1;
+int g_my_glob2 = 0;
+int g_my_glob3 = 3;
+
+static int l_my_glob1;
+static int l_my_glob2 = 0;
+static int l_my_glob3 = 3;
+
+int x[2], *y = x + 1;
+
+int
+dummy3_test1(int num)
+{
+    g_my_glob1 = 1;
+
+    dummy2 _dummy2;
+
+    x[0] = 1;
+    x[1] = 2;
+
+    return g_my_glob1 +
+           g_my_glob2 +
+           g_my_glob3 +
+           *y +
+           dummy1_add1(num) +
+           dummy2::dummy2_add2(num) +
+           dummy1_mul1(num) +
+           _dummy2.dummy2_mul2(num);
+}
+
+int
+dummy3_test2(int num)
+{
+    l_my_glob1 = 1;
+
+    return l_my_glob1 +
+           l_my_glob2 +
+           l_my_glob3 +
+           dummy3_test1(num);
+}

--- a/elf_loader/include/dummy1.h
+++ b/elf_loader/include/dummy1.h
@@ -1,0 +1,31 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef DUMMY1_H
+#define DUMMY1_H
+
+int
+dummy1_mul1(int num);
+
+int
+dummy1_add1(int num);
+
+#endif

--- a/elf_loader/include/dummy2.h
+++ b/elf_loader/include/dummy2.h
@@ -1,0 +1,43 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef DUMMY2_H
+#define DUMMY2_H
+
+class dummy2
+{
+public:
+
+    dummy2();
+
+    int
+    dummy2_mul2(int num);
+
+    static int
+    dummy2_add2(int num);
+
+private:
+
+    int m_data;
+    static int s_data;
+};
+
+#endif

--- a/elf_loader/include/dummy3.h
+++ b/elf_loader/include/dummy3.h
@@ -1,0 +1,31 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef DUMMY3_H
+#define DUMMY3_H
+
+int
+dummy3_test1(int num);
+
+int
+dummy3_test2(int num);
+
+#endif

--- a/elf_loader/include/elf_loader.h
+++ b/elf_loader/include/elf_loader.h
@@ -1,0 +1,1028 @@
+/*
+ * Bareflank Hypervisor
+ *
+ * Copyright (C) 2015 Assured Information Security, Inc.
+ * Author: Rian Quinn        <quinnr@ainfosec.com>
+ * Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef ELF_LOADER_H
+#define ELF_LOADER_H
+
+#include <stdint.h>
+
+#pragma pack(push, 1)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/******************************************************************************/
+/* ELF Defines                                                                */
+/******************************************************************************/
+
+#ifndef ELF_MAX_MODULES
+#define ELF_MAX_MODULES 100
+#endif
+
+#ifndef ELF_MAX_RELTAB
+#define ELF_MAX_RELTAB 100
+#endif
+
+/******************************************************************************/
+/* ELF Data Types                                                             */
+/******************************************************************************/
+
+/*
+ * Data Representation
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 2
+ */
+
+typedef uint64_t elf64_addr;
+typedef uint64_t elf64_off;
+typedef uint16_t elf64_half;
+typedef uint32_t elf64_word;
+typedef int32_t elf64_sword;
+typedef uint64_t elf64_xword;
+typedef int64_t elf64_sxword;
+
+const elf64_sword ELF_TRUE = 1;
+const elf64_sword ELF_FALSE = 0;
+
+/******************************************************************************/
+/* ELF Error Codes                                                            */
+/******************************************************************************/
+
+/*
+ * ELF error codes
+ *
+ * The following define the different error codes that this library might
+ * provide given bad input.
+ */
+const elf64_sword ELF_SUCCESS = 0;
+const elf64_sword ELF_ERROR_INVALID_ARG = -1;
+const elf64_sword ELF_ERROR_INVALID_FILE = -2;
+const elf64_sword ELF_ERROR_INVALID_INDEX = -3;
+const elf64_sword ELF_ERROR_INVALID_OFFSET = -4;
+const elf64_sword ELF_ERROR_INVALID_STRING = -5;
+const elf64_sword ELF_ERROR_INVALID_EI_MAG0 = -101;
+const elf64_sword ELF_ERROR_INVALID_EI_MAG1 = -102;
+const elf64_sword ELF_ERROR_INVALID_EI_MAG2 = -103;
+const elf64_sword ELF_ERROR_INVALID_EI_MAG3 = -104;
+const elf64_sword ELF_ERROR_INVALID_EI_CLASS = -105;
+const elf64_sword ELF_ERROR_INVALID_EI_DATA = -106;
+const elf64_sword ELF_ERROR_INVALID_EI_VERSION = -107;
+const elf64_sword ELF_ERROR_INVALID_EI_OSABI = -108;
+const elf64_sword ELF_ERROR_INVALID_EI_ABIVERSION = -109;
+const elf64_sword ELF_ERROR_INVALID_E_TYPE = -110;
+const elf64_sword ELF_ERROR_INVALID_E_MACHINE = -111;
+const elf64_sword ELF_ERROR_INVALID_E_ENTRY = -112;
+const elf64_sword ELF_ERROR_INVALID_E_PHOFF = -113;
+const elf64_sword ELF_ERROR_INVALID_E_SHOFF = -114;
+const elf64_sword ELF_ERROR_INVALID_E_FLAGS = -115;
+const elf64_sword ELF_ERROR_INVALID_E_EHSIZE = -116;
+const elf64_sword ELF_ERROR_INVALID_E_PHENTSIZE = -117;
+const elf64_sword ELF_ERROR_INVALID_E_PHNUM = -118;
+const elf64_sword ELF_ERROR_INVALID_E_SHENTSIZE = -119;
+const elf64_sword ELF_ERROR_INVALID_E_SHNUM = -120;
+const elf64_sword ELF_ERROR_INVALID_E_SHSTRNDX = -121;
+const elf64_sword ELF_ERROR_INVALID_PHT = -122;
+const elf64_sword ELF_ERROR_INVALID_SHT = -123;
+const elf64_sword ELF_ERROR_INVALID_SH_NAME = -200;
+const elf64_sword ELF_ERROR_INVALID_SH_TYPE = -201;
+const elf64_sword ELF_ERROR_INVALID_SH_FLAGS = -202;
+const elf64_sword ELF_ERROR_INVALID_SH_ADDR = -203;
+const elf64_sword ELF_ERROR_INVALID_SH_OFFSET = -204;
+const elf64_sword ELF_ERROR_INVALID_SH_SIZE = -205;
+const elf64_sword ELF_ERROR_INVALID_SH_LINK = -206;
+const elf64_sword ELF_ERROR_INVALID_SH_INFO = -207;
+const elf64_sword ELF_ERROR_INVALID_SH_ADDRALIGN = -208;
+const elf64_sword ELF_ERROR_INVALID_SH_ENTSIZE = -209;
+const elf64_sword ELF_ERROR_INVALID_PH_TYPE = -300;
+const elf64_sword ELF_ERROR_INVALID_PH_FLAGS = -301;
+const elf64_sword ELF_ERROR_INVALID_PH_OFFSET = -302;
+const elf64_sword ELF_ERROR_INVALID_PH_VADDR = -303;
+const elf64_sword ELF_ERROR_INVALID_PH_PADDR = -304;
+const elf64_sword ELF_ERROR_INVALID_PH_FILESZ = -305;
+const elf64_sword ELF_ERROR_INVALID_PH_MEMSZ = -306;
+const elf64_sword ELF_ERROR_INVALID_PH_ALIGN = -307;
+const elf64_sword ELF_ERROR_INVALID_STRING_TABLE = -400;
+const elf64_sword ELF_ERROR_NO_SUCH_SYMBOL = -500;
+const elf64_sword ELF_ERROR_SYMBOL_UNDEFINED = -501;
+const elf64_sword ELF_ERROR_LOADER_FULL = -600;
+const elf64_sword ELF_ERROR_INVALID_LOADER = -601;
+const elf64_sword ELF_ERROR_INVALID_RELOCATION_TYPE = -701;
+
+
+const char *ELF_SUCCESS_STR = "Success (ELF_SUCCESS)";
+const char *ELF_ERROR_INVALID_ARG_STR = "Invalid argument (ELF_ERROR_INVALID_ARG)";
+const char *ELF_ERROR_INVALID_FILE_STR = "Invalid elf file (ELF_ERROR_INVALID_FILE)";
+const char *ELF_ERROR_INVALID_INDEX_STR = "Invalid index (ELF_ERROR_INVALID_INDEX)";
+const char *ELF_ERROR_INVALID_OFFSET_STR = "Invalid offset (ELF_ERROR_INVALID_OFFSET)";
+const char *ELF_ERROR_INVALID_STRING_STR = "Invliad string (ELF_ERROR_INVALID_STRING)";
+const char *ELF_ERROR_INVALID_EI_MAG0_STR = "Invalid magic number (0) in elf header (ELF_ERROR_INVALID_EI_MAG0)";
+const char *ELF_ERROR_INVALID_EI_MAG1_STR = "Invalid magic number (1) in elf header (ELF_ERROR_INVALID_EI_MAG1)";
+const char *ELF_ERROR_INVALID_EI_MAG2_STR = "Invalid magic number (2) in elf header (ELF_ERROR_INVALID_EI_MAG2)";
+const char *ELF_ERROR_INVALID_EI_MAG3_STR = "Invalid magic number (3) in elf header (ELF_ERROR_INVALID_EI_MAG3)";
+const char *ELF_ERROR_INVALID_EI_CLASS_STR = "Invalid class field in elf header (ELF_ERROR_INVALID_EI_CLASS)";
+const char *ELF_ERROR_INVALID_EI_DATA_STR = "Invalid data field in elf header (ELF_ERROR_INVALID_EI_DATA)";
+const char *ELF_ERROR_INVALID_EI_VERSION_STR = "Invalid version in elf header (ELF_ERROR_INVALID_EI_VERSION)";
+const char *ELF_ERROR_INVALID_EI_OSABI_STR = "Invalid OS/ABI field in elf header (ELF_ERROR_INVALID_EI_OSABI)";
+const char *ELF_ERROR_INVALID_EI_ABIVERSION_STR = "Invalid ABI version in elf header (ELF_ERROR_INVALID_EI_ABIVERSION)";
+const char *ELF_ERROR_INVALID_E_TYPE_STR = "Invalid type field in elf header (ELF_ERROR_INVALID_E_TYPE)";
+const char *ELF_ERROR_INVALID_E_MACHINE_STR = "Invalid machine ID in elf header (ELF_ERROR_INVALID_E_MACHINE)";
+const char *ELF_ERROR_INVALID_E_ENTRY_STR = "Invalid entry point in elf header (ELF_ERROR_INVALID_E_ENTRY)";
+const char *ELF_ERROR_INVALID_E_PHOFF_STR = "Invalid program header offset in elf header (ELF_ERROR_INVALID_E_PHOFF)";
+const char *ELF_ERROR_INVALID_E_SHOFF_STR = "Invalid section header offset in elf header (ELF_ERROR_INVALID_E_SHOFF)";
+const char *ELF_ERROR_INVALID_E_FLAGS_STR = "Invalid flags in elf header (ELF_ERROR_INVALID_E_FLAGS)";
+const char *ELF_ERROR_INVALID_E_EHSIZE_STR = "Invalid header size in elf header (ELF_ERROR_INVALID_E_EHSIZE)";
+const char *ELF_ERROR_INVALID_E_PHENTSIZE_STR = "Invalid program entry header size in elf header (ELF_ERROR_INVALID_E_PHENTSIZE)";
+const char *ELF_ERROR_INVALID_E_PHNUM_STR = "Invalid number of program entries in elf header (ELF_ERROR_INVALID_E_PHNUM)";
+const char *ELF_ERROR_INVALID_E_SHENTSIZE_STR = "Invalid section header size in elf header (ELF_ERROR_INVALID_E_SHENTSIZE)";
+const char *ELF_ERROR_INVALID_E_SHNUM_STR = "Invalid number of section entries in elf header (ELF_ERROR_INVALID_E_SHNUM)";
+const char *ELF_ERROR_INVALID_E_SHSTRNDX_STR = "Invalid section name string index table in elf header (ELF_ERROR_INVALID_E_SHSTRNDX)";
+const char *ELF_ERROR_INVALID_PHT_STR = "Invalid program header table (ELF_ERROR_INVALID_PHT)";
+const char *ELF_ERROR_INVALID_SHT_STR = "Invalid section header table (ELF_ERROR_INVALID_SHT)";
+const char *ELF_ERROR_INVALID_SH_NAME_STR = "Invalid section name (ELF_ERROR_INVALID_SH_NAME)";
+const char *ELF_ERROR_INVALID_SH_TYPE_STR = "Invalid section type (ELF_ERROR_INVALID_SH_TYPE)";
+const char *ELF_ERROR_INVALID_SH_FLAGS_STR = "Invalid section flags (ELF_ERROR_INVALID_SH_FLAGS)";
+const char *ELF_ERROR_INVALID_SH_ADDR_STR = "Invalid section address (ELF_ERROR_INVALID_SH_ADDR)";
+const char *ELF_ERROR_INVALID_SH_OFFSET_STR = "Invalid section offset (ELF_ERROR_INVALID_SH_OFFSET)";
+const char *ELF_ERROR_INVALID_SH_SIZE_STR = "Invalid section size (ELF_ERROR_INVALID_SH_SIZE)";
+const char *ELF_ERROR_INVALID_SH_LINK_STR = "Invalid section link (ELF_ERROR_INVALID_SH_LINK)";
+const char *ELF_ERROR_INVALID_SH_INFO_STR = "Invalid section info (ELF_ERROR_INVALID_SH_INFO)";
+const char *ELF_ERROR_INVALID_SH_ADDRALIGN_STR = "Invalid section address alignment (ELF_ERROR_INVALID_SH_ADDRALIGN)";
+const char *ELF_ERROR_INVALID_SH_ENTSIZE_STR = "Invalid section entry size (ELF_ERROR_INVALID_SH_ENTSIZE)";
+const char *ELF_ERROR_INVALID_PH_TYPE_STR = "Invalid segment type (ELF_ERROR_INVALID_PH_TYPE)";
+const char *ELF_ERROR_INVALID_PH_FLAGS_STR = "Invalid segment flags (ELF_ERROR_INVALID_PH_FLAGS)";
+const char *ELF_ERROR_INVALID_PH_OFFSET_STR = "Invalid segment offset (ELF_ERROR_INVALID_PH_OFFSET)";
+const char *ELF_ERROR_INVALID_PH_VADDR_STR = "Invalid segment vaddr (ELF_ERROR_INVALID_PH_VADDR)";
+const char *ELF_ERROR_INVALID_PH_PADDR_STR = "Invalid segment paddr (ELF_ERROR_INVALID_PH_PADDR)";
+const char *ELF_ERROR_INVALID_PH_FILESZ_STR = "Invalid segment file size (ELF_ERROR_INVALID_PH_FILESZ)";
+const char *ELF_ERROR_INVALID_PH_MEMSZ_STR = "Invalid segment mem size (ELF_ERROR_INVALID_PH_MEMSZ)";
+const char *ELF_ERROR_INVALID_PH_ALIGN_STR = "Invalid segment alignment (ELF_ERROR_INVALID_PH_ALIGN)";
+const char *ELF_ERROR_INVALID_STRING_TABLE_STR = "Invalid string table (ELF_ERROR_INVALID_STRING_TABLE)";
+const char *ELF_ERROR_NO_SUCH_SYMBOL_STR = "Unable to find symbol (ELF_ERROR_NO_SUCH_SYMBOL)";
+const char *ELF_ERROR_SYMBOL_UNDEFINED_STR = "Symbol is undefined (ELF_ERROR_SYMBOL_UNDEFINED)";
+const char *ELF_ERROR_LOADER_FULL_STR = "Loader is full (ELF_ERROR_LOADER_FULL_STR)";
+const char *ELF_ERROR_INVALID_LOADER_STR = "Invalid loader (ELF_ERROR_INVALID_LOADER)";
+const char *ELF_ERROR_INVALID_RELOCATION_TYPE_STR = "Invalid relocation type (ELF_ERROR_INVALID_RELOCATION_TYPE)";
+
+/*
+ * ELF error
+ *
+ * Returns a human reabable form of an ELF error
+ *
+ * @param error the return code from an ELF function
+ * @return resulting string
+ */
+const char *
+elf_error(elf64_sword error);
+
+/******************************************************************************/
+/* ELF File                                                                   */
+/******************************************************************************/
+
+struct elf_sym;
+struct elf_rel;
+struct elf_shdr;
+struct elf64_ehdr;
+
+/*
+ * Relocation Table
+ *
+ * The following is used by this API to store information about a symbol
+ * table.
+ */
+struct reltab_t
+{
+    elf64_sword num;
+    struct elf_rel *tab;
+};
+
+struct relatab_t
+{
+    elf64_sword num;
+    struct elf_rela *tab;
+};
+
+/*
+ * ELF File
+ *
+ * The following is used by this API to store information about the ELF file
+ * being used.
+ */
+struct elf_file_t
+{
+    char *file;
+    char *exec;
+    elf64_sword fsize;
+    elf64_sword esize;
+
+    struct elf64_ehdr *ehdr;
+    struct elf_shdr *shdrtab;
+    struct elf_phdr *phdrtab;
+
+    struct elf_shdr *dynsym;
+    struct elf_shdr *strtab;
+    struct elf_shdr *shstrtab;
+
+    elf64_sword symnum;
+    struct elf_sym *symtab;
+
+    elf64_sword efnum;
+    struct elf_file_t *eftab[ELF_MAX_MODULES];
+
+    elf64_sword num_rel;
+    struct reltab_t reltab[ELF_MAX_RELTAB];
+
+    elf64_sword num_rela;
+    struct relatab_t relatab[ELF_MAX_RELTAB];
+
+    elf64_sword valid;
+};
+
+elf64_sword
+elf_file_init(char *file, elf64_sword fsize, struct elf_file_t *ef);
+
+elf64_sword
+elf_file_load(struct elf_file_t *ef, char *exec, elf64_sword esize);
+
+/******************************************************************************/
+/* ELF Loader                                                                 */
+/******************************************************************************/
+
+struct elf_loader_t
+{
+    elf64_sword num;
+    struct elf_file_t *efs[ELF_MAX_MODULES];
+};
+
+elf64_sword
+elf_loader_init(struct elf_loader_t *loader);
+
+elf64_sword
+elf_loader_add(struct elf_loader_t *loader, struct elf_file_t *ef);
+
+elf64_sword
+elf_loader_relocate(struct elf_loader_t *loader);
+
+/******************************************************************************/
+/* ELF File Header                                                            */
+/******************************************************************************/
+
+/*
+ * e_ident indexes
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 3
+ */
+const elf64_sword ei_mag0 = 0;
+const elf64_sword ei_mag1 = 1;
+const elf64_sword ei_mag2 = 2;
+const elf64_sword ei_mag3 = 3;
+const elf64_sword ei_class = 4;
+const elf64_sword ei_data = 5;
+const elf64_sword ei_version = 6;
+const elf64_sword ei_osabi = 7;
+const elf64_sword ei_abiversion = 8;
+const elf64_sword ei_pad = 9;
+const elf64_sword ei_nident = 16;
+
+/*
+ * ELF Class Types
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 5
+ */
+const unsigned char elfclass32 = 1;
+const unsigned char elfclass64 = 2;
+
+const char *elfclass32_str = "ELF32 (elfclass32)";
+const char *elfclass64_str = "ELF64 (elfclass64)";
+
+/*
+ * ELF ei_class -> char *
+ *
+ * Returns a human reabable form of ei_class
+ *
+ * @param ei_class ei_class to convert to string
+ * @return resulting string
+ */
+const char *
+ei_class_to_str(unsigned char ei_class);
+
+/*
+ * ELF Data Types
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 5
+ */
+const unsigned char elfdata2lsb = 1;
+const unsigned char elfdata2msb = 2;
+
+const char *elfdata2lsb_str = "2's complement, little endian (elfdata2lsb)";
+const char *elfdata2msb_str = "2's complement, big endian (elfdata2msb)";
+
+/*
+ * ELF ei_data -> char *
+ *
+ * Returns a human reabable form of ei_data
+ *
+ * @param ei_data ei_data to convert to string
+ * @return resulting string
+ */
+const char *
+ei_data_to_str(unsigned char ei_data);
+
+/*
+ * ELF Version
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 4
+ */
+const unsigned char ev_current = 1;
+const char *ev_current_str = "1 (ev_current)";
+
+/*
+ * ELF ei_version / e_version -> char *
+ *
+ * Returns a human reabable form of ei_version and e_version
+ *
+ * @param version version to convert to string
+ * @return resulting string
+ */
+const char *
+version_to_str(unsigned char version);
+
+/*
+ * ELF OS / ABI Types
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 5
+ */
+const unsigned char elfosabi_sysv = 0;
+const unsigned char elfosabi_hpux = 1;
+const unsigned char elfosabi_standalone = 255;
+
+const char *elfosabi_sysv_str = "System V ABI (elfosabi_sysv)";
+const char *elfosabi_hpux_str = "HP-UX operating system (elfosabi_hpux)";
+const char *elfosabi_standalone_str = "Standalone (elfosabi_standalone)";
+
+/*
+ * ELF ei_osabi -> char *
+ *
+ * Returns a human reabable form of ei_osabi
+ *
+ * @param ei_osabi ei_osabi to convert to string
+ * @return resulting string
+ */
+const char *
+ei_osabi_to_str(unsigned char ei_osabi);
+
+/*
+ * ELF Types
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 5
+ */
+const elf64_half et_none = 0;
+const elf64_half et_rel = 1;
+const elf64_half et_exec = 2;
+const elf64_half et_dyn = 3;
+const elf64_half et_core = 4;
+const elf64_half et_loos = 0xFE00;
+const elf64_half et_hios = 0xFEFF;
+const elf64_half et_loproc = 0xFF00;
+const elf64_half et_hiproc = 0xFFFF;
+
+const char *et_none_str = "No file type (et_none)";
+const char *et_rel_str = "Relocatable object file (et_rel)";
+const char *et_exec_str = "Executable file (et_exec)";
+const char *et_dyn_str = "Shared object file (et_dyn)";
+const char *et_core_str = "Core file (et_core)";
+const char *et_loos_str = "Environment-specific use (et_loos)";
+const char *et_hios_str = "Environment-specific use (et_hios)";
+const char *et_loproc_str = "Processor-specific use (et_loproc)";
+const char *et_hiproc_str = "Processor-specific use (et_hiproc)";
+
+/*
+ * ELF e_type -> char *
+ *
+ * Returns a human reabable form of e_type
+ *
+ * @param e_type e_type to convert to string
+ * @return resulting string
+ */
+const char *
+e_type_to_str(elf64_half e_type);
+
+/*
+ * ELF Machine Codes
+ *
+ * The following is defined in the Linux kernel sources:
+ * linux/include/uapi/linux/elf-em.h
+ */
+const elf64_half em_none = 0;
+const elf64_half em_m32 = 1;
+const elf64_half em_sparc = 2;
+const elf64_half em_386 = 3;
+const elf64_half em_68k = 4;
+const elf64_half em_88k = 5;
+const elf64_half em_486 = 6;
+const elf64_half em_860 = 7;
+const elf64_half em_mips = 8;
+const elf64_half em_mips_rs3_le = 10;
+const elf64_half em_mips_rs4_be = 11;
+const elf64_half em_parisc = 15;
+const elf64_half em_sparc32plus = 18;
+const elf64_half em_ppc = 20;
+const elf64_half em_ppc64 = 21;
+const elf64_half em_spu = 23;
+const elf64_half em_arm = 40;
+const elf64_half em_sh = 42;
+const elf64_half em_sparcv9 = 43;
+const elf64_half em_h8_300 = 46;
+const elf64_half em_ia_64 = 50;
+const elf64_half em_x86_64 = 62;
+const elf64_half em_s390 = 22;
+const elf64_half em_cris = 76;
+const elf64_half em_v850 = 87;
+const elf64_half em_m32r = 88;
+const elf64_half em_mn10300 = 89;
+const elf64_half em_openrisc = 92;
+const elf64_half em_blackfin = 106;
+const elf64_half em_altera_nios2 = 113;
+const elf64_half em_ti_c6000 = 140;
+const elf64_half em_aarch64 = 183;
+const elf64_half em_frv = 0x5441;
+const elf64_half em_avr32 = 0x18AD;
+const elf64_half em_alpha = 0x9026;
+const elf64_half em_cygnus_v850 = 0x9080;
+const elf64_half em_cygnus_m32r = 0x9041;
+const elf64_half em_s390_old = 0xA390;
+const elf64_half em_cygnus_mn10300 = 0xBEEF;
+
+const char *em_none_str = "none";
+const char *em_m32_str = "m32";
+const char *em_sparc_str = "sparc";
+const char *em_386_str = "386";
+const char *em_68k_str = "68k";
+const char *em_88k_str = "88k";
+const char *em_486_str = "486";
+const char *em_860_str = "860";
+const char *em_mips_str = "mips";
+const char *em_mips_rs3_le_str = "mips_rs3_le";
+const char *em_mips_rs4_be_str = "mips_rs4_be";
+const char *em_parisc_str = "parisc";
+const char *em_sparc32plus_str = "sparc32plus";
+const char *em_ppc_str = "ppc";
+const char *em_ppc64_str = "ppc64";
+const char *em_spu_str = "spu";
+const char *em_arm_str = "arm";
+const char *em_sh_str = "sh";
+const char *em_sparcv9_str = "sparcv9";
+const char *em_h8_300_str = "h8_300";
+const char *em_ia_64_str = "ia_64";
+const char *em_x86_64_str = "x86_64";
+const char *em_s390_str = "s390";
+const char *em_cris_str = "cris";
+const char *em_v850_str = "v850";
+const char *em_m32r_str = "m32r";
+const char *em_mn10300_str = "mn10300";
+const char *em_openrisc_str = "openrisc";
+const char *em_blackfin_str = "blackfin";
+const char *em_altera_nios2_str = "altera_nios2";
+const char *em_ti_c6000_str = "ti_c6000";
+const char *em_aarch64_str = "aarch64";
+const char *em_frv_str = "frv";
+const char *em_avr32_str = "avr32";
+const char *em_alpha_str = "alpha";
+const char *em_cygnus_v850_str = "cygnus_v850";
+const char *em_cygnus_m32r_str = "cygnus_m32r";
+const char *em_s390_old_str = "s390_old";
+const char *em_cygnus_mn10300_str = "cygnus_mn10300";
+
+/*
+ * ELF e_machine -> char *
+ *
+ * Returns a human reabable form of e_machine
+ *
+ * @param e_machine e_machine to convert to string
+ * @return resulting string
+ */
+const char *
+e_machine_to_str(elf64_half e_machine);
+
+/*
+ * ELF File Header
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 3
+ *
+ * The file header is located at the beginning of the file, and is used to
+ * locate the other parts of the file.
+ */
+struct elf64_ehdr
+{
+    unsigned char e_ident[ei_nident];
+    elf64_half e_type;
+    elf64_half e_machine;
+    elf64_word e_version;
+    elf64_addr e_entry;
+    elf64_off e_phoff;
+    elf64_off e_shoff;
+    elf64_word e_flags;
+    elf64_half e_ehsize;
+    elf64_half e_phentsize;
+    elf64_half e_phnum;
+    elf64_half e_shentsize;
+    elf64_half e_shnum;
+    elf64_half e_shstrndx;
+};
+
+elf64_sword
+elf_file_print_header(struct elf_file_t *ef);
+
+/******************************************************************************/
+/* ELF Section Header Table                                                   */
+/******************************************************************************/
+
+/*
+ * ELF Section Type
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 7
+ */
+const elf64_word sht_null = 0;
+const elf64_word sht_progbits = 1;
+const elf64_word sht_symtab = 2;
+const elf64_word sht_strtab = 3;
+const elf64_word sht_rela = 4;
+const elf64_word sht_hash = 5;
+const elf64_word sht_dynamic = 6;
+const elf64_word sht_note = 7;
+const elf64_word sht_nobits = 8;
+const elf64_word sht_rel = 9;
+const elf64_word sht_shlib = 10;
+const elf64_word sht_dynsym = 11;
+const elf64_word sht_loos = 0x60000000;
+const elf64_word sht_hios = 0x6FFFFFFF;
+const elf64_word sht_loproc = 0x70000000;
+const elf64_word sht_hiproc = 0x7FFFFFFF;
+
+const char *sht_null_str = "Unused (sht_null)";
+const char *sht_progbits_str = "Program data (sht_progbits)";
+const char *sht_symtab_str = "Symbol table (sht_symtab)";
+const char *sht_strtab_str = "String table (sht_strtab)";
+const char *sht_rela_str = "Rela (sht_rela)";
+const char *sht_hash_str = "Hash table (sht_hash)";
+const char *sht_dynamic_str = "Dynamic linking table (sht_dynamic)";
+const char *sht_note_str = "Note info (sht_note)";
+const char *sht_nobits_str = "Uninitialized (sht_nobits)";
+const char *sht_rel_str = "Rel (sht_rel)";
+const char *sht_shlib_str = "Reserved (sht_shlib)";
+const char *sht_dynsym_str = "Dynamic loader table (sht_dynsym)";
+const char *sht_loos_str = "Process specific (sht_loos)";
+const char *sht_hios_str = "Process specific (sht_hios)";
+const char *sht_loproc_str = "Process specific (sht_loproc)";
+const char *sht_hiproc_str = "Process specific (sht_hiproc)";
+
+/*
+ * ELF sh_type -> char *
+ *
+ * Returns a human reabable form of sh_type
+ *
+ * @param sh_type sh_type to convert to string
+ * @return resulting string
+ */
+const char *
+sh_type_to_str(elf64_word sh_type);
+
+/*
+ * ELF Section Attributes
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 8
+ */
+const elf64_xword shf_write = 0x1;
+const elf64_xword shf_alloc = 0x2;
+const elf64_xword shf_execinstr = 0x4;
+const elf64_xword shf_maskos = 0x0F000000;
+const elf64_xword shf_maskproc = 0xF0000000;
+
+/*
+ * ELF sh_flags (writable) -> bool
+ *
+ * @param sh_flags sh_flags to convert to bool
+ * @return ELF_TRUE if sh_flags contains shf_write, otherwise ELF_FALSE
+ */
+elf64_sword
+sh_flags_is_writable(struct elf_shdr *shdr);
+
+/*
+ * ELF sh_flags (allocated) -> bool
+ *
+ * @param sh_flags sh_flags to convert to bool
+ * @return ELF_TRUE if sh_flags contains shf_alloc, otherwise ELF_FALSE
+ */
+elf64_sword
+sh_flags_is_allocated(struct elf_shdr *shdr);
+
+/*
+ * ELF sh_flags (executable) -> bool
+ *
+ * @param sh_flags sh_flags to convert to bool
+ * @return ELF_TRUE if sh_flags contains shf_execinstr, otherwise ELF_FALSE
+ */
+elf64_sword
+sh_flags_is_executable(struct elf_shdr *shdr);
+
+/*
+ * ELF Section Header Entry
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 6
+ *
+ * Sections contain all the information in an ELF file, except for the ELF
+ * header, program header table, and section header table. Sections are
+ * identified by an index into the section header table.
+ */
+struct elf_shdr
+{
+    elf64_word sh_name;
+    elf64_word sh_type;
+    elf64_xword sh_flags;
+    elf64_addr sh_addr;
+    elf64_off sh_offset;
+    elf64_xword sh_size;
+    elf64_word sh_link;
+    elf64_word sh_info;
+    elf64_xword sh_addralign;
+    elf64_xword sh_entsize;
+};
+
+elf64_sword
+elf_section_header(struct elf_file_t *ef,
+                   elf64_word index,
+                   struct elf_shdr **shdr);
+
+elf64_sword
+elf_print_section_header_table(struct elf_file_t *ef);
+
+elf64_sword
+elf_print_section_header(struct elf_file_t *ef,
+                         struct elf_shdr *shdr);
+
+/******************************************************************************/
+/* String Table                                                               */
+/******************************************************************************/
+
+/*
+ * String
+ *
+ * The problem with the ELF format is that strings are nothing more than a
+ * NULL terminated character array, which doesn't help much in the presence
+ * of a fuzzer. We define a string as a character array, plus a length,
+ * which we can set to ensure safety (i.e. is NULL is not present, at least
+ * we will not overrun the file).
+ */
+struct e_string
+{
+    const char *buf;
+    elf64_sword len;
+};
+
+elf64_sword
+elf_string_table_entry(struct elf_file_t *ef,
+                       struct elf_shdr *strtab,
+                       elf64_word offset,
+                       struct e_string *str);
+
+
+elf64_sword
+elf_section_name_string(struct elf_file_t *ef,
+                        struct elf_shdr *shdr,
+                        struct e_string *str);
+
+/******************************************************************************/
+/* ELF Dynamic Symbol Table                                                   */
+/******************************************************************************/
+
+const unsigned char stb_local = 0;
+const unsigned char stb_global = 1;
+const unsigned char stb_weak = 2;
+const unsigned char stb_loos = 10;
+const unsigned char stb_hios = 12;
+const unsigned char stb_loproc = 13;
+const unsigned char stb_hiproc = 15;
+
+const char *stb_local_str = "stb_local";
+const char *stb_global_str = "stb_global";
+const char *stb_weak_str = "stb_weak";
+const char *stb_loos_str = "stb_loos";
+const char *stb_hios_str = "stb_hios";
+const char *stb_loproc_str = "stb_loproc";
+const char *stb_hiproc_str = "stb_hiproc";
+
+/*
+ * ELF stb -> char *
+ *
+ * Returns a human reabable form of st_info (bind)
+ *
+ * @param st_info st_info to convert to string
+ * @return resulting string
+ */
+const char *
+stb_to_str(elf64_word st_info);
+
+const unsigned char stt_notype = 0;
+const unsigned char stt_object = 1;
+const unsigned char stt_func = 2;
+const unsigned char stt_section = 3;
+const unsigned char stt_file = 4;
+const unsigned char stt_loos = 10;
+const unsigned char stt_hios = 12;
+const unsigned char stt_loproc = 13;
+const unsigned char stt_hiproc = 15;
+
+const char *stt_notype_str = "stt_notype";
+const char *stt_object_str = "stt_object";
+const char *stt_func_str = "stt_func";
+const char *stt_section_str = "stt_section";
+const char *stt_file_str = "stt_file";
+const char *stt_loos_str = "stt_loos";
+const char *stt_hios_str = "stt_hios";
+const char *stt_loproc_str = "stt_loproc";
+const char *stt_hiproc_str = "stt_hiproc";
+
+/*
+ * ELF stt -> char *
+ *
+ * Returns a human reabable form of st_info (type)
+ *
+ * @param st_info st_info to convert to string
+ * @return resulting string
+ */
+const char *
+stt_to_str(elf64_word st_info);
+
+#define ELF_SYM_BIND(x) ((x) >> 4)
+#define ELF_SYM_TYPE(x) ((x) & 0xF)
+
+/*
+ * ELF Symbol
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 9
+ */
+struct elf_sym
+{
+    elf64_word st_name;
+    unsigned char st_info;
+    unsigned char st_other;
+    elf64_half st_shndx;
+    elf64_addr st_value;
+    elf64_xword st_size;
+};
+
+elf64_sword
+elf_symbol_by_index(struct elf_file_t *ef,
+                    elf64_word index,
+                    struct elf_sym **sym);
+
+elf64_sword
+elf_symbol_by_name(struct elf_file_t *ef,
+                   struct e_string *name,
+                   struct elf_sym **sym);
+
+elf64_sword
+elf_symbol_by_name_global(struct elf_file_t *efl,
+                          struct e_string *name,
+                          struct elf_file_t **efr,
+                          struct elf_sym **sym);
+
+elf64_sword
+elf_resolve_symbol(struct elf_file_t *ef,
+                   struct e_string *name,
+                   void **addr);
+
+elf64_sword
+elf_print_sym_table(struct elf_file_t *ef);
+
+elf64_sword
+elf_print_sym(struct elf_file_t *ef,
+              struct elf_sym *sym);
+
+/******************************************************************************/
+/* ELF Relocations                                                            */
+/******************************************************************************/
+
+const elf64_xword R_X86_64_64 = 1;
+const elf64_xword R_X86_64_GLOB_DAT = 6;
+const elf64_xword R_X86_64_JUMP_SLOT = 7;
+const elf64_xword R_X86_64_RELATIVE = 8;
+
+const char *R_X86_64_64_STR = "R_X86_64_64";
+const char *R_X86_64_GLOB_DAT_STR = "R_X86_64_GLOB_DAT";
+const char *R_X86_64_JUMP_SLOT_STR = "R_X86_64_JUMP_SLOT";
+const char *R_X86_64_RELATIVE_STR = "R_X86_64_RELATIVE";
+
+/*
+ * ELF r_info (type) -> char *
+ *
+ * Returns a human reabable form of r_info (type)
+ *
+ * @param r_info r_info to convert to string
+ * @return resulting string
+ */
+const char *
+rel_type_to_str(elf64_xword r_info);
+
+struct elf_rel
+{
+    elf64_addr r_offset;
+    elf64_xword r_info;
+};
+
+struct elf_rela
+{
+    elf64_addr r_offset;
+    elf64_xword r_info;
+    elf64_sxword r_addend;
+};
+
+#define ELF_REL_SYM(i)  ((i) >> 32)
+#define ELF_REL_TYPE(i) ((i) & 0xFFFFFFFFL)
+
+elf64_sword
+elf_relocate_symbol(struct elf_file_t *ef,
+                    struct elf_rel *rel);
+
+elf64_sword
+elf_relocate_symbol_addend(struct elf_file_t *ef,
+                           struct elf_rela *rela);
+
+elf64_sword
+elf_relocate_symbols(struct elf_file_t *ef);
+
+elf64_sword
+elf_print_relocation(struct elf_rel *rel);
+
+elf64_sword
+elf_print_relocation_addend(struct elf_rela *rela);
+
+elf64_sword
+elf_print_relocations(struct elf_file_t *ef);
+
+/******************************************************************************/
+/* ELF Program Header                                                         */
+/******************************************************************************/
+
+/*
+ * ELF Section Attributes
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 12
+ */
+const elf64_word pt_null = 0;
+const elf64_word pt_load = 1;
+const elf64_word pt_dynamic = 2;
+const elf64_word pt_interp = 3;
+const elf64_word pt_note = 4;
+const elf64_word pt_shlib = 5;
+const elf64_word pt_phdr = 6;
+const elf64_word pt_loos = 0x60000000;
+const elf64_word pt_hios = 0x6FFFFFFF;
+const elf64_word pt_loproc = 0x70000000;
+const elf64_word pt_hiproc = 0x7FFFFFFF;
+
+const char *pt_null_str = "Unused entry (pt_null)";
+const char *pt_load_str = "Loadable segment (pt_load)";
+const char *pt_dynamic_str = "Dynamic linking tables (pt_dynamic)";
+const char *pt_interp_str = "Program interpreter path name (pt_interp)";
+const char *pt_note_str = "Note sections (pt_note)";
+const char *pt_shlib_str = "Reserved (pt_shlib)";
+const char *pt_phdr_str = "Program header table (pt_phdr)";
+const char *pt_loos_str = "Environment specific (pt_loos)";
+const char *pt_hios_str = "Environment specific (pt_hios)";
+const char *pt_loproc_str = "Processor specific (pt_loproc)";
+const char *pt_hiproc_str = "Processor specific (pt_hiproc)";
+
+/*
+ * ELF p_type -> char *
+ *
+ * Returns a human reabable form of p_type
+ *
+ * @param p_type p_type to convert to string
+ * @return resulting string
+ */
+const char *
+p_type_to_str(elf64_word p_type);
+
+/*
+ * ELF Section Attributes
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 13
+ */
+const elf64_xword pf_x = 0x1;
+const elf64_xword pf_w = 0x2;
+const elf64_xword pf_r = 0x4;
+const elf64_xword pf_maskos = 0x00FF0000;
+const elf64_xword pf_maskproc = 0xFF000000;
+
+/*
+ * ELF p_flags (executable) -> bool
+ *
+ * @param p_flags p_flags to convert to bool
+ * @return ELF_TRUE if p_flags contains pf_x, otherwise ELF_FALSE
+ */
+elf64_sword
+p_flags_is_executable(struct elf_phdr *phdr);
+
+/*
+ * ELF p_flags (writable) -> bool
+ *
+ * @param p_flags p_flags to convert to bool
+ * @return ELF_TRUE if p_flags contains pf_w, otherwise ELF_FALSE
+ */
+elf64_sword
+p_flags_is_writable(struct elf_phdr *phdr);
+
+/*
+ * ELF p_flags (readable) -> bool
+ *
+ * @param p_flags p_flags to convert to bool
+ * @return ELF_TRUE if p_flags contains pf_r, otherwise ELF_FALSE
+ */
+elf64_sword
+p_flags_is_readable(struct elf_phdr *phdr);
+
+/*
+ * ELF Program Header Entry
+ *
+ * The following is defined in the ELF 64bit file format specification:
+ * http://www.uclibc.org/docs/elf-64-gen.pdf, page 12
+ *
+ * In executable and shared object files, sections are grouped into segments for
+ * loading. The program header table contains a list of entries describing
+ * each segment.
+ */
+struct elf_phdr
+{
+    elf64_word p_type;
+    elf64_word p_flags;
+    elf64_off p_offset;
+    elf64_addr p_vaddr;
+    elf64_addr p_paddr;
+    elf64_xword p_filesz;
+    elf64_xword p_memsz;
+    elf64_xword p_align;
+};
+
+elf64_sword
+elf_program_header(struct elf_file_t *ef,
+                   elf64_word index,
+                   struct elf_phdr **phdr);
+
+elf64_sxword
+elf_total_exec_size(struct elf_file_t *ef);
+
+elf64_sword
+elf_load_segments(struct elf_file_t *ef);
+
+elf64_sword
+elf_load_segment(struct elf_file_t *ef,
+                 struct elf_phdr *phdr);
+
+elf64_sword
+elf_print_program_header_table(struct elf_file_t *ef);
+
+elf64_sword
+elf_print_program_header(struct elf_file_t *ef,
+                         struct elf_phdr *phdr);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#pragma pack(pop)
+#endif

--- a/elf_loader/src/Makefile
+++ b/elf_loader/src/Makefile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Bareflank Hypervisor
 #
@@ -21,34 +19,42 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-set -e
+################################################################################
+# FLAGS
+################################################################################
 
-if [ $# -gt 0 ]; then
-    if [ $1 = "clean" ]; then
+CC=gcc
+CXX=g++
+LD=gcc
+RM=rm -rf
+MD=mkdir -p
 
-        rm -Rf ./tools/doxygen/osx/src
-        exit
-    fi
-fi
+CCFLAGS=
+CXXFLAGS=
+LDFLAGS=
 
-if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
+DEFINES=ENABLE_ELF_DEBUGGING
 
-	pushd tools/doxygen/osx
-	rm -Rf src
+################################################################################
+# Sources
+################################################################################
 
-	git clone https://github.com/doxygen/doxygen.git src
+TARGET_NAME=elf_loader
+TARGET_TYPE=lib
 
-	cd src
-	mkdir build
-  	cd build
-  	cmake -G "Unix Makefiles" ../
-	make -j
+OBJDIR=.build
+OUTDIR=../bin
 
-	popd
-fi
+SOURCES=elf_loader.c
 
-rm -Rf doc
-mkdir doc
+INCLUDES=
+LIBS=
 
-cd doc
-../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt
+INCLUDE_PATHS=./ ../include/
+LIB_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../common/common_target.mk

--- a/elf_loader/src/elf_loader.c
+++ b/elf_loader/src/elf_loader.c
@@ -1,0 +1,1964 @@
+/*
+ * Bareflank Hypervisor
+ *
+ * Copyright (C) 2015 Assured Information Security, Inc.
+ * Author: Rian Quinn        <quinnr@ainfosec.com>
+ * Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <elf_loader.h>
+
+#ifdef ENABLE_ELF_DEBUGGING
+#ifndef ELF_PRINTF
+#include <stdio.h>
+#define ELF_PRINTF printf
+#endif
+#define DEBUG(...) ELF_PRINTF("[ELF DEBUG]: " __VA_ARGS__)
+#define INFO(...) ELF_PRINTF(__VA_ARGS__)
+#else
+#define DEBUG(...)
+#define INFO(...)
+#endif
+
+/******************************************************************************/
+/* ELF Helpers                                                                */
+/******************************************************************************/
+
+/**
+ * ELF String Comapre
+ *
+ * Determines if two strings are identical. This function is case snesitive.
+ * @param str1 string to compare
+ * @param str2 string to compare
+ * @return ELF_TRUE is the strings are the same, ELF_FALSE if the strings are
+ *     different, negative on error.
+ */
+elf64_sword
+elf_strcmp(struct e_string *str1, struct e_string *str2)
+{
+    elf64_sword i = 0;
+
+    if (!str1 || !str2)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (str1->len != str2->len)
+        return ELF_FALSE;
+
+    for (i = 0; i < str1->len && i < str2->len; i++)
+    {
+        if (str1->buf[i] != str2->buf[i])
+            return ELF_FALSE;
+
+        if (str1->buf[i] == 0 ||
+            str2->buf[i] == 0)
+        {
+            return ELF_ERROR_INVALID_STRING;
+        }
+    }
+
+    return ELF_TRUE;
+}
+
+/******************************************************************************/
+/* ELF Error Codes                                                            */
+/******************************************************************************/
+
+/**
+ * Convert ELF error -> const char *
+ *
+ * @param error error code to convert
+ * @return const char * version of error code
+ */
+const char *
+elf_error(elf64_sword error)
+{
+    switch (error)
+    {
+        case ELF_SUCCESS: return ELF_SUCCESS_STR;
+        case ELF_ERROR_INVALID_ARG: return ELF_ERROR_INVALID_ARG_STR;
+        case ELF_ERROR_INVALID_FILE: return ELF_ERROR_INVALID_FILE_STR;
+        case ELF_ERROR_INVALID_INDEX: return ELF_ERROR_INVALID_INDEX_STR;
+        case ELF_ERROR_INVALID_OFFSET: return ELF_ERROR_INVALID_OFFSET_STR;
+        case ELF_ERROR_INVALID_STRING: return ELF_ERROR_INVALID_STRING_STR;
+        case ELF_ERROR_INVALID_EI_MAG0: return ELF_ERROR_INVALID_EI_MAG0_STR;
+        case ELF_ERROR_INVALID_EI_MAG1: return ELF_ERROR_INVALID_EI_MAG1_STR;
+        case ELF_ERROR_INVALID_EI_MAG2: return ELF_ERROR_INVALID_EI_MAG2_STR;
+        case ELF_ERROR_INVALID_EI_MAG3: return ELF_ERROR_INVALID_EI_MAG3_STR;
+        case ELF_ERROR_INVALID_EI_CLASS: return ELF_ERROR_INVALID_EI_CLASS_STR;
+        case ELF_ERROR_INVALID_EI_DATA: return ELF_ERROR_INVALID_EI_DATA_STR;
+        case ELF_ERROR_INVALID_EI_VERSION: return ELF_ERROR_INVALID_EI_VERSION_STR;
+        case ELF_ERROR_INVALID_EI_OSABI: return ELF_ERROR_INVALID_EI_OSABI_STR;
+        case ELF_ERROR_INVALID_EI_ABIVERSION: return ELF_ERROR_INVALID_EI_ABIVERSION_STR;
+        case ELF_ERROR_INVALID_E_TYPE: return ELF_ERROR_INVALID_E_TYPE_STR;
+        case ELF_ERROR_INVALID_E_MACHINE: return ELF_ERROR_INVALID_E_MACHINE_STR;
+        case ELF_ERROR_INVALID_E_ENTRY: return ELF_ERROR_INVALID_E_ENTRY_STR;
+        case ELF_ERROR_INVALID_E_PHOFF: return ELF_ERROR_INVALID_E_PHOFF_STR;
+        case ELF_ERROR_INVALID_E_SHOFF: return ELF_ERROR_INVALID_E_SHOFF_STR;
+        case ELF_ERROR_INVALID_E_FLAGS: return ELF_ERROR_INVALID_E_FLAGS_STR;
+        case ELF_ERROR_INVALID_E_EHSIZE: return ELF_ERROR_INVALID_E_EHSIZE_STR;
+        case ELF_ERROR_INVALID_E_PHENTSIZE: return ELF_ERROR_INVALID_E_PHENTSIZE_STR;
+        case ELF_ERROR_INVALID_E_PHNUM: return ELF_ERROR_INVALID_E_PHNUM_STR;
+        case ELF_ERROR_INVALID_E_SHENTSIZE: return ELF_ERROR_INVALID_E_SHENTSIZE_STR;
+        case ELF_ERROR_INVALID_E_SHNUM: return ELF_ERROR_INVALID_E_SHNUM_STR;
+        case ELF_ERROR_INVALID_E_SHSTRNDX: return ELF_ERROR_INVALID_E_SHSTRNDX_STR;
+        case ELF_ERROR_INVALID_PHT: return ELF_ERROR_INVALID_PHT_STR;
+        case ELF_ERROR_INVALID_SHT: return ELF_ERROR_INVALID_SHT_STR;
+        case ELF_ERROR_INVALID_SH_NAME: return ELF_ERROR_INVALID_SH_NAME_STR;
+        case ELF_ERROR_INVALID_SH_TYPE: return ELF_ERROR_INVALID_SH_TYPE_STR;
+        case ELF_ERROR_INVALID_SH_FLAGS: return ELF_ERROR_INVALID_SH_FLAGS_STR;
+        case ELF_ERROR_INVALID_SH_ADDR: return ELF_ERROR_INVALID_SH_ADDR_STR;
+        case ELF_ERROR_INVALID_SH_OFFSET: return ELF_ERROR_INVALID_SH_OFFSET_STR;
+        case ELF_ERROR_INVALID_SH_SIZE: return ELF_ERROR_INVALID_SH_SIZE_STR;
+        case ELF_ERROR_INVALID_SH_LINK: return ELF_ERROR_INVALID_SH_LINK_STR;
+        case ELF_ERROR_INVALID_SH_INFO: return ELF_ERROR_INVALID_SH_INFO_STR;
+        case ELF_ERROR_INVALID_SH_ADDRALIGN: return ELF_ERROR_INVALID_SH_ADDRALIGN_STR;
+        case ELF_ERROR_INVALID_SH_ENTSIZE: return ELF_ERROR_INVALID_SH_ENTSIZE_STR;
+        case ELF_ERROR_INVALID_PH_TYPE: return ELF_ERROR_INVALID_PH_TYPE_STR;
+        case ELF_ERROR_INVALID_PH_FLAGS: return ELF_ERROR_INVALID_PH_FLAGS_STR;
+        case ELF_ERROR_INVALID_PH_OFFSET: return ELF_ERROR_INVALID_PH_OFFSET_STR;
+        case ELF_ERROR_INVALID_PH_VADDR: return ELF_ERROR_INVALID_PH_VADDR_STR;
+        case ELF_ERROR_INVALID_PH_PADDR: return ELF_ERROR_INVALID_PH_PADDR_STR;
+        case ELF_ERROR_INVALID_PH_FILESZ: return ELF_ERROR_INVALID_PH_FILESZ_STR;
+        case ELF_ERROR_INVALID_PH_MEMSZ: return ELF_ERROR_INVALID_PH_MEMSZ_STR;
+        case ELF_ERROR_INVALID_PH_ALIGN: return ELF_ERROR_INVALID_PH_ALIGN_STR;
+        case ELF_ERROR_INVALID_STRING_TABLE: return ELF_ERROR_INVALID_STRING_TABLE_STR;
+        case ELF_ERROR_NO_SUCH_SYMBOL: return ELF_ERROR_NO_SUCH_SYMBOL_STR;
+        case ELF_ERROR_SYMBOL_UNDEFINED: return ELF_ERROR_SYMBOL_UNDEFINED_STR;
+        case ELF_ERROR_LOADER_FULL: return ELF_ERROR_LOADER_FULL_STR;
+        case ELF_ERROR_INVALID_LOADER: return ELF_ERROR_INVALID_LOADER_STR;
+        default: return "Undefined";
+    }
+}
+
+/******************************************************************************/
+/* ELF File                                                                   */
+/******************************************************************************/
+
+/**
+ * Initialize an ELF file
+ *
+ * This function initializes an ELF file structure given the file's contents
+ * in memory. The resulting structure will be used by all of the other
+ * functions.
+ *
+ * @param file a character buffer containing the contents of the ELF file to
+ *     be loaded.
+ * @param fsize the size of the character buffer
+ * @param ef the ELF file structure to initialize.
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_file_init(char *file, elf64_sword fsize, struct elf_file_t *ef)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+    struct elf_shdr *dynsym = 0;
+    struct elf_shdr *strtab = 0;
+    struct elf_shdr *shstrtab = 0;
+
+    if (!file || !ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    for (i = 0; i < sizeof(struct elf_file_t); i++)
+        ((char *)ef)[i] = 0;
+
+    if (fsize < sizeof(struct elf64_ehdr))
+        return ELF_ERROR_INVALID_ARG;
+
+    ef->ehdr = (struct elf64_ehdr *)file;
+
+    if (ef->ehdr->e_ident[ei_mag0] != 0x7F)
+        return ELF_ERROR_INVALID_EI_MAG0;
+
+    if (ef->ehdr->e_ident[ei_mag1] != 'E')
+        return ELF_ERROR_INVALID_EI_MAG1;
+
+    if (ef->ehdr->e_ident[ei_mag2] != 'L')
+        return ELF_ERROR_INVALID_EI_MAG2;
+
+    if (ef->ehdr->e_ident[ei_mag3] != 'F')
+        return ELF_ERROR_INVALID_EI_MAG3;
+
+    if (ef->ehdr->e_ident[ei_class] != elfclass64)
+        return ELF_ERROR_INVALID_EI_CLASS;
+
+    if (ef->ehdr->e_ident[ei_data] != elfdata2lsb)
+        return ELF_ERROR_INVALID_EI_DATA;
+
+    if (ef->ehdr->e_ident[ei_version] != ev_current)
+        return ELF_ERROR_INVALID_EI_VERSION;
+
+    if (ef->ehdr->e_ident[ei_osabi] != elfosabi_sysv)
+        return ELF_ERROR_INVALID_EI_OSABI;
+
+    if (ef->ehdr->e_ident[ei_abiversion] != 0)
+        return ELF_ERROR_INVALID_EI_ABIVERSION;
+
+    if (ef->ehdr->e_type != et_dyn)
+        return ELF_ERROR_INVALID_E_TYPE;
+
+    if (ef->ehdr->e_machine != em_x86_64)
+        return ELF_ERROR_INVALID_E_MACHINE;
+
+    if (ef->ehdr->e_version != ev_current)
+        return ELF_ERROR_INVALID_EI_VERSION;
+
+    if (ef->ehdr->e_entry <= 0 ||
+        ef->ehdr->e_entry >= fsize)
+    {
+        return ELF_ERROR_INVALID_E_ENTRY;
+    }
+
+    if (ef->ehdr->e_phoff <= 0 ||
+        ef->ehdr->e_phoff >= fsize)
+    {
+        return ELF_ERROR_INVALID_E_PHOFF;
+    }
+
+    if (ef->ehdr->e_shoff <= 0 ||
+        ef->ehdr->e_shoff >= fsize)
+    {
+        return ELF_ERROR_INVALID_E_SHOFF;
+    }
+
+    if (ef->ehdr->e_flags != 0)
+        return ELF_ERROR_INVALID_E_FLAGS;
+
+    if (ef->ehdr->e_ehsize != sizeof(struct elf64_ehdr))
+        return ELF_ERROR_INVALID_E_EHSIZE;
+
+    if (ef->ehdr->e_phentsize != sizeof(struct elf_phdr))
+        return ELF_ERROR_INVALID_E_PHENTSIZE;
+
+    if (ef->ehdr->e_shentsize != sizeof(struct elf_shdr))
+        return ELF_ERROR_INVALID_E_SHENTSIZE;
+
+    if (ef->ehdr->e_shstrndx >= ef->ehdr->e_shnum)
+        return ELF_ERROR_INVALID_E_SHSTRNDX;
+
+    if (ef->ehdr->e_shoff + (ef->ehdr->e_shentsize * ef->ehdr->e_shnum) > fsize)
+        return ELF_ERROR_INVALID_SHT;
+
+    if (ef->ehdr->e_phoff + (ef->ehdr->e_phentsize * ef->ehdr->e_phnum) > fsize)
+        return ELF_ERROR_INVALID_PHT;
+
+    ef->file = file;
+    ef->fsize = fsize;
+    ef->shdrtab = (struct elf_shdr *)(file + ef->ehdr->e_shoff);
+    ef->phdrtab = (struct elf_phdr *)(file + ef->ehdr->e_phoff);
+
+    for (i = 0; i < ef->ehdr->e_shnum; i++)
+    {
+        struct elf_shdr *shdr;
+
+        ret = elf_section_header(ef, i, &shdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        if (shdr->sh_offset + shdr->sh_size > ef->fsize)
+            return ELF_ERROR_INVALID_SH_SIZE;
+    }
+
+    for (i = 0; i < ef->ehdr->e_phnum; i++)
+    {
+        struct elf_phdr *phdr;
+
+        ret = elf_program_header(ef, i, &phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        if (phdr->p_offset + phdr->p_filesz > ef->fsize)
+            return ELF_ERROR_INVALID_PH_FILESZ;
+
+        if (phdr->p_filesz > phdr->p_memsz)
+            return ELF_ERROR_INVALID_PH_FILESZ;
+    }
+
+    for (i = 0; i < ef->ehdr->e_shnum; i++)
+    {
+        struct elf_shdr *shdr;
+
+        ret = elf_section_header(ef, i, &shdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        if (shdr->sh_type == sht_dynsym)
+        {
+            dynsym = shdr;
+            break;
+        }
+    }
+
+    if (dynsym == 0)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_section_header(ef, dynsym->sh_link, &strtab);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    if (strtab->sh_type != sht_strtab)
+        return ELF_ERROR_INVALID_SH_TYPE;
+
+    ret = elf_section_header(ef, ef->ehdr->e_shstrndx, &shstrtab);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    if (shstrtab->sh_type != sht_strtab)
+        return ELF_ERROR_INVALID_SH_TYPE;
+
+    ef->dynsym = dynsym;
+    ef->strtab = strtab;
+    ef->shstrtab = shstrtab;
+
+    ef->symnum = dynsym->sh_size / sizeof(struct elf_sym);
+    ef->symtab = (struct elf_sym *)(file + dynsym->sh_offset);
+
+    for (i = 0; i < ef->ehdr->e_shnum; i++)
+    {
+        struct elf_shdr *shdr;
+
+        ret = elf_section_header(ef, i, &shdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        if (shdr->sh_type == sht_rel)
+        {
+            ef->reltab[ef->num_rel].num = shdr->sh_size / sizeof(struct elf_rel);
+            ef->reltab[ef->num_rel].tab = (struct elf_rel *)(ef->file + shdr->sh_offset);
+            ef->num_rel++;
+        }
+
+        if (shdr->sh_type == sht_rela)
+        {
+            ef->relatab[ef->num_rela].num = shdr->sh_size / sizeof(struct elf_rela);
+            ef->relatab[ef->num_rela].tab = (struct elf_rela *)(ef->file + shdr->sh_offset);
+            ef->num_rela++;
+        }
+    }
+
+    ef->valid = ELF_TRUE;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Load ELF file
+ *
+ * Once an ELF file has been initialized, use elf_total_exec_size to
+ * get the amount of RAM that is needed to load the ELF file into memory.
+ * Using this information, allocate Read, Write, Exectuable memory for the
+ * ELF file, that is used by this function. This function will actually load
+ * the ELF file into the allocated RAM.
+ *
+ * @param ef the ELF file
+ * @param exec a character buffer to load the ELF file into
+ * @param esize the size of the character buffer
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_file_load(struct elf_file_t *ef, char *exec, elf64_sword esize)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+    elf64_sxword total_size = 0;
+
+    if (!ef || !exec)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (esize < ef->fsize)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    total_size = elf_total_exec_size(ef);
+    if (total_size < ELF_SUCCESS)
+        return ret;
+
+    if (esize != total_size)
+        return ELF_ERROR_INVALID_ARG;
+
+    for (i = 0; i < esize; i++)
+        exec[i] = 0;
+
+    ef->exec = exec;
+    ef->esize = esize;
+
+    ret = elf_load_segments(ef);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    /* TODO: Make sure there are no duplicate symbols */
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* ELF Loader                                                                 */
+/******************************************************************************/
+
+/**
+ * Initialize ELF Loader
+ *
+ * The ELF loader is responsible for collecting all of the ELF files that
+ * have been loaded, and relocates them in memory. If more then one library
+ * is to be loaded, the relocation operation requires all of the symbol tables
+ * from all of the libraries to be available during relocation.
+ *
+ * @param loader the ELF loader to initialize
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_loader_init(struct elf_loader_t *loader)
+{
+    elf64_word i = 0;
+
+    if (!loader)
+        return ELF_ERROR_INVALID_ARG;
+
+    for (i = 0; i < sizeof(struct elf_loader_t); i++)
+        ((char *)loader)[i] = 0;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Add ELF file to an ELF loader
+ *
+ * Once an ELF loader has been initialized, use this function to add an
+ * ELF file to the ELF loader
+ *
+ * @param loader the ELF loader
+ * @param ef the ELF file to add
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_loader_add(struct elf_loader_t *loader, struct elf_file_t *ef)
+{
+    if (!loader || !ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (loader->num >= ELF_MAX_MODULES)
+        return ELF_ERROR_LOADER_FULL;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    loader->efs[loader->num++] = ef;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Relocate ELF Loader
+ *
+ * Relocates all of the ELF files that have been added to the ELF loader.
+ * Once all of the ELF files have been relocated, it's safe to resolve
+ * symbols for execution.
+ *
+ * @param loader the ELF loader
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_loader_relocate(struct elf_loader_t *loader)
+{
+    elf64_word i = 0;
+    elf64_word j = 0;
+    elf64_sword ret = 0;
+
+    if (!loader)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (loader->num > ELF_MAX_MODULES)
+        return ELF_ERROR_INVALID_LOADER;
+
+    for (i = 0; i < loader->num; i++)
+    {
+        struct elf_file_t *ef1 = loader->efs[i];
+
+        for (j = 0; j < ELF_MAX_MODULES; j++)
+            ef1->eftab[j] = 0;
+
+        for (j = 0; j < loader->num; j++)
+        {
+            struct elf_file_t *ef2 = loader->efs[j];
+
+            if (ef1 == ef2)
+                continue;
+
+            ef1->eftab[ef1->efnum++] = ef2;
+        }
+
+        ret = elf_relocate_symbols(ef1);
+        if (ret != ELF_SUCCESS)
+            return ret;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* ELF File Header                                                            */
+/******************************************************************************/
+
+/**
+ * Convert ei_class -> const char *
+ *
+ * @param ei_class ei_class to convert
+ * @return const char * version of ei_class
+ */
+const char *
+ei_class_to_str(unsigned char ei_class)
+{
+    switch (ei_class)
+    {
+        case elfclass32: return elfclass32_str;
+        case elfclass64: return elfclass64_str;
+        default: return "Unknown ei_class";
+    }
+}
+
+/**
+ * Convert ei_data -> const char *
+ *
+ * @param ei_data ei_data to convert
+ * @return const char * version of ei_data
+ */
+const char *
+ei_data_to_str(unsigned char ei_data)
+{
+    switch (ei_data)
+    {
+        case elfdata2lsb: return elfdata2lsb_str;
+        case elfdata2msb: return elfdata2msb_str;
+        default: return "Unknown ei_data";
+    }
+}
+
+/**
+ * Convert version -> const char *
+ *
+ * @param version version to convert
+ * @return const char * version of version
+ */
+const char *
+version_to_str(unsigned char version)
+{
+    switch (version)
+    {
+        case ev_current: return ev_current_str;
+        default: return "Unknown version";
+    }
+}
+
+/**
+ * Convert ei_osabi -> const char *
+ *
+ * @param ei_osabi ei_osabi to convert
+ * @return const char * version of ei_osabi
+ */
+const char *
+ei_osabi_to_str(unsigned char ei_osabi)
+{
+    switch (ei_osabi)
+    {
+        case elfosabi_sysv: return elfosabi_sysv_str;
+        case elfosabi_hpux: return elfosabi_hpux_str;
+        case elfosabi_standalone: return elfosabi_standalone_str;
+        default: return "Unknown ei_osabi";
+    }
+}
+
+/**
+ * Convert e_type -> const char *
+ *
+ * @param e_type e_type to convert
+ * @return const char * version of e_type
+ */
+const char *
+e_type_to_str(elf64_half e_type)
+{
+    switch (e_type)
+    {
+        case et_none: return et_none_str;
+        case et_rel: return et_rel_str;
+        case et_exec: return et_exec_str;
+        case et_dyn: return et_dyn_str;
+        case et_core: return et_core_str;
+        case et_loos: return et_loos_str;
+        case et_hios: return et_hios_str;
+        case et_loproc: return et_loproc_str;
+        case et_hiproc: return et_hiproc_str;
+        default: return "Unknown e_type";
+    }
+}
+
+/**
+ * Convert e_machine -> const char *
+ *
+ * @param e_machine e_machine to convert
+ * @return const char * version of e_machine
+ */
+const char *
+e_machine_to_str(elf64_half e_machine)
+{
+    switch (e_machine)
+    {
+        case em_none: return em_none_str;
+        case em_m32: return em_m32_str;
+        case em_sparc: return em_sparc_str;
+        case em_386: return em_386_str;
+        case em_68k: return em_68k_str;
+        case em_88k: return em_88k_str;
+        case em_486: return em_486_str;
+        case em_860: return em_860_str;
+        case em_mips: return em_mips_str;
+        case em_mips_rs3_le: return em_mips_rs3_le_str;
+        case em_mips_rs4_be: return em_mips_rs4_be_str;
+        case em_parisc: return em_parisc_str;
+        case em_sparc32plus: return em_sparc32plus_str;
+        case em_ppc: return em_ppc_str;
+        case em_ppc64: return em_ppc64_str;
+        case em_spu: return em_spu_str;
+        case em_arm: return em_arm_str;
+        case em_sh: return em_sh_str;
+        case em_sparcv9: return em_sparcv9_str;
+        case em_h8_300: return em_h8_300_str;
+        case em_ia_64: return em_ia_64_str;
+        case em_x86_64: return em_x86_64_str;
+        case em_s390: return em_s390_str;
+        case em_cris: return em_cris_str;
+        case em_v850: return em_v850_str;
+        case em_m32r: return em_m32r_str;
+        case em_mn10300: return em_mn10300_str;
+        case em_openrisc: return em_openrisc_str;
+        case em_blackfin: return em_blackfin_str;
+        case em_altera_nios2: return em_altera_nios2_str;
+        case em_ti_c6000: return em_ti_c6000_str;
+        case em_aarch64: return em_aarch64_str;
+        case em_frv: return em_frv_str;
+        case em_avr32: return em_avr32_str;
+        case em_alpha: return em_alpha_str;
+        case em_cygnus_v850: return em_cygnus_v850_str;
+        case em_cygnus_m32r: return em_cygnus_m32r_str;
+        case em_s390_old: return em_s390_old_str;
+        case em_cygnus_mn10300: return em_cygnus_mn10300_str;
+        default: return "Unknown e_machine";
+    }
+}
+
+/**
+ * Print ELF file header
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_file_print_header(struct elf_file_t *ef)
+{
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    DEBUG("ELF Header:\n");
+    DEBUG("  %-35s %X %c %c %c\n", "Magic:", ef->ehdr->e_ident[ei_mag0]
+          , ef->ehdr->e_ident[ei_mag1]
+          , ef->ehdr->e_ident[ei_mag2]
+          , ef->ehdr->e_ident[ei_mag3]);
+
+    DEBUG("  %-35s %s\n", "Class:", ei_class_to_str(ef->ehdr->e_ident[ei_class]));
+    DEBUG("  %-35s %s\n", "Data:", ei_data_to_str(ef->ehdr->e_ident[ei_data]));
+    DEBUG("  %-35s %s\n", "Version:", version_to_str(ef->ehdr->e_ident[ei_version]));
+    DEBUG("  %-35s %s\n", "OS/ABI:", ei_osabi_to_str(ef->ehdr->e_ident[ei_osabi]));
+    DEBUG("  %-35s %d\n", "ABI Version:", ef->ehdr->e_ident[ei_abiversion]);
+    DEBUG("  %-35s %s\n", "Type:", e_type_to_str(ef->ehdr->e_type));
+    DEBUG("  %-35s %s\n", "Machine:", e_machine_to_str(ef->ehdr->e_machine));
+    DEBUG("  %-35s %s\n", "Version:", version_to_str(ef->ehdr->e_version));
+    DEBUG("  %-35s 0x%llX\n", "Entry point address:", ef->ehdr->e_entry);
+    DEBUG("  %-35s 0x%llX, %llu (bytes into file)\n", "Start of program headers:", ef->ehdr->e_phoff, ef->ehdr->e_phoff);
+    DEBUG("  %-35s 0x%llX, %llu (bytes into file)\n", "Start of section headers:", ef->ehdr->e_shoff, ef->ehdr->e_shoff);
+    DEBUG("  %-35s 0x%X\n", "Flags:", ef->ehdr->e_flags);
+    DEBUG("  %-35s %d (bytes)\n", "Size of this header:", ef->ehdr->e_ehsize);
+    DEBUG("  %-35s %d (bytes)\n", "Size of program headers:", ef->ehdr->e_phentsize);
+    DEBUG("  %-35s %d\n", "Num of program headers:", ef->ehdr->e_phnum);
+    DEBUG("  %-35s %d (bytes)\n", "Size of section headers:", ef->ehdr->e_shentsize);
+    DEBUG("  %-35s %d\n", "Num of section headers:", ef->ehdr->e_shnum);
+    DEBUG("  %-35s %d\n", "Section header string table index:", ef->ehdr->e_shstrndx);
+
+    DEBUG("\n");
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* ELF Section Header Table                                                   */
+/******************************************************************************/
+
+/**
+ * Convert sh_type -> const char *
+ *
+ * @param sh_type sh_type to convert
+ * @return const char * version of sh_type
+ */
+const char *
+sh_type_to_str(elf64_word sh_type)
+{
+    switch (sh_type)
+    {
+        case sht_null: return sht_null_str;
+        case sht_progbits: return sht_progbits_str;
+        case sht_symtab: return sht_symtab_str;
+        case sht_strtab: return sht_strtab_str;
+        case sht_rela: return sht_rela_str;
+        case sht_hash: return sht_hash_str;
+        case sht_dynamic: return sht_dynamic_str;
+        case sht_note: return sht_note_str;
+        case sht_nobits: return sht_nobits_str;
+        case sht_rel: return sht_rel_str;
+        case sht_shlib: return sht_shlib_str;
+        case sht_dynsym: return sht_dynsym_str;
+        case sht_loos: return sht_loos_str;
+        case sht_hios: return sht_hios_str;
+        case sht_loproc: return sht_loproc_str;
+        case sht_hiproc: return sht_hiproc_str;
+        default: return "Unknown sh_type";
+    }
+}
+
+/**
+ * Convert sh_flags (writable) -> bool
+ *
+ * @param shdr section header with sh_flags to convert
+ * @return ELF_TRUE if writable, ELF_FALSE otherwise
+ */
+elf64_sword
+sh_flags_is_writable(struct elf_shdr *shdr)
+{
+    if (!shdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (shdr->sh_flags & shf_write) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Convert sh_flags (allocated) -> bool
+ *
+ * @param shdr section header with sh_flags to convert
+ * @return ELF_TRUE if allocated, ELF_FALSE otherwise
+ */
+elf64_sword
+sh_flags_is_allocated(struct elf_shdr *shdr)
+{
+    if (!shdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (shdr->sh_flags & shf_alloc) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Convert sh_flags (executable) -> bool
+ *
+ * @param shdr section header with sh_flags to convert
+ * @return ELF_TRUE if executable, ELF_FALSE otherwise
+ */
+elf64_sword
+sh_flags_is_executable(struct elf_shdr *shdr)
+{
+    if (!shdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (shdr->sh_flags & shf_execinstr) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Get ELF section header
+ *
+ * @param ef the ELF file
+ * @param index the index of the section to get
+ * @param shdr the section header to return
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_section_header(struct elf_file_t *ef,
+                   elf64_word index,
+                   struct elf_shdr **shdr)
+{
+    if (!ef || !ef->ehdr || !ef->shdrtab || !shdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (index >= ef->ehdr->e_shnum)
+        return ELF_ERROR_INVALID_INDEX;
+
+    *shdr = &(ef->shdrtab[index]);
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print ELF section header table
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_section_header_table(struct elf_file_t *ef)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->ehdr->e_shnum; i++)
+    {
+        struct elf_shdr *shdr = 0;
+
+        ret = elf_section_header(ef, i, &shdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_print_section_header(ef, shdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print ELF section header
+ *
+ * @param ef the ELF file
+ * @param shdr the section header to print
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_section_header(struct elf_file_t *ef,
+                         struct elf_shdr *shdr)
+{
+    elf64_sword ret = 0;
+    struct e_string section_name = {0};
+
+    if (!ef || !shdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_section_name_string(ef, shdr, &section_name);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    DEBUG("Section Header: %s\n", section_name.buf);
+    DEBUG("  %-35s %s\n", "Type:", sh_type_to_str(shdr->sh_type));
+    DEBUG("  %-35s ", "Flags:");
+
+    if (sh_flags_is_writable(shdr) == ELF_TRUE) INFO("W ");
+    if (sh_flags_is_allocated(shdr) == ELF_TRUE) INFO("A ");
+    if (sh_flags_is_executable(shdr) == ELF_TRUE) INFO("E ");
+
+    INFO("\n");
+    DEBUG("  %-35s 0x%llX\n", "Address:", shdr->sh_addr);
+    DEBUG("  %-35s 0x%llX\n", "Offset:", shdr->sh_offset);
+    DEBUG("  %-35s %llu (bytes)\n", "Size:", shdr->sh_size);
+    DEBUG("  %-35s %u\n", "Linked Section:", shdr->sh_link);
+    DEBUG("  %-35s %u\n", "Info:", shdr->sh_info);
+    DEBUG("  %-35s %llu\n", "Address Alignment:", shdr->sh_addralign);
+    DEBUG("  %-35s %llu\n", "Entry Size:", shdr->sh_entsize);
+
+    DEBUG("\n");
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* Section Name String Table                                                  */
+/******************************************************************************/
+
+/**
+ * Get ELF string table entry
+ *
+ * In each ELF file there are multiple string tables. Usually there is at
+ * least a string table for all of the section headers (e.g. .got, .hash,
+ * .dynsym, etc...) and then there is a string table for all of the dynamic
+ * symbol names (e.g. fun1, my_glob1, etc...). A string table is nothing more
+ * than a collection of null terminated strings, back to back. This function
+ * takes a string table, and an offset into the table, and returns a string.
+ *
+ * @param ef the ELF file
+ * @param strtab the string table
+ * @param offset the offset (in bytes) into the string table
+ * @param str the string being returned
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_string_table_entry(struct elf_file_t *ef,
+                       struct elf_shdr *strtab,
+                       elf64_word offset,
+                       struct e_string *str)
+{
+    char *buf = 0;
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+    elf64_sword max = 0;
+    elf64_sword length = 0;
+
+    if (!ef || !strtab || !str)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    if (offset > strtab->sh_size)
+        return ELF_ERROR_INVALID_OFFSET;
+
+    buf = ef->file + strtab->sh_offset + offset;
+    max = strtab->sh_size - offset;
+
+    for (i = 0; i < max; i++, length++)
+    {
+        if (buf[i] == 0)
+            break;
+    }
+
+    if (i == max)
+        return ELF_ERROR_INVALID_STRING_TABLE;
+
+    str->buf = buf;
+    str->len = length;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Get ELF section name
+ *
+ * This is a helper function for getting a section name.
+ *
+ * @param ef the ELF file
+ * @param shdr the section header to get the name for
+ * @param str the string being returned
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_section_name_string(struct elf_file_t *ef,
+                        struct elf_shdr *shdr,
+                        struct e_string *str)
+{
+    if (!ef || !shdr || !str)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    return elf_string_table_entry(ef, ef->shstrtab, shdr->sh_name, str);
+}
+
+/******************************************************************************/
+/* ELF Dynamic Symbol Table                                                   */
+/******************************************************************************/
+
+/**
+ * Convert stb -> const char *
+ *
+ * @param st_info stb to convert
+ * @return const char * version of stb
+ */
+const char *
+stb_to_str(elf64_word st_info)
+{
+    switch (ELF_SYM_BIND(st_info))
+    {
+        case stb_local: return stb_local_str;
+        case stb_global: return stb_global_str;
+        case stb_weak: return stb_weak_str;
+        case stb_loos: return stb_loos_str;
+        case stb_hios: return stb_hios_str;
+        case stb_loproc: return stb_loproc_str;
+        case stb_hiproc: return stb_hiproc_str;
+        default: return "Unknown st_info (bind)";
+    }
+}
+
+/**
+ * Convert stt -> const char *
+ *
+ * @param st_info stt to convert
+ * @return const char * version of stt
+ */
+const char *
+stt_to_str(elf64_word st_info)
+{
+    switch (ELF_SYM_TYPE(st_info))
+    {
+        case stt_notype: return stt_notype_str;
+        case stt_object: return stt_object_str;
+        case stt_func: return stt_func_str;
+        case stt_section: return stt_section_str;
+        case stt_file: return stt_file_str;
+        case stt_loos: return stt_loos_str;
+        case stt_hios: return stt_hios_str;
+        case stt_loproc: return stt_loproc_str;
+        case stt_hiproc: return stt_hiproc_str;
+        default: return "Unknown st_info (bind)";
+    }
+}
+
+/**
+ * Get Dynamic Symbol (by index)
+ *
+ * This function will get a symbol from the dynamic symbol table given an
+ * index. Note that this function does _not_ attempt to locate the symbol if
+ * it's value is 0.
+ *
+ * @param ef the ELF file
+ * @param index index into the .dynsym section
+ * @param sym the symbol being returned
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_symbol_by_index(struct elf_file_t *ef,
+                    elf64_word index,
+                    struct elf_sym **sym)
+{
+    if (!ef || !sym)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (index >= ef->symnum)
+        return ELF_ERROR_INVALID_INDEX;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    *sym = &(ef->symtab[index]);
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Get Dynamic Symbol (by name)
+ *
+ * This function will get a symbol from the dynamic symbol table given a
+ * name. Note that this function does _not_ attempt to locate the symbol if
+ * it's value is 0.
+ *
+ * @param ef the ELF file
+ * @param name name of the symbol in the .dynsym section to get
+ * @param sym the symbol being returned
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_symbol_by_name(struct elf_file_t *ef,
+                   struct e_string *name,
+                   struct elf_sym **sym)
+{
+    elf64_sword i = 0;
+    elf64_sword ret = 0;
+
+    /* TODO: Use .hash instead of a O(n) loop. */
+
+    if (!ef || !name || !sym)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->symnum; i++)
+    {
+        struct elf_sym *sym = 0;
+        struct e_string str = {0};
+
+        ret = elf_symbol_by_index(ef, i, &sym);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_string_table_entry(ef, ef->strtab, sym->st_name, &str);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_strcmp(name, &str);
+        if (ret == ELF_FALSE) continue;
+        if (ret == ELF_TRUE) break;
+        return ret;
+    }
+
+    if (i != ef->symnum)
+    {
+        *sym = &(ef->symtab[i]);
+        return ELF_SUCCESS;
+    }
+
+    return ELF_ERROR_NO_SUCH_SYMBOL;
+}
+
+/**
+ * Get Global Dynamic Symbol (by name)
+ *
+ * This function will get a symbol from the dynamic symbol table given a
+ * name. If the symbol is not defined in the ELF file that was provided
+ * (i.e. st_value == 0), this function will search all of the other ELF files
+ * that were provided by an ELF loader to see if it can find the symbol that
+ * is actually defined. If this function returns, ELF_ERROR_NO_SUCH_SYMBOL
+ * the symbol is not defined by any of the ELF files that were loaded. If
+ * the symbol was located, this function not only returns the symbol, but it
+ * also returns the ELF file that the symbol was located in (which might be
+ * the ELF file that was provided, or it might be an ELF file provided to
+ * an ELF loader).
+ *
+ * @param efl the ELF file
+ * @param name name of the symbol in the .dynsym section to get
+ * @param efr the resulting ELF file that the symbol was located in
+ * @param sym the symbol being returned
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_symbol_by_name_global(struct elf_file_t *efl,
+                          struct e_string *name,
+                          struct elf_file_t **efr,
+                          struct elf_sym **sym)
+{
+    elf64_sword i = 0;
+    elf64_sword ret = 0;
+    struct elf_sym *tmpsym = 0;
+    struct elf_file_t *tmpef = efl;
+
+    if (!efl || !name || !efr || !sym)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (efl->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_symbol_by_name(tmpef, name, &tmpsym);
+    switch (ret)
+    {
+        case ELF_SUCCESS:
+            if (tmpsym->st_value != 0)
+                goto found;
+
+        case ELF_ERROR_NO_SUCH_SYMBOL:
+            break;
+
+        default:
+            return ret;
+    };
+
+    for (i = 0; i < efl->efnum; i++)
+    {
+        tmpef = efl->eftab[i];
+
+        ret = elf_symbol_by_name(tmpef, name, &tmpsym);
+        switch (ret)
+        {
+            case ELF_SUCCESS:
+                if (tmpsym->st_value != 0)
+                    goto found;
+
+            case ELF_ERROR_NO_SUCH_SYMBOL:
+                break;
+
+            default:
+                return ret;
+        };
+    }
+
+    return ELF_ERROR_NO_SUCH_SYMBOL;
+
+found:
+
+    *efr = tmpef;
+    *sym = tmpsym;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Resvole Symbol
+ *
+ * This function will lookup a symbol by it's name, and return it's absolute
+ * address. Before this function can be run, the following must be done:
+ *
+ * - Each ELF file must be created and initalized.
+ * - Each ELF file must be loaded into memory
+ * - An ELF loader much be created an initalized.
+ * - Each ELF file must be added to the ELF loader
+ * - The ELF loader must be relocated
+ *
+ * Once these steps are completed, this function can be used to lookup the
+ * absolute address for any symbol. Note that this function will return
+ * the absolute address of a symbol in a different ELF file that what is
+ * provided. It will however take longer as it must perform a global search.
+ * Therefore, it is advised that the search be done on the ELF file that is
+ * likely to contain the symbol.
+ *
+ * @param ef the ELF file
+ * @param name name of the symbol in the .dynsym section to get
+ * @param addr the resulting absolute address
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_resolve_symbol(struct elf_file_t *ef,
+                   struct e_string *name,
+                   void **addr)
+{
+    elf64_sword ret = 0;
+    struct elf_sym *sym = 0;
+    struct elf_file_t *efr = 0;
+
+    if (!ef || !name || !addr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_symbol_by_name_global(ef, name, &efr, &sym);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    *addr = efr->exec + sym->st_value;
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print dynamic symbol table
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_sym_table(struct elf_file_t *ef)
+{
+    elf64_sword i = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->symnum; i++)
+    {
+        struct elf_sym *sym = 0;
+
+        ret = elf_symbol_by_index(ef, i, &sym);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_print_sym(ef, sym);
+        if (ret != ELF_SUCCESS)
+            return ret;
+    }
+
+    DEBUG("\n");
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print dynamic symbol
+ *
+ * @param ef the ELF file
+ * @param sym the symbol to print
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_sym(struct elf_file_t *ef,
+              struct elf_sym *sym)
+{
+    elf64_sword ret = 0;
+    struct e_string str = {0};
+
+    if (!ef || !sym)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_string_table_entry(ef, ef->strtab, sym->st_name, &str);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+#ifdef PRINT_DETAILED_SYM
+
+    DEBUG("Symbol: %s\n", str.buf);
+    DEBUG("  %-35s %s\n", "Bind:", stb_to_str(sym->st_info));
+    DEBUG("  %-35s %s\n", "Type:", stt_to_str(sym->st_info));
+    DEBUG("  %-35s %d\n", "Section Index:", sym->st_shndx);
+    DEBUG("  %-35s 0x%llX\n", "Value:", sym->st_value);
+    DEBUG("  %-35s 0x%llX\n", "Size:", sym->st_size);
+
+    DEBUG("\n");
+
+#else
+
+    DEBUG("Symbol: %-29s 0x%08llX %-2s %-12s %s\n", str.buf, sym->st_value, " ",
+          stb_to_str(sym->st_info),
+          stt_to_str(sym->st_info));
+
+#endif
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* ELF Relocations                                                            */
+/******************************************************************************/
+
+/**
+ * Convert r_info (type) -> const char *
+ *
+ * @param r_info r_info (type) to convert
+ * @return const char * version of r_info (type)
+ */
+const char *
+rel_type_to_str(elf64_xword r_info)
+{
+    switch (ELF_REL_TYPE(r_info))
+    {
+        case R_X86_64_64: return R_X86_64_64_STR;
+        case R_X86_64_GLOB_DAT: return R_X86_64_GLOB_DAT_STR;
+        case R_X86_64_JUMP_SLOT: return R_X86_64_JUMP_SLOT_STR;
+        case R_X86_64_RELATIVE: return R_X86_64_RELATIVE_STR;
+        default: return "Unknown ELF_REL_TYPE(r_info)";
+    }
+}
+
+/**
+ * Relocate Symbol
+ *
+ * Given a relocation record (from a relocation table), this function
+ * performs the actual relocation.
+ *
+ * @note for x86_64, the documentation states that *ptr = S for GLOB_DAT and
+ *     JUMP_SLOT. S in the documentation is sym->st_value, which is missing
+ *     the base address to make the address "absolute". Most of the
+ *     implementations that I found include the base address, so I believe this
+ *     documentation to be in error. I have included the spec and a reference
+ *     implementation in case it is needed.
+ *
+ * http://www.x86-64.org/documentation_folder/abi.pdf
+ * https://github.com/madd-games/glidix/blob/186e2f699c045440f96551fcf504833d6d81799e/src/interp.c
+ *
+ * @param ef the ELF file
+ * @param rel the relocation record to relocate
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_relocate_symbol(struct elf_file_t *ef,
+                    struct elf_rel *rel)
+{
+    elf64_addr *ptr = 0;
+    elf64_sword ret = 0;
+    struct elf_sym *sym = 0;
+    struct e_string name = {0};
+    struct elf_file_t *efr = 0;
+
+    if (!ef || !rel)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_symbol_by_index(ef, ELF_REL_SYM(rel->r_info), &sym);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ret = elf_string_table_entry(ef, ef->strtab, sym->st_name, &name);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ret = elf_symbol_by_name_global(ef, &name, &efr, &sym);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ptr = (elf64_addr *)(ef->exec + rel->r_offset);
+
+    if (ptr > (elf64_addr *)(ef->exec + ef->esize))
+        return ELF_ERROR_INVALID_FILE;
+
+    /* TODO: Remove the relocation for R_X86_64_JUMP_SLOT, and instead
+       fill in the address of a function that does the relocation and
+       then jumps to the value that should have been there. Called
+       lazy loading */
+
+    switch (ELF_REL_TYPE(rel->r_info))
+    {
+        case R_X86_64_GLOB_DAT:
+        case R_X86_64_JUMP_SLOT:
+            *ptr = (elf64_addr)(efr->exec + sym->st_value);
+            break;
+
+        default:
+            return ELF_ERROR_INVALID_RELOCATION_TYPE;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Relocate Symbol (Addend)
+ *
+ * Given a relocation record (from a relocation table), this function
+ * performs the actual relocation.
+ *
+ * @note for x86_64, the documentation states that *ptr = S for GLOB_DAT and
+ *     JUMP_SLOT. S in the documentation is sym->st_value, which is missing
+ *     the base address to make the address "absolute". Most of the
+ *     implementations that I found include the base address, so I believe this
+ *     documentation to be in error. I have included the spec and a reference
+ *     implementation in case it is needed.
+ *
+ * http://www.x86-64.org/documentation_folder/abi.pdf
+ * https://github.com/madd-games/glidix/blob/186e2f699c045440f96551fcf504833d6d81799e/src/interp.c
+ *
+ * @note The difference with this function is that it has an extra addend added
+ * to the absolute address. This is only needed for a couple of types of
+ * relocations, the big one being code like int x[2], *y = x + 1, which creates
+ * a R_X86_64_64 style relocation.
+ *
+ * @param ef the ELF file
+ * @param rela the relocation record to relocate
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_relocate_symbol_addend(struct elf_file_t *ef,
+                           struct elf_rela *rela)
+{
+    elf64_addr *ptr = 0;
+    elf64_sword ret = 0;
+    struct elf_sym *sym = 0;
+    struct e_string name = {0};
+    struct elf_file_t *efr = 0;
+
+    if (!ef || !rela)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    ret = elf_symbol_by_index(ef, ELF_REL_SYM(rela->r_info), &sym);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ret = elf_string_table_entry(ef, ef->strtab, sym->st_name, &name);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ret = elf_symbol_by_name_global(ef, &name, &efr, &sym);
+    if (ret != ELF_SUCCESS)
+        return ret;
+
+    ptr = (elf64_addr *)(ef->exec + rela->r_offset);
+
+    if (ptr > (elf64_addr *)(ef->exec + ef->esize))
+        return ELF_ERROR_INVALID_FILE;
+
+    /* TODO: Remove the relocation for R_X86_64_JUMP_SLOT, and instead
+       fill in the address of a function that does the relocation and
+       then jumps to the value that should have been there. Called
+       lazy loading */
+
+    switch (ELF_REL_TYPE(rela->r_info))
+    {
+        case R_X86_64_64:
+            *ptr = (elf64_addr)(efr->exec + sym->st_value + rela->r_addend);
+            break;
+
+        case R_X86_64_GLOB_DAT:
+        case R_X86_64_JUMP_SLOT:
+            *ptr = (elf64_addr)(efr->exec + sym->st_value);
+            break;
+
+        case R_X86_64_RELATIVE:
+            *ptr = (elf64_addr)(efr->exec + rela->r_addend);
+
+        default:
+            return ELF_ERROR_INVALID_RELOCATION_TYPE;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Relocate Symbols
+ *
+ * This function goes through all of the relocation tables, and relocates
+ * each record in each relocation table.
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_relocate_symbols(struct elf_file_t *ef)
+{
+    elf64_word t = 0;
+    elf64_word r = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (t = 0; t < ef->num_rel; t++)
+    {
+        for (r = 0; r < ef->reltab[t].num; r++)
+        {
+            ret = elf_relocate_symbol(ef, &(ef->reltab[t].tab[r]));
+            if (ret != ELF_SUCCESS)
+                return ret;
+        }
+    }
+
+    for (t = 0; t < ef->num_rela; t++)
+    {
+        for (r = 0; r < ef->relatab[t].num; r++)
+        {
+            ret = elf_relocate_symbol_addend(ef, &(ef->relatab[t].tab[r]));
+            if (ret != ELF_SUCCESS)
+                return ret;
+        }
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print Relocation
+ *
+ * @param rel the relocation record to print
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_relocation(struct elf_rel *rel)
+{
+    elf64_sword ret = 0;
+
+    if (!rel)
+        return ELF_ERROR_INVALID_ARG;
+
+#ifdef PRINT_DETAILED_REL
+
+    DEBUG("Relocation:\n");
+    DEBUG("  %-35s 0x%08llX\n", "Offset:", rel->r_offset);
+    DEBUG("  %-35s %lld\n", "Symbol:", ELF_REL_SYM(rel->r_info));
+    DEBUG("  %-35s %s\n", "Type:", rel_type_to_str(rel->r_info));
+
+    DEBUG("\n");
+
+#else
+
+    DEBUG("Relocation: %-20s 0x%08llX %04lld\n", rel_type_to_str(rel->r_info),
+          rel->r_offset,
+          ELF_REL_SYM(rel->r_info));
+
+#endif
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print Relocation (Addend)
+ *
+ * @param rela the relocation record to print
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_relocation_addend(struct elf_rela *rela)
+{
+    elf64_sword ret = 0;
+
+    if (!rela)
+        return ELF_ERROR_INVALID_ARG;
+
+#ifdef PRINT_DETAILED_REL
+
+    DEBUG("Relocation:\n");
+    DEBUG("  %-35s 0x%08llX\n", "Offset:", rela->r_offset);
+    DEBUG("  %-35s %lld\n", "Symbol:", ELF_REL_SYM(rela->r_info));
+    DEBUG("  %-35s %s\n", "Type:", rel_type_to_str(rela->r_info));
+    DEBUG("  %-35s 0x%llX\n", "Addend:", rela->r_addend);
+
+    DEBUG("\n");
+
+#else
+
+    DEBUG("Relocation: %-20s 0x%08llX %04lld 0x%08llX\n", rel_type_to_str(rela->r_info),
+          rela->r_offset,
+          ELF_REL_SYM(rela->r_info),
+          rela->r_addend);
+
+#endif
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print Relocations
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_relocations(struct elf_file_t *ef)
+{
+    elf64_word t = 0;
+    elf64_word r = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (t = 0; t < ef->num_rel; t++)
+    {
+        for (r = 0; r < ef->reltab[t].num; r++)
+        {
+            ret = elf_print_relocation(&(ef->reltab[t].tab[r]));
+            if (ret != ELF_SUCCESS)
+                return ret;
+        }
+    }
+
+    for (t = 0; t < ef->num_rela; t++)
+    {
+        for (r = 0; r < ef->relatab[t].num; r++)
+        {
+            ret = elf_print_relocation_addend(&(ef->relatab[t].tab[r]));
+            if (ret != ELF_SUCCESS)
+                return ret;
+        }
+    }
+
+    DEBUG("\n");
+
+    return ELF_SUCCESS;
+}
+
+/******************************************************************************/
+/* ELF Program Header                                                         */
+/******************************************************************************/
+
+/* TODO: Need function to return a map that explains how to set the permissions
+   of the memory used to load the ELF file. This way, portions of the RAM that
+   holds the program can be RW and other portions can be RE */
+
+/**
+ * Convert p_type (type) -> const char *
+ *
+ * @param p_type p_type (type) to convert
+ * @return const char * version of p_type (type)
+ */
+const char *
+p_type_to_str(elf64_word p_type)
+{
+    switch (p_type)
+    {
+        case pt_null: return pt_null_str;
+        case pt_load: return pt_load_str;
+        case pt_dynamic: return pt_dynamic_str;
+        case pt_interp: return pt_interp_str;
+        case pt_note: return pt_note_str;
+        case pt_shlib: return pt_shlib_str;
+        case pt_phdr: return pt_phdr_str;
+        case pt_loos: return pt_loos_str;
+        case pt_hios: return pt_hios_str;
+        case pt_loproc: return pt_loproc_str;
+        case pt_hiproc: return pt_hiproc_str;
+        default: return "Unknown p_type";
+    }
+}
+
+/**
+ * Convert p_flags (executable) -> bool
+ *
+ * @param phdr program header containing p_flags to convert
+ * @return ELF_TRUE if executable, ELF_FALSE otherwise
+ */
+elf64_sword
+p_flags_is_executable(struct elf_phdr *phdr)
+{
+    if (!phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (phdr->p_flags & pf_x) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Convert p_flags (writable) -> bool
+ *
+ * @param phdr program header containing p_flags to convert
+ * @return ELF_TRUE if writable, ELF_FALSE otherwise
+ */
+elf64_sword
+p_flags_is_writable(struct elf_phdr *phdr)
+{
+    if (!phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (phdr->p_flags & pf_w) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Convert p_flags (readable) -> bool
+ *
+ * @param phdr program header containing p_flags to convert
+ * @return ELF_TRUE if readable, ELF_FALSE otherwise
+ */
+elf64_sword
+p_flags_is_readable(struct elf_phdr *phdr)
+{
+    if (!phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    return (phdr->p_flags & pf_r) != 0 ? ELF_TRUE : ELF_FALSE;
+}
+
+/**
+ * Get ELF program header
+ *
+ * @param ef the ELF file
+ * @param index the index of the program header to get
+ * @param phdr the program header to return
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_program_header(struct elf_file_t *ef,
+                   elf64_word index,
+                   struct elf_phdr **phdr)
+{
+    if (!ef || !ef->ehdr || !ef->phdrtab || !phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (index >= ef->ehdr->e_phnum)
+        return ELF_ERROR_INVALID_INDEX;
+
+    *phdr = &(ef->phdrtab[index]);
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Get exec size
+ *
+ * If the ELF file is "x" bytes, the RAM that the ELF file needs to be
+ * loaded into would be "y" >= "x". The reason for this is the RAM would at
+ * least need to add .bss section (which is not included in the ELF file itself)
+ * and it's likely that the ELF file is broken up into read/execute and
+ * read/write program segments, which are aligned to a "max" page size
+ * boundary. For example, with a x86_64 cross compiler, the max page size is
+ * 2MB. Thus, all of the read / executable sections are mapped to the first
+ * set of pages marked for RE. The read / write sections (like .data) are all
+ * in the a RW segment that are page aligned to 2MB. For a small library, this
+ * would mean that the RE section is 0->2MB, and the RW section is 2MB->End.
+ *
+ * This function returns the total amount of RAM that is needed to load he
+ * ELF file into RAM. This includes all of the segments, and their offsets for
+ * page alignment.
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sxword
+elf_total_exec_size(struct elf_file_t *ef)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+    elf64_sxword total_size = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->ehdr->e_phnum; i++)
+    {
+        elf64_sxword size = 0;
+        struct elf_phdr *phdr = 0;
+
+        ret = elf_program_header(ef, i, &phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        size = phdr->p_vaddr + phdr->p_memsz;
+
+        if (size > total_size)
+            total_size = size;
+    }
+
+    return total_size;
+}
+
+/**
+ * Load segments
+ *
+ * Loads the segments in the ELF file into RAM.
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_load_segments(struct elf_file_t *ef)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->ehdr->e_phnum; i++)
+    {
+        struct elf_phdr *phdr = 0;
+
+        ret = elf_program_header(ef, i, &phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_load_segment(ef, phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Load segment
+ *
+ * Loads a specific segment into RAM. Note that a segment is a collection of
+ * sections (e.g. .data, .got, .text, etc...). Typically there are two, one
+ * for read / execute, and one for read / write. They can also be larger than
+ * the ELF file. For example, the RW segment likely contains a .bss which is
+ * not included in the ELF file. The segment defines where this bss section
+ * is located, and what it's size is.
+ *
+ * @param ef the ELF file
+ * @param phdr the program header for the segment to load
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_load_segment(struct elf_file_t *ef,
+                 struct elf_phdr *phdr)
+{
+    char *exec = 0;
+    char *file = 0;
+    elf64_word i = 0;
+
+    if (!ef || !phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    if (phdr->p_vaddr + phdr->p_memsz > ef->esize)
+        return ELF_ERROR_INVALID_PH_MEMSZ;
+
+    exec = ef->exec + phdr->p_vaddr;
+    file = ef->file + phdr->p_offset;
+
+    for (i = 0; i < phdr->p_filesz; i++)
+        exec[i] = file[i];
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print Program Header Table
+ *
+ * @param ef the ELF file
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_program_header_table(struct elf_file_t *ef)
+{
+    elf64_word i = 0;
+    elf64_sword ret = 0;
+
+    if (!ef)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    for (i = 0; i < ef->ehdr->e_phnum; i++)
+    {
+        struct elf_phdr *phdr = 0;
+
+        ret = elf_program_header(ef, i, &phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+
+        ret = elf_print_program_header(ef, phdr);
+        if (ret != ELF_SUCCESS)
+            return ret;
+    }
+
+    return ELF_SUCCESS;
+}
+
+/**
+ * Print Program Header
+ *
+ * @param ef the ELF file
+ * @param phdr the program header for the segment to print
+ * @return ELF_SUCCESS on success, negative on error
+ */
+elf64_sword
+elf_print_program_header(struct elf_file_t *ef,
+                         struct elf_phdr *phdr)
+{
+    elf64_sword ret = 0;
+
+    if (!ef || !phdr)
+        return ELF_ERROR_INVALID_ARG;
+
+    if (ef->valid != ELF_TRUE)
+        return ELF_ERROR_INVALID_FILE;
+
+    DEBUG("Program Header:\n");
+    DEBUG("  %-35s %s\n", "Type:", p_type_to_str(phdr->p_type));
+    DEBUG("  %-35s ", "Flags:");
+
+    if (p_flags_is_executable(phdr) == ELF_TRUE) INFO("E ");
+    if (p_flags_is_writable(phdr) == ELF_TRUE) INFO("W ");
+    if (p_flags_is_readable(phdr) == ELF_TRUE) INFO("R ");
+
+    INFO("\n");
+    DEBUG("  %-35s 0x%llX\n", "Offset:", phdr->p_offset);
+    DEBUG("  %-35s 0x%llX\n", "Virtual Address:", phdr->p_vaddr);
+    DEBUG("  %-35s 0x%llX\n", "Physical Address:", phdr->p_paddr);
+    DEBUG("  %-35s %llu (bytes)\n", "File Size:", phdr->p_filesz);
+    DEBUG("  %-35s %llu (bytes)\n", "Exec Size:", phdr->p_memsz);
+    DEBUG("  %-35s 0x%llX\n", "Alignment:", phdr->p_align);
+
+    DEBUG("\n");
+
+    return ELF_SUCCESS;
+}

--- a/elf_loader/test/Makefile
+++ b/elf_loader/test/Makefile
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 #
 # Bareflank Hypervisor
 #
@@ -21,34 +19,42 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-set -e
+################################################################################
+# FLAGS
+################################################################################
 
-if [ $# -gt 0 ]; then
-    if [ $1 = "clean" ]; then
+CC=gcc
+CXX=g++
+LD=g++
+RM=rm -rf
+MD=mkdir -p
 
-        rm -Rf ./tools/doxygen/osx/src
-        exit
-    fi
-fi
+CCFLAGS=
+CXXFLAGS=-std=c++11
+LDFLAGS=
 
-if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
+DEFINES=
 
-	pushd tools/doxygen/osx
-	rm -Rf src
+################################################################################
+# Sources
+################################################################################
 
-	git clone https://github.com/doxygen/doxygen.git src
+TARGET_NAME=test
+TARGET_TYPE=bin
 
-	cd src
-	mkdir build
-  	cd build
-  	cmake -G "Unix Makefiles" ../
-	make -j
+OBJDIR=.build
+OUTDIR=../bin
 
-	popd
-fi
+SOURCES=test.cpp
 
-rm -Rf doc
-mkdir doc
+INCLUDES=
+LIBS=elf_loader
 
-cd doc
-../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt
+INCLUDE_PATHS=../include/ ./ ../../include/
+LIB_PATHS=../bin/
+
+################################################################################
+# Common
+################################################################################
+
+include ../../common/common_target.mk

--- a/elf_loader/test/test.cpp
+++ b/elf_loader/test/test.cpp
@@ -1,0 +1,1004 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <test.h>
+
+#include <fstream>
+#include <iostream>
+#include <functional>
+
+#include <sys/mman.h>
+
+auto c_dummy1_filename = "libdummy1.so";
+auto c_dummy2_filename = "libdummy2.so";
+auto c_dummy3_filename = "libdummy3.so";
+
+struct elf_test
+{
+    elf64_ehdr header;
+    elf_phdr phdr1;
+    elf_phdr phdr2;
+    char tmp[16];
+    char strtab[12];
+    elf_sym symtab[2];
+    elf_rel reltab[2];
+    elf_rela relatab[2];
+    elf_shdr shdr1;
+    elf_shdr shdr2;
+    elf_shdr shdr3;
+    elf_shdr shdr4;
+};
+
+elf_test g_test = {0};
+
+elf_loader_ut::elf_loader_ut() :
+    m_dummy1(0),
+    m_dummy2(0),
+    m_dummy3(0),
+    m_dummy1_length(0),
+    m_dummy2_length(0),
+    m_dummy3_length(0),
+    m_dummy1_exec(0),
+    m_dummy2_exec(0),
+    m_dummy3_exec(0),
+    m_dummy1_esize(0),
+    m_dummy2_esize(0),
+    m_dummy3_esize(0),
+    m_test_exec(0),
+    m_test_esize(0)
+{
+}
+
+bool elf_loader_ut::init(void)
+{
+    auto result = false;
+
+    auto dummy1_ifs = std::ifstream(c_dummy1_filename, std::ifstream::ate);
+    auto dummy2_ifs = std::ifstream(c_dummy2_filename, std::ifstream::ate);
+    auto dummy3_ifs = std::ifstream(c_dummy3_filename, std::ifstream::ate);
+
+    if (dummy1_ifs.is_open() == false ||
+        dummy2_ifs.is_open() == false ||
+        dummy3_ifs.is_open() == false)
+    {
+        std::cout << "unable to open one or more dummy libraries: " << std::endl;
+        std::cout << "    - dummy1: " << dummy1_ifs.is_open();
+        std::cout << "    - dummy2: " << dummy2_ifs.is_open();
+        std::cout << "    - dummy3: " << dummy3_ifs.is_open();
+        goto close;
+    }
+
+    m_dummy1_length = dummy1_ifs.tellg();
+    m_dummy2_length = dummy2_ifs.tellg();
+    m_dummy3_length = dummy3_ifs.tellg();
+
+    if (m_dummy1_length == 0 ||
+        m_dummy2_length == 0 ||
+        m_dummy3_length == 0)
+    {
+        std::cout << "one or more of the dummy libraries is empty: " << std::endl;
+        std::cout << "    - dummy1: " << dummy1_ifs.tellg();
+        std::cout << "    - dummy2: " << dummy2_ifs.tellg();
+        std::cout << "    - dummy3: " << dummy3_ifs.tellg();
+        goto close;
+    }
+
+    m_dummy1 = new char[dummy1_ifs.tellg()];
+    m_dummy2 = new char[dummy2_ifs.tellg()];
+    m_dummy3 = new char[dummy3_ifs.tellg()];
+
+    if (m_dummy1 == NULL ||
+        m_dummy2 == NULL ||
+        m_dummy3 == NULL)
+    {
+        std::cout << "unable to allocate space for one or more of the dummy libraries: " << std::endl;
+        std::cout << "    - dummy1: " << (void *)m_dummy1;
+        std::cout << "    - dummy2: " << (void *)m_dummy2;
+        std::cout << "    - dummy3: " << (void *)m_dummy3;
+        goto close;
+    }
+
+    dummy1_ifs.seekg(0);
+    dummy2_ifs.seekg(0);
+    dummy3_ifs.seekg(0);
+
+    dummy1_ifs.read(m_dummy1, m_dummy1_length);
+    dummy2_ifs.read(m_dummy2, m_dummy2_length);
+    dummy3_ifs.read(m_dummy3, m_dummy3_length);
+
+    if (dummy1_ifs.fail() == true ||
+        dummy2_ifs.fail() == true ||
+        dummy3_ifs.fail() == true)
+    {
+        std::cout << "unable to load one or more dummy libraries into memory: " << std::endl;
+        std::cout << "    - dummy1: " << dummy1_ifs.fail();
+        std::cout << "    - dummy2: " << dummy2_ifs.fail();
+        std::cout << "    - dummy3: " << dummy3_ifs.fail();
+        goto close;
+    }
+
+    result = true;
+
+close:
+
+    dummy1_ifs.close();
+    dummy2_ifs.close();
+    dummy3_ifs.close();
+
+done:
+
+    return result;
+}
+
+bool elf_loader_ut::fini(void)
+{
+    if (m_dummy1 != NULL)
+        delete[] m_dummy1;
+
+    if (m_dummy2 != NULL)
+        delete[] m_dummy2;
+
+    if (m_dummy1 != NULL)
+        delete[] m_dummy3;
+
+    if (m_dummy1_exec != NULL)
+        munmap(m_dummy1_exec, m_dummy1_esize);
+
+    if (m_dummy2_exec != NULL)
+        munmap(m_dummy2_exec, m_dummy2_esize);
+
+    if (m_dummy3_exec != NULL)
+        munmap(m_dummy3_exec, m_dummy3_esize);
+
+    return true;
+}
+
+bool elf_loader_ut::list(void)
+{
+    this->test_elf_file_init();
+    this->test_elf_file_size();
+    this->test_elf_file_load();
+    this->test_elf_loader_init();
+    this->test_elf_loader_add();
+    this->test_elf_loader_relocate();
+    this->test_elf_section_header();
+    this->test_elf_string_table_entry();
+    this->test_elf_section_name_string();
+    this->test_elf_symbol_by_index();
+    this->test_elf_symbol_by_name();
+    this->test_elf_symbol_by_name_global();
+    this->test_elf_resolve_symbol();
+    this->test_elf_relocate_symbol();
+    this->test_elf_relocate_symbol_addend();
+    this->test_elf_relocate_symbols();
+    this->test_elf_program_header();
+    this->test_elf_load_segments();
+    this->test_elf_load_segment();
+
+    this->test_elf_file_print_header();
+    this->test_elf_print_section_header_table();
+    this->test_elf_print_program_header_table();
+    this->test_elf_print_sym_table();
+    this->test_elf_print_relocations();
+
+    this->test_resolve();
+
+    return true;
+}
+
+char *alloc_exec(int32_t size)
+{
+    return (char *)mmap(0, size, PROT_READ | PROT_WRITE | PROT_EXEC,
+                        MAP_PRIVATE | MAP_ANON, -1, 0);
+}
+
+void elf_loader_ut::test_elf_file_init(void)
+{
+    auto ret = 0;
+
+    ret = elf_file_init(NULL, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+    ret = elf_file_init((char *)&g_test, 10, &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_MAG0);
+    g_test.header.e_ident[ei_mag0] = 0x7F;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_MAG1);
+    g_test.header.e_ident[ei_mag1] = 'E';
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_MAG2);
+    g_test.header.e_ident[ei_mag2] = 'L';
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_MAG3);
+    g_test.header.e_ident[ei_mag3] = 'F';
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_CLASS);
+    g_test.header.e_ident[ei_class] = elfclass64;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_DATA);
+    g_test.header.e_ident[ei_data] = elfdata2lsb;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_VERSION);
+    g_test.header.e_ident[ei_version] = ev_current;
+
+    g_test.header.e_ident[ei_osabi] = 1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_OSABI);
+    g_test.header.e_ident[ei_osabi] = elfosabi_sysv;
+
+    g_test.header.e_ident[ei_abiversion] = 1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_ABIVERSION);
+    g_test.header.e_ident[ei_abiversion] = 0;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_TYPE);
+    g_test.header.e_type = et_dyn;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_MACHINE);
+    g_test.header.e_machine = em_x86_64;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_EI_VERSION);
+    g_test.header.e_version = ev_current;
+
+    g_test.header.e_entry = -1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_ENTRY);
+    g_test.header.e_entry = 10000000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_ENTRY);
+    g_test.header.e_entry = 10;
+
+    g_test.header.e_phoff = -1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_PHOFF);
+    g_test.header.e_phoff = 10000000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_PHOFF);
+    g_test.header.e_phoff = (elf64_off)&g_test.phdr1 - (elf64_off)&g_test;
+
+    g_test.header.e_shoff = -1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_SHOFF);
+    g_test.header.e_shoff = 10000000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_SHOFF);
+    g_test.header.e_shoff = (elf64_off)&g_test.shdr1 - (elf64_off)&g_test;
+
+    g_test.header.e_flags = 1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_FLAGS);
+    g_test.header.e_flags = 0;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_EHSIZE);
+    g_test.header.e_ehsize = sizeof(struct elf64_ehdr);
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_PHENTSIZE);
+    g_test.header.e_phentsize = sizeof(struct elf_phdr);
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_SHENTSIZE);
+    g_test.header.e_shentsize = sizeof(struct elf_shdr);
+
+    g_test.header.e_phnum = 2;
+    g_test.header.e_shnum = 4;
+
+    g_test.header.e_shstrndx = 10;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_E_SHSTRNDX);
+    g_test.header.e_shstrndx = 0;
+
+    g_test.header.e_phnum = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_PHT);
+    g_test.header.e_phnum = 2;
+
+    g_test.header.e_shnum = 5;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_SHT);
+    g_test.header.e_shnum = 4;
+
+    g_test.shdr1.sh_offset = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_SH_SIZE);
+    g_test.shdr1.sh_offset = (elf64_off)&g_test.strtab - (elf64_off)&g_test;
+
+    g_test.shdr1.sh_size = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_SH_SIZE);
+    g_test.shdr1.sh_size = sizeof(g_test.strtab);
+
+    g_test.shdr1.sh_offset = (elf64_off)&g_test.strtab - (elf64_off)&g_test;
+    g_test.shdr2.sh_offset = (elf64_off)&g_test.symtab - (elf64_off)&g_test;
+    g_test.shdr3.sh_offset = (elf64_off)&g_test.reltab - (elf64_off)&g_test;
+    g_test.shdr4.sh_offset = (elf64_off)&g_test.relatab - (elf64_off)&g_test;
+    g_test.shdr1.sh_size = sizeof(g_test.strtab);
+    g_test.shdr2.sh_size = sizeof(g_test.symtab);
+    g_test.shdr3.sh_size = sizeof(g_test.reltab);
+    g_test.shdr4.sh_size = sizeof(g_test.relatab);
+
+    g_test.phdr1.p_offset = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_PH_FILESZ);
+    g_test.phdr1.p_offset = (elf64_off)&g_test.strtab - (elf64_off)&g_test;
+
+    g_test.phdr1.p_memsz = 16000;
+    g_test.phdr1.p_filesz = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_PH_FILESZ);
+    g_test.phdr1.p_filesz = sizeof(g_test.strtab) + sizeof(g_test.symtab);
+
+    g_test.phdr1.p_memsz = 1;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_PH_FILESZ);
+    g_test.phdr1.p_memsz = g_test.phdr1.p_filesz;
+
+    g_test.phdr1.p_offset = (elf64_off)&g_test.strtab - (elf64_off)&g_test;
+    g_test.phdr1.p_filesz = sizeof(g_test.strtab) + sizeof(g_test.symtab);
+    g_test.phdr1.p_memsz = g_test.phdr1.p_filesz;
+    g_test.phdr1.p_vaddr = g_test.phdr1.p_offset;
+
+    g_test.phdr2.p_offset = (elf64_off)&g_test.reltab - (elf64_off)&g_test;
+    g_test.phdr2.p_filesz = sizeof(g_test.reltab) + sizeof(g_test.relatab);
+    g_test.phdr2.p_memsz = g_test.phdr2.p_filesz + 300;
+    g_test.phdr2.p_vaddr = g_test.phdr2.p_offset;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    g_test.shdr2.sh_type = sht_dynsym;
+
+    g_test.shdr2.sh_link = 16000;
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+    g_test.shdr2.sh_link = 0;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_SH_TYPE);
+
+    g_test.shdr1.sh_type = sht_strtab;
+    g_test.shdr2.sh_type = sht_dynsym;
+    g_test.shdr3.sh_type = sht_rel;
+    g_test.shdr4.sh_type = sht_rela;
+
+    g_test.strtab[0] = 'h';
+    g_test.strtab[1] = 'e';
+    g_test.strtab[2] = 'l';
+    g_test.strtab[3] = 'l';
+    g_test.strtab[4] = 'o';
+    g_test.strtab[5] = '\0';
+    g_test.strtab[6] = 'w';
+    g_test.strtab[7] = 'o';
+    g_test.strtab[8] = 'r';
+    g_test.strtab[9] = 'l';
+    g_test.strtab[10] = 'd';
+    g_test.strtab[11] = '\0';
+
+    g_test.shdr1.sh_name = 0;
+    g_test.shdr2.sh_name = 0;
+    g_test.shdr3.sh_name = 6;
+    g_test.shdr4.sh_name = 6;
+
+    g_test.symtab[0].st_value = 0x10;
+    g_test.symtab[1].st_value = 0x11;
+
+    g_test.reltab[0].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+    g_test.reltab[0].r_info = R_X86_64_GLOB_DAT;
+    g_test.reltab[1].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+    g_test.reltab[1].r_info = R_X86_64_JUMP_SLOT;
+
+    g_test.relatab[0].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+    g_test.relatab[0].r_info = R_X86_64_GLOB_DAT;
+    g_test.relatab[1].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+    g_test.relatab[1].r_info = R_X86_64_64;
+
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_init((char *)&g_test, sizeof(g_test), &m_test_elf);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_file_init(m_dummy1, m_dummy1_length, &m_dummy1_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_init(m_dummy2, m_dummy2_length, &m_dummy2_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_init(m_dummy3, m_dummy3_length, &m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+}
+
+void elf_loader_ut::test_elf_file_size(void)
+{
+    m_test_esize = elf_total_exec_size(NULL);
+    ASSERT_TRUE(m_test_esize == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    m_test_esize = elf_total_exec_size(&m_test_elf);
+    ASSERT_TRUE(m_test_esize == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    m_test_esize = elf_total_exec_size(&m_test_elf);
+    ASSERT_TRUE(m_test_esize > ELF_SUCCESS);
+
+    m_test_exec = alloc_exec(m_test_esize);
+    ASSERT_TRUE(m_test_exec != NULL);
+
+    m_dummy1_esize = elf_total_exec_size(&m_dummy1_ef);
+    ASSERT_TRUE(m_dummy1_esize > ELF_SUCCESS);
+    m_dummy2_esize = elf_total_exec_size(&m_dummy2_ef);
+    ASSERT_TRUE(m_dummy2_esize > ELF_SUCCESS);
+    m_dummy3_esize = elf_total_exec_size(&m_dummy3_ef);
+    ASSERT_TRUE(m_dummy3_esize > ELF_SUCCESS);
+
+    m_dummy1_exec = alloc_exec(m_dummy1_esize);
+    ASSERT_TRUE(m_dummy1_exec != NULL);
+    m_dummy2_exec = alloc_exec(m_dummy2_esize);
+    ASSERT_TRUE(m_dummy2_exec != NULL);
+    m_dummy3_exec = alloc_exec(m_dummy3_esize);
+    ASSERT_TRUE(m_dummy3_exec != NULL);
+}
+
+void elf_loader_ut::test_elf_file_load(void)
+{
+    auto ret = 0;
+
+    ret = elf_file_load(NULL, m_test_exec, m_test_esize);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_file_load(&m_test_elf, NULL, m_test_esize);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_file_load(&m_test_elf, m_test_exec, 10);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_file_load(&m_test_elf, m_test_exec, m_test_esize);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_file_load(&m_test_elf, m_test_exec, 1000000);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_file_load(&m_test_elf, m_test_exec, m_test_esize);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_load(&m_test_elf, m_test_exec, m_test_esize);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_file_load(&m_dummy1_ef, m_dummy1_exec, m_dummy1_esize);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_load(&m_dummy2_ef, m_dummy2_exec, m_dummy2_esize);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_file_load(&m_dummy3_ef, m_dummy3_exec, m_dummy3_esize);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_loader_init(void)
+{
+    auto ret = 0;
+
+    ret = elf_loader_init(NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_loader_init(&m_test_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_loader_init(&m_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_loader_add(void)
+{
+    auto ret = 0;
+
+    ret = elf_loader_add(NULL, &m_dummy1_ef);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_loader_add(&m_test_loader, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_loader_add(&m_test_loader, &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    for (auto i = 0; i < ELF_MAX_MODULES + 1; i++)
+        ret = elf_loader_add(&m_test_loader, &m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_LOADER_FULL);
+
+    ret = elf_loader_init(&m_test_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_loader_add(&m_test_loader, &m_test_elf);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_loader_add(&m_loader, &m_dummy1_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_loader_add(&m_loader, &m_dummy2_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_loader_add(&m_loader, &m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_loader_relocate(void)
+{
+    auto ret = 0;
+
+    ret = elf_loader_relocate(NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_loader.num = 1000;
+    ret = elf_loader_relocate(&m_test_loader);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_LOADER);
+    m_test_loader.num = 1;
+
+    ret = elf_loader_relocate(&m_test_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ret = elf_loader_relocate(&m_test_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_loader_relocate(&m_loader);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_section_header(void)
+{
+    auto ret = 0;
+    struct elf_shdr *shdr = 0;
+    struct elf_file_t tmp_elf = {0};
+
+    ret = elf_section_header(NULL, 0, &shdr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_section_header(&m_test_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_section_header(&tmp_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    tmp_elf.ehdr = m_test_elf.ehdr;
+    ret = elf_section_header(&tmp_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_section_header(&m_test_elf, 100, &shdr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+
+    ret = elf_section_header(&m_test_elf, 0, &shdr);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_string_table_entry(void)
+{
+    auto ret = 0;
+    struct e_string str = {0};
+
+    ret = elf_string_table_entry(NULL, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_string_table_entry(&m_test_elf, NULL, 0, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 100, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_OFFSET);
+
+    g_test.strtab[11] = 'a';
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 6, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_STRING_TABLE);
+    g_test.strtab[11] = '\0';
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ASSERT_TRUE(str.buf[0] == 'h');
+    ASSERT_TRUE(str.len == 5);
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 6, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ASSERT_TRUE(str.buf[0] == 'w');
+    ASSERT_TRUE(str.len == 5);
+}
+
+void elf_loader_ut::test_elf_section_name_string(void)
+{
+    auto ret = 0;
+    struct e_string str = {0};
+    struct elf_shdr *shdr = 0;
+
+    ret = elf_section_name_string(NULL, &g_test.shdr1, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_section_name_string(&m_test_elf, NULL, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_section_name_string(&m_test_elf, &g_test.shdr1, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_section_name_string(&m_test_elf, &g_test.shdr1, &str);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_section_name_string(&m_test_elf, &g_test.shdr1, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ASSERT_TRUE(str.buf[0] == 'h');
+}
+
+void elf_loader_ut::test_elf_symbol_by_index(void)
+{
+    auto ret = 0;
+    struct elf_sym *sym = 0;
+
+    ret = elf_symbol_by_index(NULL, 0, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_index(&m_test_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_index(&m_test_elf, 3, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_symbol_by_index(&m_test_elf, 0, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_symbol_by_index(&m_test_elf, 0, &sym);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_symbol_by_name(void)
+{
+    auto ret = 0;
+    struct elf_sym *sym = 0;
+    struct e_string str = {0};
+
+    ret = elf_symbol_by_name(NULL, &str, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_name(&m_test_elf, NULL, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_name(&m_test_elf, &str, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_symbol_by_name(&m_test_elf, &str, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_symbol_by_name(&m_test_elf, &str, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_NO_SUCH_SYMBOL);
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_symbol_by_name(&m_test_elf, &str, &sym);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_symbol_by_name_global(void)
+{
+    auto ret = 0;
+    struct elf_sym *sym = 0;
+    struct e_string str = {0};
+    struct elf_file_t *efr = 0;
+
+    ret = elf_symbol_by_name_global(NULL, &str, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_name_global(&m_test_elf, NULL, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, NULL, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, &efr, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_NO_SUCH_SYMBOL);
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    g_test.symtab[0].st_value = 0x0;
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_ERROR_NO_SUCH_SYMBOL);
+    g_test.symtab[0].st_value = 0x10;
+
+    ret = elf_symbol_by_name_global(&m_test_elf, &str, &efr, &sym);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+    ASSERT_TRUE(efr == &m_test_elf);
+}
+
+void elf_loader_ut::test_elf_resolve_symbol(void)
+{
+    auto ret = 0;
+    void *addr = 0;
+    struct e_string str = {0};
+
+    ret = elf_resolve_symbol(NULL, &str, &addr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_resolve_symbol(&m_test_elf, NULL, &addr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_resolve_symbol(&m_test_elf, &str, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_resolve_symbol(&m_test_elf, &str, &addr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_resolve_symbol(&m_test_elf, &str, &addr);
+    ASSERT_TRUE(ret == ELF_ERROR_NO_SUCH_SYMBOL);
+
+    ret = elf_string_table_entry(&m_test_elf, m_test_elf.strtab, 0, &str);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+
+    ret = elf_resolve_symbol(&m_test_elf, &str, &addr);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_relocate_symbol(void)
+{
+    auto ret = 0;
+
+    ret = elf_relocate_symbol(NULL, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_relocate_symbol(&m_test_elf, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_relocate_symbol(&m_test_elf, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    g_test.reltab[0].r_info = 0xFFFFFFFFFFFFFFFF;
+    ret = elf_relocate_symbol(&m_test_elf, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+    g_test.reltab[0].r_info = 0;
+
+    g_test.reltab[0].r_offset = 1000000;
+    ret = elf_relocate_symbol(&m_test_elf, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    g_test.reltab[0].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+
+    g_test.reltab[0].r_info = 100;
+    ret = elf_relocate_symbol(&m_test_elf, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_RELOCATION_TYPE);
+    g_test.reltab[0].r_info = R_X86_64_GLOB_DAT;
+
+    ret = elf_relocate_symbol(&m_test_elf, &(g_test.reltab[0]));
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_relocate_symbol_addend(void)
+{
+    auto ret = 0;
+
+    ret = elf_relocate_symbol_addend(NULL, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_relocate_symbol_addend(&m_test_elf, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_relocate_symbol_addend(&m_test_elf, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    g_test.relatab[0].r_info = 0xFFFFFFFFFFFFFFFF;
+    ret = elf_relocate_symbol_addend(&m_test_elf, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+    g_test.relatab[0].r_info = 0;
+
+    g_test.relatab[0].r_offset = 1000000;
+    ret = elf_relocate_symbol_addend(&m_test_elf, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    g_test.relatab[0].r_offset = (elf64_addr)g_test.tmp - (elf64_addr)&g_test;
+
+    g_test.relatab[0].r_info = 100;
+    ret = elf_relocate_symbol_addend(&m_test_elf, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_RELOCATION_TYPE);
+    g_test.relatab[0].r_info = R_X86_64_GLOB_DAT;
+
+    ret = elf_relocate_symbol_addend(&m_test_elf, &(g_test.relatab[0]));
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_relocate_symbols(void)
+{
+    auto ret = 0;
+
+    ret = elf_relocate_symbols(NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_relocate_symbols(&m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_relocate_symbols(&m_test_elf);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_program_header(void)
+{
+    auto ret = 0;
+    struct elf_phdr *phdr = 0;
+    struct elf_file_t tmp_elf = {0};
+
+    ret = elf_program_header(NULL, 0, &phdr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_program_header(&m_test_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_program_header(&tmp_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    tmp_elf.ehdr = m_test_elf.ehdr;
+    ret = elf_program_header(&tmp_elf, 0, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_program_header(&m_test_elf, 100, &phdr);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_INDEX);
+
+    ret = elf_program_header(&m_test_elf, 0, &phdr);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_load_segments(void)
+{
+    auto ret = 0;
+
+    ret = elf_load_segments(NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_load_segments(&m_test_elf);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    ret = elf_load_segments(&m_test_elf);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_load_segment(void)
+{
+    auto ret = 0;
+
+    ret = elf_load_segment(NULL, &g_test.phdr1);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    ret = elf_load_segment(&m_test_elf, NULL);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_ARG);
+
+    m_test_elf.valid = ELF_FALSE;
+    ret = elf_load_segment(&m_test_elf, &g_test.phdr1);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_FILE);
+    m_test_elf.valid = ELF_TRUE;
+
+    g_test.phdr1.p_memsz = 1000000;
+    ret = elf_load_segment(&m_test_elf, &g_test.phdr1);
+    ASSERT_TRUE(ret == ELF_ERROR_INVALID_PH_MEMSZ);
+    g_test.phdr1.p_memsz = g_test.phdr1.p_filesz;
+
+    ret = elf_load_segment(&m_test_elf, &g_test.phdr1);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_file_print_header(void)
+{
+    auto ret = 0;
+
+    ret = elf_file_print_header(&m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_print_section_header_table(void)
+{
+    auto ret = 0;
+
+    ret = elf_print_section_header_table(&m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_print_program_header_table(void)
+{
+    auto ret = 0;
+
+    ret = elf_print_program_header_table(&m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_print_sym_table(void)
+{
+    auto ret = 0;
+
+    ret = elf_print_sym_table(&m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_elf_print_relocations(void)
+{
+    auto ret = 0;
+
+    ret = elf_print_relocations(&m_dummy3_ef);
+    ASSERT_TRUE(ret == ELF_SUCCESS);
+}
+
+void elf_loader_ut::test_resolve(void)
+{
+    auto ret = 0;
+    void *entry = 0;
+    struct e_string str = {"_Z12dummy3_test2i", 17};
+
+    ret = elf_resolve_symbol(&m_dummy3_ef, &str, &entry);
+    EXPECT_TRUE(ret == ELF_SUCCESS);
+
+    if (ret == ELF_SUCCESS)
+    {
+        std::function<int(int)> dummy3_test1 =
+            reinterpret_cast<int(*)(int)>(entry);
+
+        std::cout << std::endl;
+        std::cout << "Result: " << dummy3_test1(5) << std::endl;
+        std::cout << std::endl;
+    }
+    else
+    {
+        std::cout << std::endl;
+        std::cout << "Error: " << elf_error(ret) << std::endl;
+        std::cout << std::endl;
+    }
+}
+
+int
+main(int argc, char *argv[])
+{
+    return RUN_ALL_TESTS(elf_loader_ut);
+}

--- a/elf_loader/test/test.h
+++ b/elf_loader/test/test.h
@@ -1,0 +1,99 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef TEST_H
+#define TEST_H
+
+#include <unittest.h>
+#include <elf_loader.h>
+
+class elf_loader_ut : public unittest
+{
+public:
+
+    elf_loader_ut();
+    virtual ~elf_loader_ut() {}
+
+protected:
+
+    virtual bool init(void) override;
+    virtual bool fini(void) override;
+    virtual bool list(void) override;
+
+private:
+
+    virtual void test_elf_file_init(void);
+    virtual void test_elf_file_size(void);
+    virtual void test_elf_file_load(void);
+    virtual void test_elf_loader_init(void);
+    virtual void test_elf_loader_add(void);
+    virtual void test_elf_loader_relocate(void);
+    virtual void test_elf_section_header(void);
+    virtual void test_elf_string_table_entry(void);
+    virtual void test_elf_section_name_string(void);
+    virtual void test_elf_symbol_by_index(void);
+    virtual void test_elf_symbol_by_name(void);
+    virtual void test_elf_symbol_by_name_global(void);
+    virtual void test_elf_resolve_symbol(void);
+    virtual void test_elf_relocate_symbol(void);
+    virtual void test_elf_relocate_symbol_addend(void);
+    virtual void test_elf_relocate_symbols(void);
+    virtual void test_elf_program_header(void);
+    virtual void test_elf_load_segments(void);
+    virtual void test_elf_load_segment(void);
+
+    virtual void test_elf_file_print_header(void);
+    virtual void test_elf_print_section_header_table(void);
+    virtual void test_elf_print_program_header_table(void);
+    virtual void test_elf_print_sym_table(void);
+    virtual void test_elf_print_relocations(void);
+
+    virtual void test_resolve(void);
+
+private:
+
+    char *m_dummy1;
+    char *m_dummy2;
+    char *m_dummy3;
+    int32_t m_dummy1_length;
+    int32_t m_dummy2_length;
+    int32_t m_dummy3_length;
+
+    char *m_dummy1_exec;
+    char *m_dummy2_exec;
+    char *m_dummy3_exec;
+    int32_t m_dummy1_esize;
+    int32_t m_dummy2_esize;
+    int32_t m_dummy3_esize;
+
+    elf_file_t m_dummy1_ef;
+    elf_file_t m_dummy2_ef;
+    elf_file_t m_dummy3_ef;
+
+    char *m_test_exec;
+    int32_t m_test_esize;
+    elf_file_t m_test_elf;
+
+    elf_loader_t m_loader;
+    elf_loader_t m_test_loader;
+};
+
+#endif

--- a/include/unittest.h
+++ b/include/unittest.h
@@ -1,0 +1,150 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef UNITTEST_H
+#define UNITTEST_H
+
+#include <iostream>
+
+#define EXPECT_TRUE(condition) \
+    if((condition)) { this->inc_pass(); } \
+    else { this->expect_failed(#condition, __PRETTY_FUNCTION__, __LINE__); }
+#define EXPECT_FALSE(condition) \
+    if(!(condition)) { this->inc_pass(); } \
+    else { this->expect_failed(#condition, __PRETTY_FUNCTION__, __LINE__); }
+
+#define ASSERT_TRUE(condition) \
+    if((condition)) { this->inc_pass(); } \
+    else { this->assert_failed(#condition, __PRETTY_FUNCTION__, __LINE__); }
+#define ASSERT_FALSE(condition) \
+    if(!(condition)) { this->inc_pass(); } \
+    else { this->assert_failed(#condition, __PRETTY_FUNCTION__, __LINE__); }
+
+#define RUN_ALL_TESTS(ut) []() -> int { ut _ut; return _ut.run(); }()
+
+class unittest
+{
+public:
+
+    unittest() {}
+    virtual ~unittest() {}
+
+    virtual int run(void)
+    {
+        if (this->internal_init() == false)
+            return EXIT_FAILURE;
+
+        if (this->init() == false)
+        {
+            std::cout << "\033[1;31mFAILED\033[0m: init" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        try
+        {
+            if (this->list() == false)
+            {
+                std::cout << "\033[1;31mFAILED\033[0m: list" << std::endl;
+                return EXIT_FAILURE;
+            }
+        }
+        catch (...)
+        {
+        }
+
+        if (this->fini() == false)
+        {
+            std::cout << "\033[1;31mFAILED\033[0m: fini" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        if (this->internal_fini() == false)
+            return EXIT_FAILURE;
+
+        return EXIT_SUCCESS;
+    }
+
+    virtual void expect_failed(const char *condition, const char *func, int line)
+    {
+        std::cout << "\033[1;31mFAILED\033[0m: [" << line << "]: " << func << std::endl;
+        std::cout << "   - condition: " << condition << std::endl;
+        this->inc_fail();
+    }
+
+    virtual void assert_failed(const char *condition, const char *func, int line)
+    {
+        this->expect_failed(condition, func, line);
+        throw (0);
+    }
+
+protected:
+
+    virtual bool list(void) { return true; };
+    virtual bool init(void) { return true; };
+    virtual bool fini(void) { return true; };
+
+    virtual void inc_pass(void) { m_pass++; }
+    virtual void inc_fail(void) { m_fail++; }
+
+private:
+
+    virtual bool internal_init(void)
+    {
+        m_pass = 0;
+        m_fail = 0;
+
+        return true;
+    }
+
+    virtual bool internal_fini(void)
+    {
+        if (m_fail > 0)
+        {
+            std::cout << std::endl;
+            std::cout << "totals: ";
+            std::cout << m_pass << " passed, ";
+            std::cout << "\033[1;31m";
+            std::cout << m_fail << " failed";
+            std::cout << "\033[0m";
+            std::cout << std::endl;
+
+            return false;
+        }
+        else
+        {
+            std::cout << "totals: ";
+            std::cout << "\033[1;32m";
+            std::cout << m_pass << " passed, ";
+            std::cout << "\033[0m";
+            std::cout << m_fail << " failed";
+            std::cout << std::endl;
+
+            return true;
+        }
+    }
+
+private:
+
+    int m_pass;
+    int m_fail;
+};
+
+#endif

--- a/tools/astyle/osx/run.sh
+++ b/tools/astyle/osx/run.sh
@@ -14,12 +14,12 @@
 #
 # This library is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
 # Lesser General Public License for more details.
 #
 # You should have received a copy of the GNU Lesser General Public
 # License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 set -e
 
@@ -46,10 +46,14 @@ if [ ! -f $ASTYLE ]; then
 	popd
 fi
 
-find src/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find src/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find src/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find include/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find include/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find include/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 
-find test/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find test/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find test/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find common/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find common/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find common/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
+find elf_loader/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find elf_loader/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find elf_loader/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;

--- a/tools/doxygen/config.txt
+++ b/tools/doxygen/config.txt
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include ../src ../test ../example
+INPUT                  = ../include ../common ../elf_loader
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This pull request contains the initial ELF loader. It is
capable of loading multiple ELF files into memory,
relocating and resolving all symbols, and then executing
arbitrary entry points.

This pull request also contains a basic unit test framework
as well as a basic Makefile framework for compiling.

Tasks to be completed in the future include:
- Lazy loading for R_X86_64_JUMP_SLOT
- Using .hash instead of doing O(n) search
- Detecting duplicate symbols

[RFC]: https://groups.google.com/forum/#!topic/bareflank/8NO9AVGzlaU

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>