### PR TITLE
New Build System / Debug Ring

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ install:
 
 script:
 - make
-- cd bfelf_loader/bin
+- cd bfelf_loader/bin/native/
 - LD_LIBRARY_PATH=. ./test
-- cd ../..
-- cd bfm/bin
+- cd ../../../
+- cd bfm/bin/native/
 - LD_LIBRARY_PATH=. ./test
-- cd ../..
+- cd ../../../
+- cd bfvmm/src/debug_ring/bin/native/
+- LD_LIBRARY_PATH=. ./test
+- cd ../../../../../

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@
 
 SUBDIRS += bfelf_loader
 SUBDIRS += bfm
+SUBDIRS += bfvmm
 
 ################################################################################
 # Common

--- a/README.md
+++ b/README.md
@@ -2,12 +2,26 @@
 
 ## Description
 
-The Bareflank Hypervisor aims to provide a platform for performing hypervisor research. Some highlights include:
+The Bareflank Hypervisor aims to provide a platform for performing hypervisor
+research. Some highlights include:
 
-- Zero legacy support (e.g. requires 64bit)
+- Reduced legacy support (e.g. requires 64bit, no support for BIOS, etc...)
 - Written in C++
 - Cross Platform
 - Few external dependencies
+
+In addition to simplied archiecture, the Bareflank hypervisor has been
+licensed under the v2.1 LGPL. The entire Bareflank hypervisor is a collection
+of cross-compiled libraries. Users of the Bareflank hypervisor are welcome
+to repalce any or all of the open source libraries with proprietary versions,
+enabling the development of internal hypevisor based research, while
+sharing the core portions of the hypervisor that don't usually change (for
+example, starting and stopping an Intel VT-x based hypervisor is the same
+whether it's KVM, Xen, VMWare, VIrtualBox or Bareflank).
+
+In return we ask that users contribute back to the project to enhance
+and maitain the open source portions of the hypervisor, such that all users
+can benefit.
 
 ## Compilation Instructions
 
@@ -24,17 +38,6 @@ you should be able to run:
 ```
 make
 make clean
-```
-
-If you placed the cross-compiler into a different directory, simply do the
-following (replace the path with yours);
-
-```
-export CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
-export CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
-export CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
-make -e
-make -e clean
 ```
 
 ## Contributing

--- a/bfelf_loader/dummy1/Makefile
+++ b/bfelf_loader/dummy1/Makefile
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Cross Flags
 ################################################################################
 
 CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
@@ -28,19 +28,22 @@ CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
 CROSS_ASM=~/opt/cross/bin/nasm
 CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
 
-CC=$(CROSS_CC)
-CXX=$(CROSS_CXX)
-ASM=$(CROSS_ASM)
-LD=$(CROSS_LD)
+CROSS_CCFLAGS=
+CROSS_CXXFLAGS=-std=c++14
+CROSS_ASMFLAGS=-f elf64
+CROSS_LDFLAGS=
+
+CROSS_DEFINES=
+
+CROSS_OBJDIR=.build/cross
+CROSS_OUTDIR=../bin/cross
+
+################################################################################
+# Common
+################################################################################
+
 RM=rm -rf
 MD=mkdir -p
-
-CCFLAGS=
-CXXFLAGS=
-ASMFLAGS=-f elf64
-LDFLAGS=
-
-DEFINES=
 
 ################################################################################
 # Sources
@@ -48,18 +51,31 @@ DEFINES=
 
 TARGET_NAME=dummy1
 TARGET_TYPE=lib
-TARGET_CROSS_COMPILED=true
+TARGET_COMPILER=cross
 
-OBJDIR=.build
-OUTDIR=../bin
+SOURCES=dummy1.cpp
+HEADERS=
 
-SOURCES=dummy1.c
-
-INCLUDES=
 LIBS=
 
-INCLUDE_PATHS=./ ../include/
 LIB_PATHS=
+INCLUDE_PATHS=./ ../include/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfelf_loader/dummy2/Makefile
+++ b/bfelf_loader/dummy2/Makefile
@@ -20,7 +20,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Cross Flags
 ################################################################################
 
 CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
@@ -28,19 +28,22 @@ CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
 CROSS_ASM=~/opt/cross/bin/nasm
 CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
 
-CC=$(CROSS_CC)
-CXX=$(CROSS_CXX)
-ASM=$(CROSS_ASM)
-LD=$(CROSS_LD)
+CROSS_CCFLAGS=
+CROSS_CXXFLAGS=-std=c++14
+CROSS_ASMFLAGS=-f elf64
+CROSS_LDFLAGS=
+
+CROSS_DEFINES=
+
+CROSS_OBJDIR=.build/cross
+CROSS_OUTDIR=../bin/cross
+
+################################################################################
+# Common
+################################################################################
+
 RM=rm -rf
 MD=mkdir -p
-
-CCFLAGS=
-CXXFLAGS=
-ASMFLAGS=-f elf64
-LDFLAGS=
-
-DEFINES=
 
 ################################################################################
 # Sources
@@ -48,18 +51,31 @@ DEFINES=
 
 TARGET_NAME=dummy2
 TARGET_TYPE=lib
-TARGET_CROSS_COMPILED=true
-
-OBJDIR=.build
-OUTDIR=../bin
+TARGET_COMPILER=cross
 
 SOURCES=dummy2.cpp
+HEADERS=
 
-INCLUDES=
 LIBS=
 
-INCLUDE_PATHS=./ ../include/
 LIB_PATHS=
+INCLUDE_PATHS=./ ../include/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfelf_loader/src/Makefile
+++ b/bfelf_loader/src/Makefile
@@ -20,20 +20,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Native Flags
 ################################################################################
 
 CC=gcc
 CXX=g++
-LD=gcc
-RM=rm -rf
-MD=mkdir -p
+ASM=nasm
+LD=g++
 
 CCFLAGS=
-CXXFLAGS=
+CXXFLAGS=-std=c++14
+ASMFLAGS=
 LDFLAGS=
 
 DEFINES=ENABLE_BFELF_DEBUGGING
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
 
 ################################################################################
 # Sources
@@ -41,17 +51,31 @@ DEFINES=ENABLE_BFELF_DEBUGGING
 
 TARGET_NAME=bfelf_loader
 TARGET_TYPE=lib
+TARGET_COMPILER=native
 
-OBJDIR=.build
-OUTDIR=../bin
+SOURCES=bfelf_loader.cpp
+HEADERS=
 
-SOURCES=bfelf_loader.c
-
-INCLUDES=
 LIBS=
 
-INCLUDE_PATHS=./ ../include/
 LIB_PATHS=
