### PR TITLE
Update Travis CI to GCC 5.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,16 @@ before_install:
 - if [ "$GCC_BASE" = "520" ]; then export GCC_PATH="https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2";  fi
 
 install:
+- sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get update
-- travis_wait 30 ./tools/scripts/debian-cross-compiler.sh
+- sudo apt-get install g++-5
+- sudo rm /usr/bin/gcc
+- sudo rm /usr/bin/g++
+- sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc
+- sudo ln -s /usr/bin/g++-5 /usr/bin/g++
+- gcc --version
+- g++ --version
+- travis_wait 40 ./tools/scripts/debian-cross-compiler.sh
 
 script:
 - make

--- a/tools/scripts/debian-cross-compiler.sh
+++ b/tools/scripts/debian-cross-compiler.sh
@@ -42,21 +42,21 @@ mkdir build-gcc
 
 pushd $TMPDIR/build-binutils
 ../binutils-*/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
-make
+make -j2
 make install
 popd
 
 pushd $TMPDIR/build-gcc
 ../gcc-*/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c,c++ --without-headers
-make all-gcc
-make all-target-libgcc
-make install-gcc
-make install-target-libgcc
+make -j2 all-gcc
+make -j2 all-target-libgcc
+make -j2 install-gcc
+make -j2 install-target-libgcc
 popd
 
 pushd $TMPDIR/nasm-*
 ./configure --prefix="$PREFIX"
-make
+make -j2
 make install
 popd
 


### PR DESCRIPTION
Travis CI needs to have the same compiler that we support in
the hypervisor to support unit testing. If it doesn't, the
code in the hypervisor will not compile on Travis CI (since
we use new features in GCC 5.2), and thus cannot be tested.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>