### PR TITLE
Fix issue with GCC and c++11 features

### DIFF
--- a/elf_loader/test/Makefile
+++ b/elf_loader/test/Makefile
@@ -30,7 +30,7 @@ RM=rm -rf
 MD=mkdir -p
 
 CCFLAGS=
-CXXFLAGS=-std=c++11
+CXXFLAGS=-std=c++0x
 LDFLAGS=
 
 DEFINES=

--- a/elf_loader/test/test.h
+++ b/elf_loader/test/test.h
@@ -34,9 +34,9 @@ public:
 
 protected:
 
-    virtual bool init(void) override;
-    virtual bool fini(void) override;
-    virtual bool list(void) override;
+    virtual bool init(void);
+    virtual bool fini(void);
+    virtual bool list(void);
 
 private:
 


### PR DESCRIPTION
GCC 4.6 (used by Travis CI) does not recognize c++11. Instead
it uses c++0x, which does not support the "override" keyword.
As a result, the following patches remove c++11 to support
Travis CI, as well as the override command.

Note: These changes are only needed for the native compiler.
Cross-compiled code will use GCC 5.2 and above which has
support for c++14.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/17

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>