+INCLUDE_PATHS=./ ../include/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfelf_loader/src/bfelf_loader.c
+++ b/bfelf_loader/src/bfelf_loader.c
@@ -780,8 +780,8 @@ sh_flags_is_executable(struct bfelf_shdr *shdr)
 
 bfelf64_sword
 bfelf_section_header(struct bfelf_file_t *ef,
-                   bfelf64_word index,
-                   struct bfelf_shdr **shdr)
+                     bfelf64_word index,
+                     struct bfelf_shdr **shdr)
 {
     if (!ef || !ef->ehdr || !ef->shdrtab || !shdr)
         return BFELF_ERROR_INVALID_ARG;
@@ -824,7 +824,7 @@ bfelf_print_section_header_table(struct bfelf_file_t *ef)
 
 bfelf64_sword
 bfelf_print_section_header(struct bfelf_file_t *ef,
-                         struct bfelf_shdr *shdr)
+                           struct bfelf_shdr *shdr)
 {
     bfelf64_sword ret = 0;
     struct e_string section_name = {0};
@@ -867,9 +867,9 @@ bfelf_print_section_header(struct bfelf_file_t *ef,
 
 bfelf64_sword
 bfelf_string_table_entry(struct bfelf_file_t *ef,
-                       struct bfelf_shdr *strtab,
-                       bfelf64_word offset,
-                       struct e_string *str)
+                         struct bfelf_shdr *strtab,
+                         bfelf64_word offset,
+                         struct e_string *str)
 {
     char *buf = 0;
     bfelf64_word i = 0;
@@ -905,8 +905,8 @@ bfelf_string_table_entry(struct bfelf_file_t *ef,
 
 bfelf64_sword
 bfelf_section_name_string(struct bfelf_file_t *ef,
-                        struct bfelf_shdr *shdr,
-                        struct e_string *str)
+                          struct bfelf_shdr *shdr,
+                          struct e_string *str)
 {
     if (!ef || !shdr || !str)
         return BFELF_ERROR_INVALID_ARG;
@@ -975,8 +975,8 @@ stt_to_str(bfelf64_word value)
 
 bfelf64_sword
 bfelf_symbol_by_index(struct bfelf_file_t *ef,
-                    bfelf64_word index,
-                    struct bfelf_sym **sym)
+                      bfelf64_word index,
+                      struct bfelf_sym **sym)
 {
     if (!ef || !sym)
         return BFELF_ERROR_INVALID_ARG;
@@ -994,8 +994,8 @@ bfelf_symbol_by_index(struct bfelf_file_t *ef,
 
 bfelf64_sword
 bfelf_symbol_by_name(struct bfelf_file_t *ef,
-                   struct e_string *name,
-                   struct bfelf_sym **sym)
+                     struct e_string *name,
+                     struct bfelf_sym **sym)
 {
     bfelf64_sword i = 0;
     bfelf64_sword ret = 0;
@@ -1038,9 +1038,9 @@ bfelf_symbol_by_name(struct bfelf_file_t *ef,
 
 bfelf64_sword
 bfelf_symbol_by_name_global(struct bfelf_file_t *efl,
-                          struct e_string *name,
-                          struct bfelf_file_t **efr,
-                          struct bfelf_sym **sym)
+                            struct e_string *name,
+                            struct bfelf_file_t **efr,
+                            struct bfelf_sym **sym)
 {
     bfelf64_sword i = 0;
     bfelf64_sword ret = 0;
@@ -1098,8 +1098,8 @@ found:
 
 bfelf64_sword
 bfelf_resolve_symbol(struct bfelf_file_t *ef,
-                   struct e_string *name,
-                   void **addr)
+                     struct e_string *name,
+                     void **addr)
 {
     bfelf64_sword ret = 0;
     struct bfelf_sym *sym = 0;
@@ -1152,7 +1152,7 @@ bfelf_print_sym_table(struct bfelf_file_t *ef)
 
 bfelf64_sword
 bfelf_print_sym(struct bfelf_file_t *ef,
-              struct bfelf_sym *sym)
+                struct bfelf_sym *sym)
 {
     bfelf64_sword ret = 0;
     struct e_string str = {0};
@@ -1213,7 +1213,7 @@ rel_type_to_str(bfelf64_xword value)
 
 bfelf64_sword
 bfelf_relocate_symbol(struct bfelf_file_t *ef,
-                    struct bfelf_rel *rel)
+                      struct bfelf_rel *rel)
 {
     bfelf64_addr *ptr = 0;
     bfelf64_sword ret = 0;
@@ -1265,7 +1265,7 @@ bfelf_relocate_symbol(struct bfelf_file_t *ef,
 
 bfelf64_sword
 bfelf_relocate_symbol_addend(struct bfelf_file_t *ef,
-                           struct bfelf_rela *rela)
+                             struct bfelf_rela *rela)
 {
     bfelf64_addr *ptr = 0;
     bfelf64_sword ret = 0;
@@ -1519,8 +1519,8 @@ p_flags_is_readable(struct bfelf_phdr *phdr)
 
 bfelf64_sword
 bfelf_program_header(struct bfelf_file_t *ef,
-                   bfelf64_word index,
-                   struct bfelf_phdr **phdr)
+                     bfelf64_word index,
+                     struct bfelf_phdr **phdr)
 {
     if (!ef || !ef->ehdr || !ef->phdrtab || !phdr)
         return BFELF_ERROR_INVALID_ARG;
@@ -1594,7 +1594,7 @@ bfelf_load_segments(struct bfelf_file_t *ef)
 
 bfelf64_sword
 bfelf_load_segment(struct bfelf_file_t *ef,
-                 struct bfelf_phdr *phdr)
+                   struct bfelf_phdr *phdr)
 {
     char *exec = 0;
     char *file = 0;
@@ -1648,7 +1648,7 @@ bfelf_print_program_header_table(struct bfelf_file_t *ef)
 
 bfelf64_sword
 bfelf_print_program_header(struct bfelf_file_t *ef,
-                         struct bfelf_phdr *phdr)
+                           struct bfelf_phdr *phdr)
 {
     if (!ef || !phdr)
         return BFELF_ERROR_INVALID_ARG;

--- a/bfelf_loader/test/Makefile
+++ b/bfelf_loader/test/Makefile
@@ -20,20 +20,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Native Flags
 ################################################################################
 
 CC=gcc
 CXX=g++
+ASM=nasm
 LD=g++
-RM=rm -rf
-MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=-std=c++14
+ASMFLAGS=
 LDFLAGS=
 
 DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
 
 ################################################################################
 # Sources
@@ -41,17 +51,31 @@ DEFINES=
 
 TARGET_NAME=test
 TARGET_TYPE=bin
-
-OBJDIR=.build
-OUTDIR=../bin
+TARGET_COMPILER=native
 
 SOURCES=test.cpp
+HEADERS=
 
-INCLUDES=
 LIBS=bfelf_loader
 
+LIB_PATHS=../bin/native/
 INCLUDE_PATHS=./ ../include/ ../../include/
-LIB_PATHS=../bin/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfelf_loader/test/test.cpp
+++ b/bfelf_loader/test/test.cpp
@@ -28,9 +28,9 @@
 
 #include <sys/mman.h>
 
-auto c_dummy1_filename = "libdummy1.so";
-auto c_dummy2_filename = "libdummy2.so";
-auto c_dummy3_filename = "libdummy3.so";
+auto c_dummy1_filename = "../cross/libdummy1.so";
+auto c_dummy2_filename = "../cross/libdummy2.so";
+auto c_dummy3_filename = "../cross/libdummy3.so";
 
 struct bfelf_test
 {

--- a/bfm/bin/native/test.modules
+++ b/bfm/bin/native/test.modules
@@ -1,0 +1,3 @@
+../../../bfelf_loader/bin/cross/libdummy1.so
+../../../bfelf_loader/bin/cross/libdummy2.so
+../../../bfelf_loader/bin/cross/libdummy3.so

--- a/bfm/bin/test.modules
+++ b/bfm/bin/test.modules
@@ -1,3 +1,0 @@
-../../bfelf_loader/bin/libdummy1.so
-../../bfelf_loader/bin/libdummy2.so
-../../bfelf_loader/bin/libdummy3.so

--- a/bfm/main/Makefile
+++ b/bfm/main/Makefile
@@ -20,20 +20,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Native Flags
 ################################################################################
 
 CC=gcc
 CXX=g++
+ASM=nasm
 LD=g++
-RM=rm -rf
-MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=-std=c++14
+ASMFLAGS=
 LDFLAGS=
 
 DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
 
 ################################################################################
 # Sources
@@ -41,17 +51,31 @@ DEFINES=
 
 TARGET_NAME=bfm
 TARGET_TYPE=bin
-
-OBJDIR=.build
-OUTDIR=../bin
+TARGET_COMPILER=native
 
 SOURCES=main.cpp
+HEADERS=
 
-INCLUDES=
 LIBS=bfm
 
+LIB_PATHS=../bin/native
 INCLUDE_PATHS=./ ../include/ ../../include/
-LIB_PATHS=../bin/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfm/src/Makefile
+++ b/bfm/src/Makefile
@@ -20,20 +20,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Native Flags
 ################################################################################
 
 CC=gcc
 CXX=g++
+ASM=nasm
 LD=g++
-RM=rm -rf
-MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=-std=c++14
+ASMFLAGS=
 LDFLAGS=
 
 DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
 
 ################################################################################
 # Sources
@@ -41,28 +51,38 @@ DEFINES=
 
 TARGET_NAME=bfm
 TARGET_TYPE=lib
-
-OBJDIR=.build
-OUTDIR=../bin
+TARGET_COMPILER=native
 
 SOURCES+=command_line_parser.cpp
 SOURCES+=debug.cpp
 SOURCES+=file.cpp
 SOURCES+=ioctl_driver.cpp
 SOURCES+=split.cpp
+HEADERS=
+
+LIBS=
+
+LIB_PATHS=
+INCLUDE_PATHS=./ ../include/ ../../include/
+
+VPATH=arch/linux
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
 
 LINUX_SOURCES+=ioctl.cpp
 LINUX_SOURCES+=ioctl_private.cpp
+LINUX_INCLUDE_PATHS+=./arch/linux/
 
-INCLUDES=
-LIBS=
-
-INCLUDE_PATHS=./ ../include/ ../../include/
-LIB_PATHS=
-
-LINUX_INCLUDE_PATHS=./arch/linux/
-
-VPATH=arch/linux
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfm/test/Makefile
+++ b/bfm/test/Makefile
@@ -20,20 +20,30 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# FLAGS
+# Native Flags
 ################################################################################
 
 CC=gcc
 CXX=g++
+ASM=nasm
 LD=g++
-RM=rm -rf
-MD=mkdir -p
 
 CCFLAGS=
 CXXFLAGS=-std=c++14
+ASMFLAGS=
 LDFLAGS=
 
 DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
 
 ################################################################################
 # Sources
@@ -41,17 +51,31 @@ DEFINES=
 
 TARGET_NAME=test
 TARGET_TYPE=bin
-
-OBJDIR=.build
-OUTDIR=../bin
+TARGET_COMPILER=native
 
 SOURCES=test.cpp
+HEADERS=
 
-INCLUDES=
 LIBS=bfm
 
+LIB_PATHS=../bin/native
 INCLUDE_PATHS=./ ../include/ ../../include/ ../src/arch/include/
-LIB_PATHS=../bin/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
 
 ################################################################################
 # Common

--- a/bfvmm/Makefile
+++ b/bfvmm/Makefile
@@ -20,67 +20,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Cross Flags
+# Subdirs
 ################################################################################
 
-CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
-CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
-CROSS_ASM=~/opt/cross/bin/nasm
-CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
-
-CROSS_CCFLAGS=
-CROSS_CXXFLAGS=-std=c++14
-CROSS_ASMFLAGS=-f elf64
-CROSS_LDFLAGS=
-
-CROSS_DEFINES=
-
-CROSS_OBJDIR=.build/cross
-CROSS_OUTDIR=../bin/cross
+SUBDIRS += src
 
 ################################################################################
 # Common
 ################################################################################
 
-RM=rm -rf
-MD=mkdir -p
-
-################################################################################
-# Sources
-################################################################################
-
-TARGET_NAME=dummy3
-TARGET_TYPE=lib
-TARGET_COMPILER=cross
-
-SOURCES=dummy3.cpp abi_conversion.asm
-HEADERS=
-
-LIBS=
-
-LIB_PATHS=
-INCLUDE_PATHS=./ ../include/
-
-VPATH=../../common/
-
-################################################################################
-# Environment Specific
-################################################################################
-
-VMM_SOURCES=
-VMM_INCLUDE_PATHS=
-
-WINDOWS_SOURCES=
-WINDOWS_INCLUDE_PATHS=
-
-LINUX_SOURCES=
-LINUX_INCLUDE_PATHS=
-
-OSX_SOURCES=
-OSX_INCLUDE_PATHS=
-
-################################################################################
-# Common
-################################################################################
-
-include ../../common/common_target.mk
+include ../common/common_subdir.mk

--- a/bfvmm/include/debug_ring/debug_ring.h
+++ b/bfvmm/include/debug_ring/debug_ring.h
@@ -1,0 +1,86 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef DEBUG_RING_H
+#define DEBUG_RING_H
+
+#include <debug_ring_interface.h>
+#include <debug_ring/debug_ring_base.h>
+
+/// Debug Ring
+///
+/// The debug ring is a simple debug facility that allows the vmm to write
+/// string data into a ring buffer while a reader that has shared access to
+/// the same buffer can read from the debug ring to extract the strings
+/// that are written to the buffer.
+///
+class debug_ring : public debug_ring_base
+{
+public:
+
+    /// Debug Ring Constructor
+    ///
+    /// Creates a debug ring based on the debug ring resources provided.
+    ///
+    /// @param drr debug resources created by the driver entry
+    ///
+    debug_ring(struct debug_ring_resources *drr);
+
+    /// Debug Ring Destructor
+    ///
+    ~debug_ring();
+
+    /// Clear Debug Ring
+    ///
+    /// Clears the debug ring, and resets all of the internal variables
+    /// back to 0.
+    ///
+    void clear() override;
+
+    /// Is Valid
+    ///
+    /// Returns false if the debug ring is not valid. An invalid debug
+    /// ring usually means that you either provided the debug ring with
+    /// a NULL debug ring resource, or the length in the debug ring was
+    /// not set.
+    ///
+    bool is_valid() override;
+
+    /// Write to Debug Ring
+    ///
+    /// Writes a string to the debug ring. If the string is larger than
+    /// the debug ring's internal buffer, the write will fail. If the debug
+    /// ring is full, the write will keep removing existing strings in the
+    /// buffer until enough space is made, to add the string.
+    ///
+    /// @param str the string to write to the debug ring
+    /// @param len the length of the string in bytes
+    /// @return success on success, error code on failure.
+    ///
+    debug_ring_error::type write(const char *str, int64_t len) override;
+
+private:
+
+    bool m_is_valid;
+    struct debug_ring_resources *m_drr;
+};
+
+#endif

--- a/bfvmm/include/debug_ring/debug_ring_base.h
+++ b/bfvmm/include/debug_ring/debug_ring_base.h
@@ -19,66 +19,36 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <dummy1.h>
-#include <dummy2.h>
-#include <dummy3.h>
+#ifndef DEBUG_RING_BASE_H
+#define DEBUG_RING_BASE_H
 
-int g_my_glob1;
-int g_my_glob2 = 0;
-int g_my_glob3 = 3;
+#include <stdint.h>
 
-static int l_my_glob1;
-static int l_my_glob2 = 0;
-static int l_my_glob3 = 3;
-
-int x[2], *y = x + 1;
-
-int
-dummy3_test1(int num)
+namespace debug_ring_error
 {
-    g_my_glob1 = 1;
-
-    dummy2 _dummy2;
-
-    x[0] = 1;
-    x[1] = 2;
-
-    return g_my_glob1 +
-           g_my_glob2 +
-           g_my_glob3 +
-           *y +
-           dummy1_add1(num) +
-           dummy2::dummy2_add2(num) +
-           dummy1_mul1(num) +
-           _dummy2.dummy2_mul2(num);
+    enum type
+    {
+        success = 0,
+        failure = 1,
+        invalid = 2
+    };
 }
 
-int
-dummy3_test2(int num)
+class debug_ring_base
 {
-    l_my_glob1 = 1;
+public:
 
-    return l_my_glob1 +
-           l_my_glob2 +
-           l_my_glob3 +
-           dummy3_test1(num);
-}
+    debug_ring_base() {}
+    virtual ~debug_ring_base() {}
 
-int start_vmm(int num)
-{
-    if (num != 0)
-        return -1;
+    virtual void clear()
+    {}
 
-    if (dummy3_test2(5) != 0x26)
-        return -2;
+    virtual bool is_valid()
+    { return false; }
 
-    return 0;
-}
+    virtual debug_ring_error::type write(const char *str, int64_t len)
+    { return debug_ring_error::failure; }
+};
 
-int stop_vmm(int num)
-{
-    if (num != 0)
-        return -1;
-
-    return 0;
-}
+#endif

--- a/bfvmm/include/std/assert.h
+++ b/bfvmm/include/std/assert.h
@@ -19,66 +19,11 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <dummy1.h>
-#include <dummy2.h>
-#include <dummy3.h>
+#ifndef ASSERT_H
+#define ASSERT_H
 
-int g_my_glob1;
-int g_my_glob2 = 0;
-int g_my_glob3 = 3;
+// TODO: Implement an assert that we can use in the vmm. Likely this
+//       will output some nasty text via serial, and then hlt.
+#define assert(a)
 
-static int l_my_glob1;
-static int l_my_glob2 = 0;
-static int l_my_glob3 = 3;
-
-int x[2], *y = x + 1;
-
-int
-dummy3_test1(int num)
-{
-    g_my_glob1 = 1;
-
-    dummy2 _dummy2;
-
-    x[0] = 1;
-    x[1] = 2;
-
-    return g_my_glob1 +
-           g_my_glob2 +
-           g_my_glob3 +
-           *y +
-           dummy1_add1(num) +
-           dummy2::dummy2_add2(num) +
-           dummy1_mul1(num) +
-           _dummy2.dummy2_mul2(num);
-}
-
-int
-dummy3_test2(int num)
-{
-    l_my_glob1 = 1;
-
-    return l_my_glob1 +
-           l_my_glob2 +
-           l_my_glob3 +
-           dummy3_test1(num);
-}
-
-int start_vmm(int num)
-{
-    if (num != 0)
-        return -1;
-
-    if (dummy3_test2(5) != 0x26)
-        return -2;
-
-    return 0;
-}
-
-int stop_vmm(int num)
-{
-    if (num != 0)
-        return -1;
-
-    return 0;
-}
+#endif

--- a/bfvmm/include/std/stdint.h
+++ b/bfvmm/include/std/stdint.h
@@ -19,66 +19,19 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <dummy1.h>
-#include <dummy2.h>
-#include <dummy3.h>
+#ifndef STDINT_H
+#define STDINT_H
 
-int g_my_glob1;
-int g_my_glob2 = 0;
-int g_my_glob3 = 3;
+typedef char int8_t;
+typedef unsigned char uint8_t;
 
-static int l_my_glob1;
-static int l_my_glob2 = 0;
-static int l_my_glob3 = 3;
+typedef short int int16_t;
+typedef unsigned short int uint16_t;
 
-int x[2], *y = x + 1;
+typedef long int int32_t;
+typedef unsigned long int uint32_t;
 
-int
-dummy3_test1(int num)
-{
-    g_my_glob1 = 1;
+typedef long long int int64_t;
+typedef unsigned long long int uint64_t;
 
-    dummy2 _dummy2;
-
-    x[0] = 1;
-    x[1] = 2;
-
-    return g_my_glob1 +
-           g_my_glob2 +
-           g_my_glob3 +
-           *y +
-           dummy1_add1(num) +
-           dummy2::dummy2_add2(num) +
-           dummy1_mul1(num) +
-           _dummy2.dummy2_mul2(num);
-}
-
-int
-dummy3_test2(int num)
-{
-    l_my_glob1 = 1;
-
-    return l_my_glob1 +
-           l_my_glob2 +
-           l_my_glob3 +
-           dummy3_test1(num);
-}
-
-int start_vmm(int num)
-{
-    if (num != 0)
-        return -1;
-
-    if (dummy3_test2(5) != 0x26)
-        return -2;
-
-    return 0;
-}
-
-int stop_vmm(int num)
-{
-    if (num != 0)
-        return -1;
-
-    return 0;
-}
+#endif

--- a/bfvmm/src/Makefile
+++ b/bfvmm/src/Makefile
@@ -20,67 +20,13 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Cross Flags
+# Subdirs
 ################################################################################
 
-CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
-CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
-CROSS_ASM=~/opt/cross/bin/nasm
-CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
-
-CROSS_CCFLAGS=
-CROSS_CXXFLAGS=-std=c++14
-CROSS_ASMFLAGS=-f elf64
-CROSS_LDFLAGS=
-
-CROSS_DEFINES=
-
-CROSS_OBJDIR=.build/cross
-CROSS_OUTDIR=../bin/cross
+SUBDIRS += debug_ring
 
 ################################################################################
 # Common
 ################################################################################
 
-RM=rm -rf
-MD=mkdir -p
-
-################################################################################
-# Sources
-################################################################################
-
-TARGET_NAME=dummy3
-TARGET_TYPE=lib
-TARGET_COMPILER=cross
-
-SOURCES=dummy3.cpp abi_conversion.asm
-HEADERS=
-
-LIBS=
-
-LIB_PATHS=
-INCLUDE_PATHS=./ ../include/
-
-VPATH=../../common/
-
-################################################################################
-# Environment Specific
-################################################################################
-
-VMM_SOURCES=
-VMM_INCLUDE_PATHS=
-
-WINDOWS_SOURCES=
-WINDOWS_INCLUDE_PATHS=
-
-LINUX_SOURCES=
-LINUX_INCLUDE_PATHS=
-
-OSX_SOURCES=
-OSX_INCLUDE_PATHS=
-
-################################################################################
-# Common
-################################################################################
-
-include ../../common/common_target.mk
+include ../../common/common_subdir.mk

--- a/bfvmm/src/debug_ring/Makefile
+++ b/bfvmm/src/debug_ring/Makefile
@@ -20,67 +20,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Cross Flags
+# Subdirs
 ################################################################################
 
-CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
-CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
-CROSS_ASM=~/opt/cross/bin/nasm
-CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
-
-CROSS_CCFLAGS=
-CROSS_CXXFLAGS=-std=c++14
-CROSS_ASMFLAGS=-f elf64
-CROSS_LDFLAGS=
-
-CROSS_DEFINES=
-
-CROSS_OBJDIR=.build/cross
-CROSS_OUTDIR=../bin/cross
+SUBDIRS += src
+SUBDIRS += test
 
 ################################################################################
 # Common
 ################################################################################
 
-RM=rm -rf
-MD=mkdir -p
-
-################################################################################
-# Sources
-################################################################################
-
-TARGET_NAME=dummy3
-TARGET_TYPE=lib
-TARGET_COMPILER=cross
-
-SOURCES=dummy3.cpp abi_conversion.asm
-HEADERS=
-
-LIBS=
-
-LIB_PATHS=
-INCLUDE_PATHS=./ ../include/
-
-VPATH=../../common/
-
-################################################################################
-# Environment Specific
-################################################################################
-
-VMM_SOURCES=
-VMM_INCLUDE_PATHS=
-
-WINDOWS_SOURCES=
-WINDOWS_INCLUDE_PATHS=
-
-LINUX_SOURCES=
-LINUX_INCLUDE_PATHS=
-
-OSX_SOURCES=
-OSX_INCLUDE_PATHS=
-
-################################################################################
-# Common
-################################################################################
-
-include ../../common/common_target.mk
+include ../../../common/common_subdir.mk

--- a/bfvmm/src/debug_ring/src/Makefile
+++ b/bfvmm/src/debug_ring/src/Makefile
@@ -20,6 +20,25 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
+# Native Flags
+################################################################################
+
+CC=gcc
+CXX=g++
+ASM=nasm
+LD=g++
+
+CCFLAGS=
+CXXFLAGS=-std=c++14
+ASMFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
 # Cross Flags
 ################################################################################
 
@@ -36,7 +55,7 @@ CROSS_LDFLAGS=
 CROSS_DEFINES=
 
 CROSS_OBJDIR=.build/cross
-CROSS_OUTDIR=../bin/cross
+CROSS_OUTDIR=../../../bin/cross
 
 ################################################################################
 # Common
@@ -49,26 +68,24 @@ MD=mkdir -p
 # Sources
 ################################################################################
 
-TARGET_NAME=dummy3
+TARGET_NAME=debug_ring
 TARGET_TYPE=lib
-TARGET_COMPILER=cross
+TARGET_COMPILER=both
 
-SOURCES=dummy3.cpp abi_conversion.asm
+SOURCES=debug_ring.cpp
 HEADERS=
 
 LIBS=
 
 LIB_PATHS=
-INCLUDE_PATHS=./ ../include/
-
-VPATH=../../common/
+INCLUDE_PATHS=./ ../../../include/ ../../../../include/
 
 ################################################################################
 # Environment Specific
 ################################################################################
 
 VMM_SOURCES=
-VMM_INCLUDE_PATHS=
+VMM_INCLUDE_PATHS=../../../include/std/
 
 WINDOWS_SOURCES=
 WINDOWS_INCLUDE_PATHS=
@@ -83,4 +100,4 @@ OSX_INCLUDE_PATHS=
 # Common
 ################################################################################
 
-include ../../common/common_target.mk
+include ../../../../common/common_target.mk

--- a/bfvmm/src/debug_ring/src/debug_ring.cpp
+++ b/bfvmm/src/debug_ring/src/debug_ring.cpp
@@ -1,0 +1,132 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <assert.h>
+#include <debug_ring/debug_ring.h>
+
+debug_ring::debug_ring(struct debug_ring_resources *drr) :
+    m_is_valid(false),
+    m_drr(drr)
+{
+    if (m_drr == 0)
+        return;
+
+    if (m_drr->len <= 0)
+        return;
+
+    m_is_valid = true;
+
+    clear();
+}
+
+debug_ring::~debug_ring()
+{
+}
+
+void debug_ring::clear()
+{
+    if (m_is_valid == false)
+        return;
+
+    m_drr->epos = 0;
+    m_drr->spos = 0;
+
+    for (auto i = 0; i < m_drr->len; i++)
+        m_drr->buf[i] = '\0';
+}
+
+bool debug_ring::is_valid()
+{
+    return m_is_valid;
+}
+
+debug_ring_error::type debug_ring::write(const char *str, int64_t len)
+{
+    // TODO: A more interesting implementation would use an optimized
+    //       memcpy to implement this code. Doing so would increase it's
+    //       performance, but would require some better math, and an
+    //       optimized memcpy that used both rep string instructions and
+    //       SIMD instructions
+
+    if (m_is_valid == false)
+        return debug_ring_error::invalid;
+
+    if (str == 0 || len == 0 || len >= m_drr->len)
+        return debug_ring_error::failure;
+
+    len++;
+    auto epos = m_drr->epos % m_drr->len;
+    auto spos = m_drr->spos % m_drr->len;
+    auto space = m_drr->len - (m_drr->epos - m_drr->spos);
+
+    if (space < len)
+    {
+        auto pos = spos;
+
+        // Make room for the write. Normally, with a circular buffer, you
+        // would just move the start position when a read occurs, but in this
+        // case, the vmm needs to be able to write as it wishes to the buffer.
+        // If we just move the start position based on the amount of space we
+        // need, you would end up with the first string being cropped once
+        // the ring wraps. The following code makes sure that we are making
+        // room by removing complete strings.
+        //
+        // Note: There is still a race condition with this code. If the reader
+        //       reads at the same time we are writing, you could end up with
+        //       a cropped string for the first string, but that's fine, as
+        //       this is just debug text, and if we add locks, we would
+        //       greatly increase the complexity of this code, while
+        //       serializing the code, which is not a good idea.
+        while (space <= m_drr->len)
+        {
+            if (pos == m_drr->len)
+                pos = 0;
+
+            if (spos == m_drr->len)
+                spos = 0;
+
+            spos++;
+            space++;
+            m_drr->spos++;
+
+            if (m_drr->buf[pos] == '\0' &&
+                space >= len)
+            {
+                break;
+            }
+
+            m_drr->buf[pos++] = '\0';
+        }
+    }
+
+    for (auto i = 0; i < len; i++)
+    {
+        if (epos == m_drr->len)
+            epos = 0;
+
+        m_drr->buf[epos] = str[i];
+
+        epos++;
+        m_drr->epos++;
+    }
+
+    return debug_ring_error::success;
+}

--- a/bfvmm/src/debug_ring/test/Makefile
+++ b/bfvmm/src/debug_ring/test/Makefile
@@ -20,23 +20,23 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Cross Flags
+# Native Flags
 ################################################################################
 
-CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
-CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
-CROSS_ASM=~/opt/cross/bin/nasm
-CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+CC=gcc
+CXX=g++
+ASM=nasm
+LD=g++
 
-CROSS_CCFLAGS=
-CROSS_CXXFLAGS=-std=c++14
-CROSS_ASMFLAGS=-f elf64
-CROSS_LDFLAGS=
+CCFLAGS=
+CXXFLAGS=-std=c++14
+ASMFLAGS=
+LDFLAGS=
 
-CROSS_DEFINES=
+DEFINES=
 
-CROSS_OBJDIR=.build/cross
-CROSS_OUTDIR=../bin/cross
+OBJDIR=.build/native
+OUTDIR=../bin/native
 
 ################################################################################
 # Common
@@ -49,19 +49,17 @@ MD=mkdir -p
 # Sources
 ################################################################################
 
-TARGET_NAME=dummy3
-TARGET_TYPE=lib
-TARGET_COMPILER=cross
+TARGET_NAME=test
+TARGET_TYPE=bin
+TARGET_COMPILER=native
 
-SOURCES=dummy3.cpp abi_conversion.asm
+SOURCES=test.cpp
 HEADERS=
 
-LIBS=
+LIBS=debug_ring
 
-LIB_PATHS=
-INCLUDE_PATHS=./ ../include/
-
-VPATH=../../common/
+LIB_PATHS=../bin/native
+INCLUDE_PATHS=./ ../../../include/  ../../../../include/
 
 ################################################################################
 # Environment Specific
@@ -83,4 +81,4 @@ OSX_INCLUDE_PATHS=
 # Common
 ################################################################################
 
-include ../../common/common_target.mk
+include ../../../../common/common_target.mk

--- a/bfvmm/src/debug_ring/test/test.cpp
+++ b/bfvmm/src/debug_ring/test/test.cpp
@@ -1,0 +1,360 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <test.h>
+
+#include <debug_ring/debug_ring.h>
+#include <debug_ring/debug_ring_base.h>
+
+debug_ring_ut::debug_ring_ut()
+{
+}
+
+bool
+debug_ring_ut::init()
+{
+    return true;
+}
+
+bool
+debug_ring_ut::fini()
+{
+    return true;
+}
+
+bool
+debug_ring_ut::list()
+{
+    this->test_create_dr_with_null_drr();
+    this->test_create_dr_with_zero_length();
+    this->test_read_with_invalid_drr();
+    this->test_write_with_invalid_dr();
+    this->test_read_with_null_string();
+    this->test_read_with_zero_length();
+    this->test_write_with_null_string();
+    this->test_write_with_zero_length();
+    this->test_write_string_to_dr_that_is_larger_than_dr();
+    this->test_write_string_to_dr_that_is_much_larger_than_dr();
+    this->test_write_one_small_string_to_dr();
+    this->test_fill_dr();
+    this->test_overcommit_dr();
+    this->test_overcommit_dr_more_than_once();
+    this->test_read_with_empty_dr();
+    this->test_clear_empty_dr();
+    this->test_write_dr_and_clear();
+    this->test_overcommit_dr_and_clear();
+    this->test_overcommit_dr_and_clear_and_write();
+
+    this->acceptance_test_stress();
+
+    return true;
+}
+
+#define BUF_SIZE 10
+#define DRR_SIZE 4096
+
+debug_ring_resources *
+create_drr()
+{
+    int len = DRR_SIZE;
+    debug_ring_resources *drr = (debug_ring_resources *)malloc(len);
+
+    memset(drr, 0, len);
+    drr->len = BUF_SIZE;
+
+    return drr;
+}
+
+void
+delete_drr(debug_ring_resources *drr)
+{
+    if (drr == NULL)
+        return
+
+            free(drr);
+}
+
+void debug_ring_ut::test_create_dr_with_null_drr()
+{
+    debug_ring dr(NULL);
+
+    EXPECT_TRUE(dr.is_valid() == false);
+}
+
+void debug_ring_ut::test_create_dr_with_zero_length()
+{
+    debug_ring_resources *drr = create_drr();
+    drr->len = 0;
+
+    debug_ring dr(drr);
+
+    EXPECT_TRUE(dr.is_valid() == false);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_read_with_invalid_drr()
+{
+    debug_ring dr(NULL);
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(debug_ring_read(NULL, r_buf, sizeof(r_buf)) == DEBUG_RING_READ_ERROR);
+}
+
+void debug_ring_ut::test_write_with_invalid_dr()
+{
+    debug_ring dr(NULL);
+    char w_buf[] = "01234";
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::invalid);
+}
+
+void debug_ring_ut::test_read_with_null_string()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(debug_ring_read(drr, NULL, sizeof(r_buf)) == DEBUG_RING_READ_ERROR);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_read_with_zero_length()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, 0) == DEBUG_RING_READ_ERROR);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_with_null_string()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "01234";
+
+    EXPECT_TRUE(dr.write(NULL, strlen(w_buf)) == debug_ring_error::failure);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_with_zero_length()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "01234";
+
+    EXPECT_TRUE(dr.write(w_buf, 0) == debug_ring_error::failure);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_string_to_dr_that_is_larger_than_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "0123456789";
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::failure);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_string_to_dr_that_is_much_larger_than_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "0123456789ABCDEFG";
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::failure);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_one_small_string_to_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "01234";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::success);
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 6);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_fill_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "012345678";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::success);
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == BUF_SIZE);
+    EXPECT_TRUE(r_buf[BUF_SIZE - 1] == '\0');
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_overcommit_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf1[] = "012345678";
+    char w_buf2[] = "ABCDE";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf1, strlen(w_buf1)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf2, strlen(w_buf2)) == debug_ring_error::success);
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 6);
+    EXPECT_TRUE(r_buf[0] == 'A');
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_overcommit_dr_more_than_once()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf1[] = "012345678";
+    char w_buf2[] = "ABCDE";
+    char w_buf3[] = "FG";
+    char w_buf4[] = "012345";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf1, strlen(w_buf1)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf2, strlen(w_buf2)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf3, strlen(w_buf3)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf4, strlen(w_buf4)) == debug_ring_error::success);
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == BUF_SIZE);
+    EXPECT_TRUE(r_buf[0] == 'F');
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_read_with_empty_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 0);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_clear_empty_dr()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char r_buf[BUF_SIZE];
+
+    dr.clear();
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 0);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_write_dr_and_clear()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "01234";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf, strlen(w_buf)) == debug_ring_error::success);
+
+    dr.clear();
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 0);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_overcommit_dr_and_clear()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf1[] = "012345678";
+    char w_buf2[] = "ABCDE";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf1, strlen(w_buf1)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf2, strlen(w_buf2)) == debug_ring_error::success);
+
+    dr.clear();
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 0);
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::test_overcommit_dr_and_clear_and_write()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf1[] = "012345678";
+    char w_buf2[] = "ABCDE";
+    char w_buf3[] = "FGHIJ";
+    char r_buf[BUF_SIZE];
+
+    EXPECT_TRUE(dr.write(w_buf1, strlen(w_buf1)) == debug_ring_error::success);
+    EXPECT_TRUE(dr.write(w_buf2, strlen(w_buf2)) == debug_ring_error::success);
+
+    dr.clear();
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 0);
+
+    EXPECT_TRUE(dr.write(w_buf3, strlen(w_buf3)) == debug_ring_error::success);
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 6);
+    EXPECT_TRUE(r_buf[0] == 'F');
+
+    delete_drr(drr);
+}
+
+void debug_ring_ut::acceptance_test_stress()
+{
+    debug_ring_resources *drr = create_drr();
+    debug_ring dr(drr);
+    char w_buf[] = "012";
+    char r_buf[BUF_SIZE];
+
+    for (auto i = 0; i < 1000; i++)
+        dr.write(w_buf, strlen(w_buf));
+
+    EXPECT_TRUE(debug_ring_read(drr, r_buf, sizeof(r_buf)) == 8);
+    EXPECT_TRUE(r_buf[0] == '0');
+
+    delete_drr(drr);
+}
+
+int
+main(int argc, char *argv[])
+{
+    return RUN_ALL_TESTS(debug_ring_ut);
+}

