### PR TITLE
Fix compilation error

### DIFF
--- a/elf_loader/include/elf_loader.h
+++ b/elf_loader/include/elf_loader.h
@@ -183,16 +183,8 @@ const char *ELF_ERROR_LOADER_FULL_STR = "Loader is full (ELF_ERROR_LOADER_FULL_S
 const char *ELF_ERROR_INVALID_LOADER_STR = "Invalid loader (ELF_ERROR_INVALID_LOADER)";
 const char *ELF_ERROR_INVALID_RELOCATION_TYPE_STR = "Invalid relocation type (ELF_ERROR_INVALID_RELOCATION_TYPE)";
 
-/*
- * ELF error
- *
- * Returns a human reabable form of an ELF error
- *
- * @param error the return code from an ELF function
- * @return resulting string
- */
 const char *
-elf_error(elf64_sword error);
+elf_error(elf64_sword value);
 
 /******************************************************************************/
 /* ELF File                                                                   */
@@ -316,16 +308,8 @@ elf_loader_relocate(struct elf_loader_t *loader);
 const char *elfclass32_str = "ELF32 (elfclass32)";
 const char *elfclass64_str = "ELF64 (elfclass64)";
 
-/*
- * ELF ei_class -> char *
- *
- * Returns a human reabable form of ei_class
- *
- * @param class ei_class to convert to string
- * @return resulting string
- */
 const char *
-ei_class_to_str(unsigned char class);
+ei_class_to_str(unsigned char value);
 
 /*
  * ELF Data Types
@@ -339,16 +323,8 @@ ei_class_to_str(unsigned char class);
 const char *elfdata2lsb_str = "2's complement, little endian (elfdata2lsb)";
 const char *elfdata2msb_str = "2's complement, big endian (elfdata2msb)";
 
-/*
- * ELF ei_data -> char *
- *
- * Returns a human reabable form of ei_data
- *
- * @param data ei_data to convert to string
- * @return resulting string
- */
 const char *
-ei_data_to_str(unsigned char data);
+ei_data_to_str(unsigned char value);
 
 /*
  * ELF Version
@@ -360,16 +336,8 @@ ei_data_to_str(unsigned char data);
 
 const char *ev_current_str = "1 (ev_current)";
 
-/*
- * ELF ei_version / e_version -> char *
- *
- * Returns a human reabable form of ei_version and e_version
- *
- * @param version version to convert to string
- * @return resulting string
- */
 const char *
-version_to_str(unsigned char version);
+version_to_str(unsigned char value);
 
 /*
  * ELF OS / ABI Types
@@ -385,16 +353,8 @@ const char *elfosabi_sysv_str = "System V ABI (elfosabi_sysv)";
 const char *elfosabi_hpux_str = "HP-UX operating system (elfosabi_hpux)";
 const char *elfosabi_standalone_str = "Standalone (elfosabi_standalone)";
 
-/*
- * ELF ei_osabi -> char *
- *
- * Returns a human reabable form of ei_osabi
- *
- * @param osabi ei_osabi to convert to string
- * @return resulting string
- */
-const char*
-ei_osabi_to_str(unsigned char osabi);
+const char *
+ei_osabi_to_str(unsigned char value);
 
 /*
  * ELF Types
@@ -422,16 +382,8 @@ const char *et_hios_str = "Environment-specific use (et_hios)";
 const char *et_loproc_str = "Processor-specific use (et_loproc)";
 const char *et_hiproc_str = "Processor-specific use (et_hiproc)";
 
-/*
- * ELF e_type -> char *
- *
- * Returns a human reabable form of e_type
- *
- * @param e_type e_type to convert to string
- * @return resulting string
- */
 const char *
-e_type_to_str(elf64_half e_type);
+e_type_to_str(elf64_half value);
 
 /*
  * ELF Machine Codes
@@ -519,16 +471,8 @@ const char *em_cygnus_m32r_str = "cygnus_m32r";
 const char *em_s390_old_str = "s390_old";
 const char *em_cygnus_mn10300_str = "cygnus_mn10300";
 
-/*
- * ELF e_machine -> char *
- *
- * Returns a human reabable form of e_machine
- *
- * @param e_machine e_machine to convert to string
- * @return resulting string
- */
 const char *
-e_machine_to_str(elf64_half e_machine);
+e_machine_to_str(elf64_half value);
 
 /*
  * ELF File Header
@@ -604,16 +548,8 @@ const char *sht_hios_str = "Process specific (sht_hios)";
 const char *sht_loproc_str = "Process specific (sht_loproc)";
 const char *sht_hiproc_str = "Process specific (sht_hiproc)";
 
-/*
- * ELF sh_type -> char *
- *
- * Returns a human reabable form of sh_type
- *
- * @param sh_type sh_type to convert to string
- * @return resulting string
- */
 const char *
