### PR TITLE
Fix issue with Windows support

### DIFF
--- a/common/abi_conversion.asm
+++ b/common/abi_conversion.asm
@@ -1,0 +1,41 @@
+global exec_ms64tosv64
+
+section .text
+exec_ms64tosv64:
+
+    ; Microsoft ABI
+    ;   - RCX: First argument (entry point)
+    ;   - RDX: Second argument (argument to be given to the entry point)
+    ;   - RAX: Return register
+
+    ; System V ABI
+    ;   - RDI: First argument (argument to be given to the entry point)
+    ;   - RAX: Return register
+
+    ; Save off the nonvolatile registers as defined by the following:
+    ; https://msdn.microsoft.com/en-us/library/6t169e9c.aspx
+    push rbx
+    push rbp
+    push rdi
+    push rsi
+    push rsp
+    push r12
+    push r13
+    push r14
+    push r15
+
+    mov     rdi, rdx
+    call    rcx
+
+    ; Restore the nonvolatile registers
+    pop r15
+    pop r14
+    pop r13
+    pop r12
+    pop rsp
+    pop rsi
+    pop rdi
+    pop rbp
+    pop rbx
+
+    ret

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -66,14 +66,17 @@ endif
 # Get a list of C and CPP sources
 CC_SOURCES=$(filter %.c,$(SOURCES))
 CXX_SOURCES=$(filter %.cpp,$(SOURCES))
+ASM_SOURCES=$(filter %.asm,$(SOURCES))
 
 # Create a list of object files to compile for C and CPP
-CC_OBJECTS=$(patsubst %.c,$(OBJDIR)/%.o,$(CC_SOURCES))
-CXX_OBJECTS=$(patsubst %.cpp,$(OBJDIR)/%.o,$(CXX_SOURCES))
+CC_OBJECTS=$(patsubst %.c,%.o,$(CC_SOURCES))
+CXX_OBJECTS=$(patsubst %.cpp,%.o,$(CXX_SOURCES))
+ASM_OBJECTS=$(patsubst %.asm,%.o,$(ASM_SOURCES))
 
 # Concat the object file list (we need both forms)
 OBJECTS+=$(CC_OBJECTS)
 OBJECTS+=$(CXX_OBJECTS)
+OBJECTS+=$(ASM_OBJECTS)
 
 # Create a list of include files for C and CPP
 CC_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
@@ -119,7 +122,10 @@ $(OBJDIR)/%.o: %.cpp $(OBJDIR)/%.d
 	$(CXX) $< -o $@ -c $(CXXFLAGS) $(DFLAGS) $(DEPFLAGS) $(CXX_FLAGS_INCLUDE_PATHS) $(INCLUDES)
 	$(POSTCOMPILE)
 
-$(TARGET): $(OBJECTS)
+$(OBJDIR)/%.o: %.asm
+	$(ASM) $< -o $@ $(ASMFLAGS)
+
+$(TARGET): $(addprefix $(OBJDIR)/, $(OBJECTS))
 	$(LD) -o $@ $^ $(LDFLAGS) $(LD_FLAGS_LIB_PATHS) $(LD_FLAGS_LIBS)
 
 clean: custom_clean

--- a/elf_loader/dummy1/Makefile
+++ b/elf_loader/dummy1/Makefile
@@ -25,16 +25,19 @@
 
 CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
 CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_ASM=~/opt/cross/bin/nasm
 CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
 
 CC=$(CROSS_CC)
 CXX=$(CROSS_CXX)
+ASM=$(CROSS_ASM)
 LD=$(CROSS_LD)
 RM=rm -rf
 MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=
+ASMFLAGS=-f elf64
 LDFLAGS=
 
 DEFINES=

--- a/elf_loader/dummy2/Makefile
+++ b/elf_loader/dummy2/Makefile
@@ -25,16 +25,19 @@
 
 CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
 CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_ASM=~/opt/cross/bin/nasm
 CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
 
 CC=$(CROSS_CC)
 CXX=$(CROSS_CXX)
+ASM=$(CROSS_ASM)
 LD=$(CROSS_LD)
 RM=rm -rf
 MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=
+ASMFLAGS=-f elf64
 LDFLAGS=
 
 DEFINES=

--- a/elf_loader/dummy3/Makefile
+++ b/elf_loader/dummy3/Makefile
@@ -25,16 +25,19 @@
 
 CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
 CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_ASM=~/opt/cross/bin/nasm
 CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
 
 CC=$(CROSS_CC)
 CXX=$(CROSS_CXX)