--- a/bfvmm/src/debug_ring/test/test.h
+++ b/bfvmm/src/debug_ring/test/test.h
@@ -1,0 +1,65 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef TEST_H
+#define TEST_H
+
+#include <unittest.h>
+
+class debug_ring_ut : public unittest
+{
+public:
+
+    debug_ring_ut();
+    ~debug_ring_ut() {}
+
+protected:
+
+    bool init() override;
+    bool fini() override;
+    bool list() override;
+
+private:
+
+    void test_create_dr_with_null_drr();
+    void test_create_dr_with_zero_length();
+    void test_read_with_invalid_drr();
+    void test_write_with_invalid_dr();
+    void test_read_with_null_string();
+    void test_read_with_zero_length();
+    void test_write_with_null_string();
+    void test_write_with_zero_length();
+    void test_write_string_to_dr_that_is_larger_than_dr();
+    void test_write_string_to_dr_that_is_much_larger_than_dr();
+    void test_write_one_small_string_to_dr();
+    void test_fill_dr();
+    void test_overcommit_dr();
+    void test_overcommit_dr_more_than_once();
+    void test_read_with_empty_dr();
+    void test_clear_empty_dr();
+    void test_write_dr_and_clear();
+    void test_overcommit_dr_and_clear();
+    void test_overcommit_dr_and_clear_and_write();
+
+    void acceptance_test_stress();
+};
+
+#endif