-sh_type_to_str(elf64_word sh_type);
+sh_type_to_str(elf64_word value);
 
 /*
  * ELF Section Attributes
@@ -741,16 +677,8 @@ const char *stb_hios_str = "stb_hios";
 const char *stb_loproc_str = "stb_loproc";
 const char *stb_hiproc_str = "stb_hiproc";
 
-/*
- * ELF stb -> char *
- *
- * Returns a human reabable form of st_info (bind)
- *
- * @param st_info st_info to convert to string
- * @return resulting string
- */
 const char *
-stb_to_str(elf64_word st_info);
+stb_to_str(elf64_word value);
 
 #define stt_notype ((unsigned char)0)
 #define stt_object ((unsigned char)1)
@@ -772,16 +700,8 @@ const char *stt_hios_str = "stt_hios";
 const char *stt_loproc_str = "stt_loproc";
 const char *stt_hiproc_str = "stt_hiproc";
 
-/*
- * ELF stt -> char *
- *
- * Returns a human reabable form of st_info (type)
- *
- * @param st_info st_info to convert to string
- * @return resulting string
- */
 const char *
-stt_to_str(elf64_word st_info);
+stt_to_str(elf64_word value);
 
 #define ELF_SYM_BIND(x) ((x) >> 4)
 #define ELF_SYM_TYPE(x) ((x) & 0xF)
@@ -844,16 +764,8 @@ const char *R_X86_64_GLOB_DAT_STR = "R_X86_64_GLOB_DAT";
 const char *R_X86_64_JUMP_SLOT_STR = "R_X86_64_JUMP_SLOT";
 const char *R_X86_64_RELATIVE_STR = "R_X86_64_RELATIVE";
 
-/*
- * ELF r_info (type) -> char *
- *
- * Returns a human reabable form of r_info (type)
- *
- * @param r_info r_info to convert to string
- * @return resulting string
- */
 const char *