+ASM=$(CROSS_ASM)
 LD=$(CROSS_LD)
 RM=rm -rf
 MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=
+ASMFLAGS=-f elf64
 LDFLAGS=
 
 DEFINES=
@@ -50,13 +53,15 @@ TARGET_CROSS_COMPILED=true
 OBJDIR=.build
 OUTDIR=../bin
 
-SOURCES=dummy3.c
+SOURCES=dummy3.c abi_conversion.asm
 
 INCLUDES=
 LIBS=
 
 INCLUDE_PATHS=./ ../include/
 LIB_PATHS=
+
+VPATH=../../common/
 
 ################################################################################
 # Common

--- a/elf_loader/test/Makefile
+++ b/elf_loader/test/Makefile
@@ -50,7 +50,7 @@ SOURCES=test.cpp
 INCLUDES=
 LIBS=elf_loader
 
-INCLUDE_PATHS=../include/ ./ ../../include/
+INCLUDE_PATHS=./ ../include/ ../../include/
 LIB_PATHS=../bin/
 
 ################################################################################

--- a/include/abi_conversion.h
+++ b/include/abi_conversion.h
@@ -1,0 +1,31 @@
+#ifndef ABI_CONVERSION_H
+#define ABI_CONVERSION_H
+
+/**
+ * Entry Point
+ *
+ * This typedef defines what an entry point is. All functions that are to
+ * be called using the ELF loader should conform to this prototype.
+ *
+ * @param arg the argument you wish to pass to the entry point
+ * @return the return value of the entry point
+ */
+typedef void * (*entry_point_t)(void *arg);
+
+/**
+ * Microsoft 64bit ABI to System V 64bit ABI
+ *
+ * With the switch to 64bit, there are really only two different types of
+ * ABIs that can be used. MS x64 and System V 64bit ABI. Since the cross
+ * compiled code is compiled using System V, the code that is compiled using
+ * MS x64 that needs to call into the cross-compiled code needs a means to
+ * swich from one calling convention to another. This function executes an
+ * entry point, while performing this conversion.
+ *
+ * @param entry_point the entry point you wish to execute
+ * @param arg the argument you wish to pass to the entry point
+ * @return the return value of the entry point
+ */
+typedef void * (*exec_ms64tosv64_t)(void *entry_point, void *arg);
+
+#endif

--- a/include/unittest.h
+++ b/include/unittest.h
@@ -22,6 +22,7 @@
 #ifndef UNITTEST_H
 #define UNITTEST_H
 
+#include <stdlib.h>
 #include <iostream>
 
 #define EXPECT_TRUE(condition) \

--- a/tools/scripts/debian-cross-compiler.sh
+++ b/tools/scripts/debian-cross-compiler.sh
@@ -8,6 +8,10 @@ if [ -z "$GCC_PATH" ]; then
     export GCC_PATH="https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
 fi
 
+if [ -z "$NASM_PATH" ]; then
+    export NASM_PATH="http://www.nasm.us/pub/nasm/releasebuilds/2.11.08/nasm-2.11.08.tar.gz"
+fi
+
 if [ -n "${SILENCE+1}" ]; then
   exec 1>/dev/null
   exec 2>/dev/null
@@ -27,9 +31,11 @@ pushd $TMPDIR
 
 wget $BINUTILS_PATH
 wget $GCC_PATH
+wget $NASM_PATH
 
-tar xf binutils-*.tar.bz2
-tar xf gcc-*.tar.bz2
+tar xvf binutils-*.tar.bz2
+tar xvf gcc-*.tar.bz2
+tar xvf nasm-*.tar.gz
 
 mkdir build-binutils
 mkdir build-gcc
@@ -46,6 +52,12 @@ make all-gcc
 make all-target-libgcc
 make install-gcc
 make install-target-libgcc
+popd
+
+pushd $TMPDIR/nasm-*
+./configure --prefix="$PREFIX"
+make
+make install
 popd
 
 popd


### PR DESCRIPTION
Currently, Windows doesn't support the ELF loader. Other than
some missing headers, the biggest issue is Windows use of
MS x64 calling convention that prevents Windows code from
executing a symbol in the cross-compiled code. This patch
allows the Windows code to not only build, but it also provides
support for it to execute System V ABI compiled symbols.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/21

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>