--- a/common/common_subdir.mk
+++ b/common/common_subdir.mk
@@ -27,21 +27,28 @@ CS='\033[1;34m'
 CE='\033[0m'
 
 ################################################################################
+# Current Directory
+################################################################################
+
+CURRENT_DIR=$(shell pwd)
+
+################################################################################
 # Targets
 ################################################################################
 
 .PHONY: all
 .PHONY: clean
-.PHONY: custom_clean
 
-all:
-	@for dir in $(SUBDIRS); do \
-		echo -e $(CS)$(PWD)/$$dir$(CE); \
-		$(MAKE) --no-print-directory -C $$dir; \
-	done
+all: $(SUBDIRS)
 
-clean: custom_clean
+$(SUBDIRS): force
+		@echo $(CS)$(CURRENT_DIR)/$@$(CE);
+		@$(MAKE) --no-print-directory -C $@
+
+force:;
+
+clean:
 	@for dir in $(SUBDIRS); do \
-		echo -e $(CS)$(PWD)/$$dir$(CE); \
+		echo $(CS)$(CURRENT_DIR)/$$dir$(CE); \
 		$(MAKE) --no-print-directory -C $$dir clean; \
 	done

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -20,77 +20,156 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Automated Sources
+# OS Detection
 ################################################################################
 
