### PR TITLE
Fix issue with doxygen script

### DIFF
--- a/tools/doxygen/osx/run.sh
+++ b/tools/doxygen/osx/run.sh
@@ -47,8 +47,7 @@ if [ ! -f tools/doxygen/osx/src/build/bin/doxygen ]; then
 	popd
 fi
 
-rm -Rf doc
-mkdir doc
+mkdir -p doc
 
 cd doc
 ../tools/doxygen/osx/src/build/bin/doxygen ../tools/doxygen/config.txt


### PR DESCRIPTION
The OSX doxygen script was removing the "doc" folder and then
recreating it instead of using the "-p"

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/12

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>