-rel_type_to_str(elf64_xword r_info);
+rel_type_to_str(elf64_xword value);
 
 struct elf_rel
 {
@@ -925,16 +837,8 @@ const char *pt_hios_str = "Environment specific (pt_hios)";
 const char *pt_loproc_str = "Processor specific (pt_loproc)";
 const char *pt_hiproc_str = "Processor specific (pt_hiproc)";
 
-/*
- * ELF p_type -> char *
- *
- * Returns a human reabable form of p_type
- *
- * @param p_type p_type to convert to string
- * @return resulting string
- */
 const char *
-p_type_to_str(elf64_word p_type);
+p_type_to_str(elf64_word value);
 
 /*
  * ELF Section Attributes

--- a/elf_loader/src/elf_loader.c
+++ b/elf_loader/src/elf_loader.c
@@ -80,13 +80,13 @@ elf_strcmp(struct e_string *str1, struct e_string *str2)
 /**
  * Convert ELF error -> const char *
  *
- * @param error error code to convert
+ * @param value error code to convert
  * @return const char * version of error code
  */
 const char *
-elf_error(elf64_sword error)
+elf_error(elf64_sword value)
 {
-    switch (error)
+    switch (value)
     {
         case ELF_SUCCESS: return ELF_SUCCESS_STR;
         case ELF_ERROR_INVALID_ARG: return ELF_ERROR_INVALID_ARG_STR;
@@ -518,13 +518,13 @@ elf_loader_relocate(struct elf_loader_t *loader)
 /**
  * Convert ei_class -> const char *
  *
- * @param ei_class ei_class to convert
+ * @param value ei_class to convert
  * @return const char * version of ei_class
  */
 const char *
-ei_class_to_str(unsigned char class)
+ei_class_to_str(unsigned char value)
 {
-    switch (class)
+    switch (value)
     {
         case elfclass32: return elfclass32_str;
         case elfclass64: return elfclass64_str;
@@ -535,13 +535,13 @@ ei_class_to_str(unsigned char class)
 /**
  * Convert ei_data -> const char *
  *
- * @param ei_data ei_data to convert
+ * @param value ei_data to convert
  * @return const char * version of ei_data
  */
 const char *
-ei_data_to_str(unsigned char data)
+ei_data_to_str(unsigned char value)
 {
-    switch (data)
+    switch (value)
     {
         case elfdata2lsb: return elfdata2lsb_str;
         case elfdata2msb: return elfdata2msb_str;
@@ -552,13 +552,13 @@ ei_data_to_str(unsigned char data)
 /**
  * Convert version -> const char *
  *
- * @param version version to convert
+ * @param value version to convert
  * @return const char * version of version
  */
 const char *
-version_to_str(unsigned char version)
+version_to_str(unsigned char value)
 {
-    switch (version)
+    switch (value)
     {
         case ev_current: return ev_current_str;
         default: return "Unknown version";
@@ -568,13 +568,13 @@ version_to_str(unsigned char version)
 /**
  * Convert ei_osabi -> const char *
  *
- * @param ei_osabi ei_osabi to convert
+ * @param value ei_osabi to convert
  * @return const char * version of ei_osabi
  */
 const char *
-ei_osabi_to_str(unsigned char osabi)
+ei_osabi_to_str(unsigned char value)
 {
-    switch (osabi)
+    switch (value)
     {
         case elfosabi_sysv: return elfosabi_sysv_str;
         case elfosabi_hpux: return elfosabi_hpux_str;
@@ -586,13 +586,13 @@ ei_osabi_to_str(unsigned char osabi)
 /**
  * Convert e_type -> const char *
  *
- * @param e_type e_type to convert
+ * @param value e_type to convert
  * @return const char * version of e_type
  */
 const char *
-e_type_to_str(elf64_half e_type)
+e_type_to_str(elf64_half value)
 {
-    switch (e_type)
+    switch (value)
     {
         case et_none: return et_none_str;
         case et_rel: return et_rel_str;
@@ -610,13 +610,13 @@ e_type_to_str(elf64_half e_type)
 /**
  * Convert e_machine -> const char *
  *
- * @param e_machine e_machine to convert
+ * @param value e_machine to convert
  * @return const char * version of e_machine
  */
 const char *
-e_machine_to_str(elf64_half e_machine)
+e_machine_to_str(elf64_half value)
 {
-    switch (e_machine)
+    switch (value)
     {
         case em_none: return em_none_str;
         case em_m32: return em_m32_str;
@@ -713,13 +713,13 @@ elf_file_print_header(struct elf_file_t *ef)
 /**
  * Convert sh_type -> const char *
  *
- * @param sh_type sh_type to convert
+ * @param value sh_type to convert
  * @return const char * version of sh_type
  */
 const char *
-sh_type_to_str(elf64_word sh_type)
+sh_type_to_str(elf64_word value)
 {
-    switch (sh_type)
+    switch (value)
     {
         case sht_null: return sht_null_str;
         case sht_progbits: return sht_progbits_str;
@@ -980,13 +980,13 @@ elf_section_name_string(struct elf_file_t *ef,
 /**
  * Convert stb -> const char *
  *
- * @param st_info stb to convert
+ * @param value stb to convert
  * @return const char * version of stb
  */
 const char *
-stb_to_str(elf64_word st_info)
+stb_to_str(elf64_word value)
 {
-    switch (ELF_SYM_BIND(st_info))
+    switch (ELF_SYM_BIND(value))
     {
         case stb_local: return stb_local_str;
         case stb_global: return stb_global_str;
@@ -1002,13 +1002,13 @@ stb_to_str(elf64_word st_info)
 /**
  * Convert stt -> const char *
  *
- * @param st_info stt to convert
+ * @param value stt to convert
  * @return const char * version of stt
  */
 const char *
-stt_to_str(elf64_word st_info)
+stt_to_str(elf64_word value)
 {
-    switch (ELF_SYM_TYPE(st_info))
+    switch (ELF_SYM_TYPE(value))
     {
         case stt_notype: return stt_notype_str;
         case stt_object: return stt_object_str;
@@ -1327,13 +1327,13 @@ elf_print_sym(struct elf_file_t *ef,
 /**
  * Convert r_info (type) -> const char *
  *
- * @param r_info r_info (type) to convert
+ * @param value r_info (type) to convert
  * @return const char * version of r_info (type)
  */
 const char *
-rel_type_to_str(elf64_xword r_info)
+rel_type_to_str(elf64_xword value)
 {
-    switch (ELF_REL_TYPE(r_info))
+    switch (ELF_REL_TYPE(value))
     {
         case R_X86_64_64: return R_X86_64_64_STR;
         case R_X86_64_GLOB_DAT: return R_X86_64_GLOB_DAT_STR;
@@ -1669,13 +1669,13 @@ elf_print_relocations(struct elf_file_t *ef)
 /**
  * Convert p_type (type) -> const char *
  *
- * @param p_type p_type (type) to convert
+ * @param value p_type (type) to convert
  * @return const char * version of p_type (type)
  */
 const char *
-p_type_to_str(elf64_word p_type)
+p_type_to_str(elf64_word value)
 {
-    switch (p_type)
+    switch (value)
     {
         case pt_null: return pt_null_str;
         case pt_load: return pt_load_str;


### PR DESCRIPTION
The #define -> const char * conversion functions were causing
problems with compilations once we moved to #define to support
GCC. The following patch fixes an issue with the first attempt
to fix the compilation problems, as clang does not like the
keyword "class" being used. Instead, all of the functions have
been changed to use "value" which is consistent.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/10

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>