-# The following provides us a place to handle OS specific logic.
-ifeq ($(TARGET_CROSS_COMPILED),true)
-	BIN_EXT=
-	LIB_EXT=.so
-	LIB_PRE=lib
+ifeq ($(OS),Windows_NT)
+	OS=windows
 else
-	ifeq ($(OS),Windows_NT)
+	UNAME=$(shell uname -s)
+	ifeq ($(UNAME),Linux)
+		OS=linux
+	endif
+	ifeq ($(UNAME),Darwin)
+		OS=osx
+	endif
+endif
+
+################################################################################
+# Compilers
+################################################################################
+
+ifeq ($(TARGET_COMPILER),native)
+	TARGET_CROSS_COMPILED=
+	TARGET_NATIVE_COMPILED=true
+endif
+
+ifeq ($(TARGET_COMPILER),cross)
+	TARGET_CROSS_COMPILED=true
+	TARGET_NATIVE_COMPILED=
+endif
+
+ifeq ($(TARGET_COMPILER),both)
+	TARGET_CROSS_COMPILED=true
+	TARGET_NATIVE_COMPILED=true
+endif
+
+################################################################################
+# Target Naming
+################################################################################
+
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	CROSS_BIN_EXT=
+	CROSS_LIB_EXT=.so
+	CROSS_LIB_PRE=lib
+	CROSS_SOURCES += $(SOURCES)
+	CROSS_SOURCES += $(VMM_SOURCES)
+	CROSS_INCLUDE_PATHS+=$(INCLUDE_PATHS)
+	CROSS_INCLUDE_PATHS+=$(VMM_INCLUDE_PATHS)
+	CROSS_DEFINES+=OS_VMM
+endif
+
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+	ifeq ($(OS),windows)
 		BIN_EXT=.exe
 		LIB_EXT=.dll
 		LIB_PRE=
-		SOURCES+=$(WINDOWS_SOURCES)
+		SOURCES += $(WINDOWS_SOURCES)
 		INCLUDE_PATHS+=$(WINDOWS_INCLUDE_PATHS)
-	else
-		UNAME=$(shell uname -s)
-		ifeq ($(UNAME),Linux)
-			BIN_EXT=
-			LIB_EXT=.so
-			LIB_PRE=lib
-			SOURCES+=$(LINUX_SOURCES)
-			INCLUDE_PATHS+=$(LINUX_INCLUDE_PATHS)
-		endif
-		ifeq ($(UNAME),Darwin)
-			BIN_EXT=
-			LIB_EXT=.dylib
-			LIB_PRE=lib
-			SOURCES+=$(OSX_SOURCES)
-			INCLUDE_PATHS+=$(OSX_INCLUDE_PATHS)
-			ifeq ($(TARGET_TYPE),lib)
-				LDFLAGS += -undefined dynamic_lookup
-			endif
+		DEFINES+=OS_WINDOWS
+	endif
+	ifeq ($(OS),linux)
+		BIN_EXT=
+		LIB_EXT=.so
+		LIB_PRE=lib
+		SOURCES += $(LINUX_SOURCES)
+		INCLUDE_PATHS+=$(LINUX_INCLUDE_PATHS)
+		DEFINES+=OS_LINUX
+	endif
+	ifeq ($(OS),osx)
+		BIN_EXT=
+		LIB_EXT=.dylib
+		LIB_PRE=lib
+		SOURCES += $(OSX_SOURCES)
+		INCLUDE_PATHS+=$(OSX_INCLUDE_PATHS)
+		DEFINES+=OS_OSX
+		ifeq ($(TARGET_TYPE),lib)
+			LDFLAGS += -undefined dynamic_lookup
 		endif
 	endif
 endif
 
-# If we have a library, we need to compile the executable using -shared, and
-# -pic for the compilation stage. We also need to modify the target name as
-# libraries have very spcific names
 ifeq ($(TARGET_TYPE),lib)
-	CCFLAGS+=-fpic
-	CXXFLAGS+=-fpic
-	LDFLAGS+=-shared
-	TARGET=$(patsubst %,$(OUTDIR)/$(LIB_PRE)%$(LIB_EXT),$(TARGET_NAME))
+	ifeq ($(TARGET_CROSS_COMPILED),true)
+		CROSS_CCFLAGS+=-fpic
+		CROSS_CXXFLAGS+=-fpic
+		CROSS_LDFLAGS+=-shared
+		CROSS_TARGET=$(patsubst %,$(CROSS_OUTDIR)/$(CROSS_LIB_PRE)%$(CROSS_LIB_EXT),$(TARGET_NAME))
+	endif
+	ifeq ($(TARGET_NATIVE_COMPILED),true)
+		CCFLAGS+=-fpic
+		CXXFLAGS+=-fpic
+		LDFLAGS+=-shared
+		TARGET=$(patsubst %,$(OUTDIR)/$(LIB_PRE)%$(LIB_EXT),$(TARGET_NAME))
+	endif
 else
-	TARGET=$(patsubst %,$(OUTDIR)/%$(BIN_EXT),$(TARGET_NAME))
+	ifeq ($(TARGET_CROSS_COMPILED),true)
+		CROSS_TARGET=$(patsubst %,$(CROSS_OUTDIR)/%$(CROSS_BIN_EXT),$(TARGET_NAME))
+	endif
+	ifeq ($(TARGET_NATIVE_COMPILED),true)
+		TARGET=$(patsubst %,$(OUTDIR)/%$(BIN_EXT),$(TARGET_NAME))
+	endif
 endif
 
-# Get a list of C and CPP sources
-CC_SOURCES=$(filter %.c,$(SOURCES))
-CXX_SOURCES=$(filter %.cpp,$(SOURCES))
-ASM_SOURCES=$(filter %.asm,$(SOURCES))
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	CROSS_DEFINES+=CROSS_COMPILED
+	CROSS_DFLAGS=$(patsubst %,-D%,$(CROSS_DEFINES))
+endif
 
-# Create a list of object files to compile for C and CPP
-CC_OBJECTS=$(patsubst %.c,%.o,$(CC_SOURCES))
-CXX_OBJECTS=$(patsubst %.cpp,%.o,$(CXX_SOURCES))
-ASM_OBJECTS=$(patsubst %.asm,%.o,$(ASM_SOURCES))
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+	DEFINES+=NATIVE_COMPILED
+	DFLAGS=$(patsubst %,-D%,$(DEFINES))
+endif
 
-# Concat the object file list (we need both forms)
-OBJECTS+=$(CC_OBJECTS)
-OBJECTS+=$(CXX_OBJECTS)
-OBJECTS+=$(ASM_OBJECTS)
+################################################################################
+# Source Files
+################################################################################
 
-# Create a list of include files for C and CPP
-CC_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
-CXX_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	CROSS_CC_SOURCES=$(filter %.c,$(CROSS_SOURCES))
+	CROSS_CXX_SOURCES=$(filter %.cpp,$(CROSS_SOURCES))
+	CROSS_ASM_SOURCES=$(filter %.asm,$(CROSS_SOURCES))
+endif
 
-# Create a list of lib files for C and CPP
-LD_FLAGS_LIBS=$(patsubst %,-l%,$(LIBS))
-LD_FLAGS_LIB_PATHS=$(patsubst %,-L%,$(LIB_PATHS))
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+	CC_SOURCES=$(filter %.c,$(SOURCES))
+	CXX_SOURCES=$(filter %.cpp,$(SOURCES))
+	ASM_SOURCES=$(filter %.asm,$(SOURCES))
+endif
+
+################################################################################
+# Object Files
+################################################################################
+
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	CROSS_OBJECTS+=$(patsubst %.c,%.o,$(CROSS_CC_SOURCES))
+	CROSS_OBJECTS+=$(patsubst %.cpp,%.o,$(CROSS_CXX_SOURCES))
+	CROSS_OBJECTS+=$(patsubst %.asm,%.o,$(CROSS_ASM_SOURCES))
+	CROSS_CC_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(CROSS_INCLUDE_PATHS))
+	CROSS_CXX_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(CROSS_INCLUDE_PATHS))
+	CROSS_LD_FLAGS_LIBS=$(patsubst %,-l%,$(LIBS))
+	CROSS_LD_FLAGS_LIB_PATHS=$(patsubst %,-L%,$(LIB_PATHS))
+endif
+
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+	OBJECTS+=$(patsubst %.c,%.o,$(CC_SOURCES))
+	OBJECTS+=$(patsubst %.cpp,%.o,$(CXX_SOURCES))
+	OBJECTS+=$(patsubst %.asm,%.o,$(ASM_SOURCES))
+	CC_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
+	CXX_FLAGS_INCLUDE_PATHS=$(patsubst %,-I%,$(INCLUDE_PATHS))
+	LD_FLAGS_LIBS=$(patsubst %,-l%,$(LIBS))
+	LD_FLAGS_LIB_PATHS=$(patsubst %,-L%,$(LIB_PATHS))
+endif
 
 ################################################################################
 # Dependency Auto-Genetaion
@@ -98,21 +177,76 @@ LD_FLAGS_LIB_PATHS=$(patsubst %,-L%,$(LIB_PATHS))
 
 # http://make.mad-scientist.net/papers/advanced-auto-dependency-generation/
 
-DFLAGS=$(patsubst %,-D%,$(DEFINES))
-DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)/$*.Td
-POSTCOMPILE = @mv -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
+ifeq ($(TARGET_CROSS_COMPILED),true)
+	CROSS_DEPFLAGS = -MT $@ -MMD -MP -MF $(CROSS_OBJDIR)/$*.Td
+	CROSS_POSTCOMPILE = @mv -f $(CROSS_OBJDIR)/$*.Td $(CROSS_OBJDIR)/$*.d
+endif
+
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+	DEPFLAGS = -MT $@ -MMD -MP -MF $(OBJDIR)/$*.Td
+	POSTCOMPILE = @mv -f $(OBJDIR)/$*.Td $(OBJDIR)/$*.d
+endif
 
 ################################################################################
-# Targets
+# Target Settings
 ################################################################################
 
 .PHONY: all
+.PHONY: cross
+.PHONY: native
 .PHONY: clean
-.PHONY: custom_clean
+.PHONY: clean-cross
+.PHONY: clean-native
 
 .DEFAULT_GOAL := all
 
-all: $(OBJDIR) $(OUTDIR) $(TARGET)
+all: cross native
+
+clean: clean-cross clean-native
+
+################################################################################
+# Cross Targets
+################################################################################
+
+ifeq ($(TARGET_CROSS_COMPILED),true)
+
+cross: $(CROSS_OBJDIR) $(CROSS_OUTDIR) $(CROSS_TARGET)
+
+$(CROSS_OBJDIR):
+	@$(MD) $(CROSS_OBJDIR)
+
+$(CROSS_OUTDIR):
+	@$(MD) $(CROSS_OUTDIR)
+
+$(CROSS_OBJDIR)/%.o: %.c $(CROSS_OBJDIR)/%.d
+	$(CROSS_CC) $< -o $@ -c $(CROSS_CCFLAGS) $(CROSS_DFLAGS) $(CROSS_DEPFLAGS) $(CROSS_CC_FLAGS_INCLUDE_PATHS) $(HEADERS)
+	$(CROSS_POSTCOMPILE)
+
+$(CROSS_OBJDIR)/%.o: %.cpp $(CROSS_OBJDIR)/%.d
+	$(CROSS_CXX) $< -o $@ -c $(CROSS_CXXFLAGS) $(CROSS_DFLAGS) $(CROSS_DEPFLAGS) $(CROSS_CXX_FLAGS_INCLUDE_PATHS) $(HEADERS)
+	$(CROSS_POSTCOMPILE)
+
+$(CROSS_OBJDIR)/%.o: %.asm
+	$(CROSS_ASM) $< -o $@ $(CROSS_ASMFLAGS)
+
+$(CROSS_TARGET): $(addprefix $(CROSS_OBJDIR)/, $(CROSS_OBJECTS))
+	$(CROSS_LD) -o $@ $^ $(CROSS_LDFLAGS) $(CROSS_LD_FLAGS_LIB_PATHS) $(CROSS_LD_FLAGS_LIBS)
+
+$(CROSS_OBJDIR)/%.d: ;
+-include $(patsubst %,$(CROSS_OBJDIR)/%.d,$(basename $(CROSS_SOURCES)))
+
+clean-cross:
+	$(RM) $(CROSS_OBJDIR) $(CROSS_TARGET)
+
+endif
+
+################################################################################
+# Native Targets
+################################################################################
+
+ifeq ($(TARGET_NATIVE_COMPILED),true)
+
+native: $(OBJDIR) $(OUTDIR) $(TARGET)
 
 $(OBJDIR):
 	@$(MD) $(OBJDIR)
@@ -121,11 +255,11 @@ $(OUTDIR):
 	@$(MD) $(OUTDIR)
 
 $(OBJDIR)/%.o: %.c $(OBJDIR)/%.d
-	$(CC) $< -o $@ -c $(CCFLAGS) $(DFLAGS) $(DEPFLAGS) $(CC_FLAGS_INCLUDE_PATHS) $(INCLUDES)
+	$(CC) $< -o $@ -c $(CCFLAGS) $(DFLAGS) $(DEPFLAGS) $(CC_FLAGS_INCLUDE_PATHS) $(HEADERS)
 	$(POSTCOMPILE)
 
 $(OBJDIR)/%.o: %.cpp $(OBJDIR)/%.d
-	$(CXX) $< -o $@ -c $(CXXFLAGS) $(DFLAGS) $(DEPFLAGS) $(CXX_FLAGS_INCLUDE_PATHS) $(INCLUDES)
+	$(CXX) $< -o $@ -c $(CXXFLAGS) $(DFLAGS) $(DEPFLAGS) $(CXX_FLAGS_INCLUDE_PATHS) $(HEADERS)
 	$(POSTCOMPILE)
 
 $(OBJDIR)/%.o: %.asm
@@ -134,8 +268,10 @@ $(OBJDIR)/%.o: %.asm
 $(TARGET): $(addprefix $(OBJDIR)/, $(OBJECTS))
 	$(LD) -o $@ $^ $(LDFLAGS) $(LD_FLAGS_LIB_PATHS) $(LD_FLAGS_LIBS)
 
-clean: custom_clean
-	$(RM) $(OBJDIR) $(TARGET)
-
 $(OBJDIR)/%.d: ;
 -include $(patsubst %,$(OBJDIR)/%.d,$(basename $(SOURCES)))
+
+clean-native:
+	$(RM) $(OBJDIR) $(TARGET)
+
+endif

--- a/driver_entry/src/arch/linux/entry.c
+++ b/driver_entry/src/arch/linux/entry.c
@@ -41,7 +41,7 @@ ioctl_add_module(char *file)
     char *buf;
     int32_t ret;
 
-    if(g_num_files >= MAX_NUM_MODULES)
+    if (g_num_files >= MAX_NUM_MODULES)
     {
         ALERT("IOCTL_ADD_MODULE: too many modules have been loaded\n");
         return BF_IOCTL_ERROR_ADD_MODULE_FAILED;
@@ -61,21 +61,21 @@ ioctl_add_module(char *file)
      */
 
     buf = platform_alloc(g_module_length);
-    if(buf == NULL)
+    if (buf == NULL)
     {
         ALERT("IOCTL_ADD_MODULE: failed to allocate memory for the module\n");
         return BF_IOCTL_ERROR_ADD_MODULE_FAILED;
     }
 
     ret = copy_from_user(buf, file, g_module_length);
-    if(ret != 0)
+    if (ret != 0)
     {
         ALERT("IOCTL_ADD_MODULE: failed to copy memory from userspace\n");
         goto failed;
     }
 
     ret = add_module(buf, g_module_length);
-    if(ret != BF_SUCCESS)
+    if (ret != BF_SUCCESS)
     {
         ALERT("IOCTL_ADD_MODULE: failed to add module\n");
         goto failed;
@@ -110,7 +110,7 @@ ioctl_start_vmm(void)
     int ret;
 
     ret = start_vmm();
-    if(ret != BF_SUCCESS)
+    if (ret != BF_SUCCESS)
     {
         ALERT("IOCTL_START_VMM: failed to start vmm: %d\n", ret);
         return ret;
@@ -127,10 +127,10 @@ ioctl_stop_vmm(void)
     int ret;
 
     ret = stop_vmm();
-    if(ret != BF_SUCCESS)
+    if (ret != BF_SUCCESS)
         ALERT("IOCTL_START_VMM: failed to start vmm: %d\n", ret);
 
-    for(i = 0; i < g_num_files; i++)
+    for (i = 0; i < g_num_files; i++)
         platform_free(files[i]);
 
     g_num_files = 0;
@@ -144,7 +144,7 @@ dev_unlocked_ioctl(struct file *file,
                    unsigned int cmd,
                    unsigned long arg)
 {
-    switch(cmd)
+    switch (cmd)
     {
         case IOCTL_ADD_MODULE:
             return ioctl_add_module((char *)arg);
@@ -170,7 +170,8 @@ static struct file_operations fops =
     .unlocked_ioctl = dev_unlocked_ioctl,
 };
 
-static struct miscdevice bareflank_dev = {
+static struct miscdevice bareflank_dev =
+{
     MISC_DYNAMIC_MINOR,
     "bareflank",
     &fops
@@ -185,7 +186,7 @@ dev_init(void)
 {
     int ret;
 
-    if((ret = misc_register(&bareflank_dev)) < 0)
+    if ((ret = misc_register(&bareflank_dev)) < 0)
     {
         ALERT("misc_register failed\n");
         return ret;

--- a/driver_entry/src/arch/linux/platform.c
+++ b/driver_entry/src/arch/linux/platform.c
@@ -30,7 +30,7 @@ platform_alloc(int32_t len)
 {
     void *addr;
 
-    if(len == 0)
+    if (len == 0)
     {
         ALERT("platform_alloc: invalid length\n");
         return NULL;
@@ -38,7 +38,7 @@ platform_alloc(int32_t len)
 
     addr = vmalloc(len);
 
-    if(addr == NULL)
+    if (addr == NULL)
     {
         ALERT("platform_alloc: failed to vmalloc mem: %d\n", len);
         return NULL;
@@ -52,7 +52,7 @@ platform_alloc_exec(int32_t len)
 {
     void *addr;
 
-    if(len == 0)
+    if (len == 0)
     {
         ALERT("platform_alloc_exec: invalid length\n");
         return NULL;
@@ -60,7 +60,7 @@ platform_alloc_exec(int32_t len)
 
     addr = __vmalloc(len, GFP_KERNEL, PAGE_KERNEL_EXEC);
 
-    if(addr == NULL)
+    if (addr == NULL)
     {
         ALERT("platform_alloc_exec: failed to vmalloc executable mem: %d\n", len);
         return NULL;
@@ -72,7 +72,7 @@ platform_alloc_exec(int32_t len)
 void
 platform_free(void *addr)
 {
-    if(addr == NULL)
+    if (addr == NULL)
     {
         ALERT("platform_free: invalid address %p\n", addr);
         return;
@@ -84,7 +84,7 @@ platform_free(void *addr)
 void
 platform_free_exec(void *addr)
 {
-    if(addr == NULL)
+    if (addr == NULL)
     {
         ALERT("platform_free_exec: invalid address %p\n", addr);
         return;

--- a/driver_entry/src/common.c
+++ b/driver_entry/src/common.c
@@ -59,38 +59,38 @@ add_module(char *file, int32_t fsize)
     void *exec;
     struct bfelf_file_t bfelf_file = {0};
 
-    if(g_vmm_status == VMM_STARTED)
+    if (g_vmm_status == VMM_STARTED)
     {
         ALERT("add_module: vmm already running\n");
         return BF_ERROR_VMM_ALREADY_STARTED;
     }
 
-    if(g_num_bfelf_files == MAX_NUM_MODULES)
+    if (g_num_bfelf_files == MAX_NUM_MODULES)
         return BF_ERROR_REACHED_MAX_MODULES;
 
     ret = bfelf_file_init(file, fsize, &bfelf_file);
-    if(ret != BFELF_SUCCESS)
+    if (ret != BFELF_SUCCESS)
     {
         ALERT("add_module: failed to initialize elf file: %d - %s\n", ret, bfelf_error(ret));
         goto failed;
     }
 
     size = bfelf_total_exec_size(&bfelf_file);
-    if(ret < BFELF_SUCCESS)
+    if (ret < BFELF_SUCCESS)
     {
         ALERT("add_module: failed to get the module's exec size %d - %s\n", size, bfelf_error(size));
         goto failed;
     }
 
     exec = platform_alloc_exec(size);
-    if(exec == NULL)
+    if (exec == NULL)
     {
         ALERT("add_module: failed alloc memory for exec\n");
         goto failed;
     }
 
     ret = bfelf_file_load(&bfelf_file, exec, size);
-    if(ret != BFELF_SUCCESS)
+    if (ret != BFELF_SUCCESS)
     {
         ALERT("add_module: failed to load the elf module: %d - %s\n", ret, bfelf_error(ret));
         goto failed_load;
@@ -120,10 +120,10 @@ clear_modules(void)
     int i;
     struct bfelf_file_t bfelf_file = {0};
 
-    for(i = 0; i < g_num_bfelf_execs; i++)
+    for (i = 0; i < g_num_bfelf_execs; i++)
         platform_free_exec(g_bfelf_execs[i]);
 
-    for(i = 0; i < MAX_NUM_MODULES; i++)
+    for (i = 0; i < MAX_NUM_MODULES; i++)
     {
         g_bfelf_execs[i] = 0;
         g_bfelf_files[i] = bfelf_file;
@@ -142,29 +142,29 @@ start_vmm(void)
     struct bfelf_loader_t loader = {0};
     struct e_string entry_str = {"_Z9start_vmmi", 13};
 
-    if(g_vmm_status == VMM_STARTED)
+    if (g_vmm_status == VMM_STARTED)
     {
         ALERT("start_vmm: cannot start vmm. vmm already started\n");
         return BF_ERROR_VMM_ALREADY_STARTED;
     }
 
-    if(g_num_bfelf_files <= 0)
+    if (g_num_bfelf_files <= 0)
     {
         ALERT("start_vmm: cannot start vmm. no modules were added\n");
         return BF_ERROR_NO_MODULES_ADDED;
     }
 
     ret = bfelf_loader_init(&loader);
-    if(ret != BFELF_SUCCESS)
+    if (ret != BFELF_SUCCESS)
     {
         ALERT("start_vmm: failed to initialize the elf loader: %d - %s\n", ret, bfelf_error(ret));
         return ret;
     }
 
-    for(i = 0; i < g_num_bfelf_files; i++)
+    for (i = 0; i < g_num_bfelf_files; i++)
     {
         ret = bfelf_loader_add(&loader, &(g_bfelf_files[i]));
-        if(ret != BFELF_SUCCESS)
+        if (ret != BFELF_SUCCESS)
         {
             ALERT("start_vmm: failed to add elf file to the elf loader: %d - %s\n", ret, bfelf_error(ret));
             return ret;
@@ -172,7 +172,7 @@ start_vmm(void)
     }
 
     ret = bfelf_loader_relocate(&loader);
-    if(ret != BFELF_SUCCESS)
+    if (ret != BFELF_SUCCESS)
     {
         ALERT("start_vmm: failed to relocate the elf loader: %d - %s\n", ret, bfelf_error(ret));
         return ret;
@@ -189,7 +189,7 @@ start_vmm(void)
         int64_t ret;
         entry_point_t entry_point = (entry_point_t)entry;
 
-        if((ret = (int64_t)entry_point((void *)0)) == 0)
+        if ((ret = (int64_t)entry_point((void *)0)) == 0)
         {
             DEBUG("\n");
             DEBUG("vmm started successfully:\n");
@@ -222,10 +222,10 @@ stop_vmm(void)
     void *entry = 0;
     struct e_string entry_str = {"_Z8stop_vmmi", 12};
 
-    if(g_vmm_status == VMM_STOPPED)
+    if (g_vmm_status == VMM_STOPPED)
         goto success;
 
-    if(g_num_bfelf_files <= 0)
+    if (g_num_bfelf_files <= 0)
     {
         ALERT("stop_vmm: cannot stop vmm. no modules were added\n");
         return BF_ERROR_NO_MODULES_ADDED;
@@ -242,7 +242,7 @@ stop_vmm(void)
         int64_t ret;
         entry_point_t entry_point = (entry_point_t)entry;
 
-        if((ret = (int64_t)entry_point((void *)0)) == 0)
+        if ((ret = (int64_t)entry_point((void *)0)) == 0)
         {
             DEBUG("\n");
             DEBUG("vmm stopped successfully:\n");

--- a/include/debug_ring_interface.h
+++ b/include/debug_ring_interface.h
@@ -1,0 +1,121 @@
+/*
+ * Bareflank Hypervisor
+ *
+ * Copyright (C) 2015 Assured Information Security, Inc.
+ * Author: Rian Quinn        <quinnr@ainfosec.com>
+ * Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef DEBUG_RING_INTERFACE_H
+#define DEBUG_RING_INTERFACE_H
+
+/**
+ * Returned by debug_ring_read on error
+ */
+#define DEBUG_RING_READ_ERROR -1
+
+/**
+ * Debug Ring Resources
+ *
+ * Each driver entry needs to allocate some memory for the debug ring, and
+ * then cast this structure over the allocated memory to access the bits used
+ * by the ring.
+ *
+ * Prior to providing this structure to the debug ring, the memory should be
+ * cleared, and the len of the buffer should be set to the total length of
+ * memory allocated minus the size of debug_ring_resources.
+ *
+ * @code
+ *
+ *  int len = PAGE_SIZE * 100;
+ *  struct debug_ring_resources *drr = valloc(len);
+ *
+ *  memset(drr, 0, len);
+ *  drr->len = len - sizeof(debug_ring_resources);
+ *
+ *  <give to vmm and do stuff>
+ *
+ *  int ret;
+ *  char read_buf[len]
+ *
+ *  ret = debug_ring_read(drr, read_buf, len);
+ *  if(ret < 0)
+ *      <report error>
+ *
+ * @endcode
+ *
+ * Note there are many different designs for cicular buffers, but all of the
+ * designs have to face the same problem. How to detect when the buffer is
+ * full vs when it is empty. This design uses two counters the grow
+ * forever. The current position in the buffer is then pos % len. If the
+ * counters are 64bit, it would take a life time for the counters to
+ * overflow.
+ *
+ * @len the length of the buffer (not the length of this struct)
+ * @var epos the end position in the circular buffer
+ * @var epos the start position in the circular buffer
+ * @buf the circular buffer that stores the debug strings.
+ */
+struct debug_ring_resources
+{
+    long long int len;
+    long long int epos;
+    long long int spos;
+
+    char buf[];
+};
+
+/**
+ * Debug Ring Read
+ *
+ * Reads strings that have been written to the debug ring. Although you can
+ * provide any buffer size you want, it's advised to provide a buffer that
+ * is the same size as the buffer that was originally allocated.
+ *
+ * @param drr the debug_ring_resource that was used to create the
+ *        debug ring
+ * @param str the buffer to read the string into. should be the same size
+ *        as drr in bytes
+ * @param len the length of the str buffer in bytes
+ * @return the number of bytes read from the debug ring, DEBUG_RING_READ_ERROR
+ *        on error
+ */
+inline long long int
+debug_ring_read(struct debug_ring_resources *drr, char *str, long long int len)
+{
+    long long int i;
+    long long int spos;
+    long long int content;
+
+    if(drr == 0 || str == 0 || len == 0)
+        return DEBUG_RING_READ_ERROR;
+
+    spos = drr->spos % drr->len;
+    content = drr->epos - drr->spos;
+
+    for(i = 0; i < content && i < len; i++)
+    {
+        if(spos == drr->len)
+            spos = 0;
+
+        str[i] = drr->buf[spos++];
+    }
+
+    return content;
+}
+
+#endif

--- a/include/hippomocks.h
+++ b/include/hippomocks.h
@@ -1274,7 +1274,7 @@ namespace HippoMocks
             RAISEEXCEPTION(:: HM_NS NotImplementedException(repo));
         }
     protected:
-        std::map<int, void (* *)()> funcTables;
+        std::map<int, void ( * *)()> funcTables;
         void (*notimplementedfuncs[VIRT_FUNC_LIMIT])();
     public:
         bool isZombie;
@@ -1306,7 +1306,7 @@ namespace HippoMocks
             {
                 delete *i;
             }
-            for (std::map<int, void (* *)()>::iterator i = funcTables.begin(); i != funcTables.end(); ++i)
+            for (std::map<int, void ( * *)()>::iterator i = funcTables.begin(); i != funcTables.end(); ++i)
             {
                 delete [] i->second;
             }

--- a/tools/astyle/linux/run.sh
+++ b/tools/astyle/linux/run.sh
@@ -46,18 +46,26 @@ if [ ! -f $ASTYLE ]; then
 	popd
 fi
 
+find bfelf_loader/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfelf_loader/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfelf_loader/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
 find bfm/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find bfm/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find bfm/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
+find bfvmm/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfvmm/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfvmm/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 
 find common/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find common/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find common/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 
+find driver_entry/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find driver_entry/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find driver_entry/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
 find include/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find include/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find include/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-
-find elf_loader/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find elf_loader/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find elf_loader/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;

--- a/tools/astyle/osx/run.sh
+++ b/tools/astyle/osx/run.sh
@@ -46,14 +46,26 @@ if [ ! -f $ASTYLE ]; then
 	popd
 fi
 
-find include/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find include/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find include/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfelf_loader/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfelf_loader/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfelf_loader/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
+find bfm/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfm/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfm/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
+find bfvmm/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfvmm/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find bfvmm/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 
 find common/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find common/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 find common/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
 
-find elf_loader/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find elf_loader/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
-find elf_loader/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find driver_entry/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find driver_entry/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find driver_entry/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+
+find include/ -name "*.h" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find include/ -name "*.c" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;
+find include/ -name "*.cpp" -exec $ASTYLE --options=./tools/astyle/astyle.config {} \;

--- a/tools/doxygen/config.txt
+++ b/tools/doxygen/config.txt
@@ -733,7 +733,7 @@ WARN_LOGFILE           =
 # spaces.
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = ../include ../common ../elf_loader ../bfm
+INPUT                  = ../include ../common ../bfelf_loader ../bfm ../bfvmm ../driver_entry
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses


### PR DESCRIPTION
This patch contains a new build system. The VMM code actually
needs to be compiled twice. Once for the VMM itself using the
cross compiler, and once for the unit tests which need to
use the native compilers. The previous build system didn't
clearly define the difference.

This patch also contains the scafolding for a basic debugging
library for the VMM to demonstrate how to layout the different
files a class will need in the VMM

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>