### PR TITLE
Memory Manager

### DIFF
--- a/bfm/bin/native/vmm.modules
+++ b/bfm/bin/native/vmm.modules
@@ -1,3 +1,4 @@
+../../../bfvmm/bin/cross/libmemory_manager.so
 ../../../bfvmm/bin/cross/libentry.so
 ../../../bfvmm/bin/cross/libstd.so
 ../../../bfvmm/bin/cross/libdebug_ring.so

--- a/bfvmm/include/memory_manager/memory_manager.h
+++ b/bfvmm/include/memory_manager/memory_manager.h
@@ -1,0 +1,108 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef MEMORY_MANAGER_H
+#define MEMORY_MANAGER_H
+
+#include <stdint.h>
+#include <memory.h>
+#include <memory_manager/memory_manager_base.h>
+
+class memory_manager : public memory_manager_base
+{
+public:
+
+    /// Get Singleton Instance
+    ///
+    /// @return an instance to this singleton class
+    ///
+    static memory_manager &instance();
+
+    /// Memory Manager Destructor
+    ///
+    ~memory_manager() {}
+
+    /// Init Memory Manager
+    ///
+    /// Initializes the memory manager.
+    ///
+    /// @return succss on success, failure otherwise
+    ///
+    memory_manager_error::type init() override;
+
+    /// Add Page to Memory Manager
+    ///
+    /// Adds a page to the memory mamanger. The page must be a valid page
+    /// that has not already been added.
+    ///
+    /// @param pg valid page to add to the memory manager
+    /// @return failure if the page is invalid, full if too many pages have
+    ///     been added to the memory manager, already_added if the page has
+    ///     already been added to the memory manager, and success on success
+    ///
+    memory_manager_error::type add_page(page &pg) override;
+
+    /// Allocate Page
+    ///
+    /// Allocates a page from the memory manage. Once a page has been
+    /// allocated, it cannot be allocated again unless it has been freed.
+    ///
+    /// @param pg pointer to page to store the allocated page
+    /// @return invalid if a NULL page is provide, out_of_memory if the
+    ///     memory manager has run out of pages to allocate, success on
+    ///     success
+    ///
+    memory_manager_error::type alloc_page(page *pg) override;
+
+    /// Free Page
+    ///
+    /// Frees a page that has been previously allocated. Once a page is free
+    /// it can be allocated again (i.e. discontinue use of a page once it has
+    /// been freed)
+    ///
+    /// @param pg page to free
+    ///
+    void free_page(page &pg) override;
+
+private:
+
+    /// Private Memory Manager Constructor
+    ///
+    /// Since this is a singleton class, the constructor should not be used
+    /// directly. Instead, use instance()
+    ///
+    memory_manager() {}
+
+public:
+
+    /// Explicitly delete the use of the copying this class as it is a
+    /// singleton class
+    ///
+
+    memory_manager(const memory_manager &) = delete;
+    void operator=(const memory_manager &) = delete;
+
+private:
+
+    page m_pages[MAX_PAGES];
+};
+
+#endif

--- a/bfvmm/include/memory_manager/memory_manager_base.h
+++ b/bfvmm/include/memory_manager/memory_manager_base.h
@@ -1,0 +1,59 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef MEMORY_MANAGER_BASE_H
+#define MEMORY_MANAGER_BASE_H
+
+#include <memory_manager/page.h>
+
+namespace memory_manager_error
+{
+    enum type
+    {
+        success = 0,
+        failure = 1,
+        out_of_memory = 2,
+        full = 3,
+        already_added = 4
+    };
+};
+
+class memory_manager_base
+{
+public:
+
+    memory_manager_base() {}
+    virtual ~memory_manager_base() {}
+
+    virtual memory_manager_error::type init()
+    { return memory_manager_error::failure; }
+
+    virtual memory_manager_error::type add_page(page &pg)
+    { return memory_manager_error::failure; }
+
+    virtual memory_manager_error::type alloc_page(page *pg)
+    { return memory_manager_error::failure; }
+
+    virtual void free_page(page &pg)
+    {  }
+};
+
+#endif

--- a/bfvmm/include/memory_manager/page.h
+++ b/bfvmm/include/memory_manager/page.h
@@ -1,0 +1,125 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PAGE_H
+#define PAGE_H
+
+#include <stdint.h>
+
+class page
+{
+public:
+
+    /// Page Default Constructor
+    ///
+    /// Creates an empty, invalid page
+    ///
+    page();
+
+    /// Valid Page Constructor
+    ///
+    /// If given the correct values, creates a valid page
+    ///
+    /// @param phys the physical address of the page
+    /// @param virt the virtual address of the page
+    /// @param size the size of the page in bytes
+    ///
+    page(void *phys, void *virt, uint64_t size);
+
+    /// Page Destructor
+    ///
+    virtual ~page();
+
+    /// Is Valid
+    ///
+    /// @return true if the page is valid, false otherwise. A valid page has
+    ///     a physical address, virtual address, and non-zero size.
+    ///
+    virtual bool is_valid() const;
+
+    /// Is Allocated
+    ///
+    /// @return true if the page is allocated, false otherwise
+    ///
+    virtual bool is_allocated() const;
+
+    /// Allocate Page
+    ///
+    /// Changes the page's is_allocated() status to true
+    ///
+    virtual void allocate();
+
+    /// Free Page
+    ///
+    /// Changes the page's is_allocated() status to false
+    ///
+    virtual void free();
+
+    /// Physical Address
+    ///
+    /// @return the physical address of the page
+    ///
+    virtual void *phys_addr() const;
+
+    /// Virtual Address
+    ///
+    /// @return the virtual address of the page
+    ///
+    virtual void *virt_addr() const;
+
+    /// Page Size
+    ///
+    /// @return the size of the page in bytes
+    ///
+    virtual uint64_t size() const;
+
+    /// Page Copy Constructor
+    ///
+    page(const page &other);
+
+    /// Page Equal Operator
+    ///
+    void operator=(const page &other);
+
+    /// Page Is Equal
+    ///
+    /// @return true if both pages have the same physical address, virtual
+    ///     address and size. False otherwise. A page's allocated status is
+    ///     ignored.
+    bool operator==(const page &other);
+
+    /// Page Is Not Equal
+    ///
+    /// @return false if both pages have the same physical address, virtual
+    ///     address and size. True otherwise. A page's allocated status is
+    ///     ignored.
+    bool operator!=(const page &other);
+
+private:
+
+    void *m_phys;
+    void *m_virt;
+    uint64_t m_size;
+
+    bool m_allocated;
+};
+
+#endif

--- a/bfvmm/src/memory_manager/Makefile
+++ b/bfvmm/src/memory_manager/Makefile
@@ -23,17 +23,12 @@
 # Subdirs
 ################################################################################
 
-SUBDIRS += memory_manager
-SUBDIRS += debug_ring
-SUBDIRS += entry
-SUBDIRS += std
-SUBDIRS += serial
-SUBDIRS += vmm
-SUBDIRS += vmcs
-SUBDIRS += intrinsics
+SUBDIRS += src
+SUBDIRS += test
+SUBDIRS += bin
 
 ################################################################################
 # Common
 ################################################################################
 
-include ../../common/common_subdir.mk
+include ../../../common/common_subdir.mk

--- a/bfvmm/src/memory_manager/bin/Makefile
+++ b/bfvmm/src/memory_manager/bin/Makefile
@@ -23,17 +23,10 @@
 # Subdirs
 ################################################################################
 
-SUBDIRS += memory_manager
-SUBDIRS += debug_ring
-SUBDIRS += entry
-SUBDIRS += std
-SUBDIRS += serial
-SUBDIRS += vmm
-SUBDIRS += vmcs
-SUBDIRS += intrinsics
+SUBDIRS += native
 
 ################################################################################
 # Common
 ################################################################################
 
-include ../../common/common_subdir.mk
+include ../../../../common/common_subdir.mk

--- a/bfvmm/src/memory_manager/bin/native/Makefile
+++ b/bfvmm/src/memory_manager/bin/native/Makefile
@@ -19,21 +19,4 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-################################################################################
-# Subdirs
-################################################################################
-
-SUBDIRS += memory_manager
-SUBDIRS += debug_ring
-SUBDIRS += entry
-SUBDIRS += std
-SUBDIRS += serial
-SUBDIRS += vmm
-SUBDIRS += vmcs
-SUBDIRS += intrinsics
-
-################################################################################
-# Common
-################################################################################
-
-include ../../common/common_subdir.mk
+include ../../../../../common/common_test.mk

--- a/bfvmm/src/memory_manager/src/Makefile
+++ b/bfvmm/src/memory_manager/src/Makefile
@@ -1,0 +1,104 @@
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+################################################################################
+# Native Flags
+################################################################################
+
+CC=gcc
+CXX=g++
+ASM=nasm
+LD=g++
+
+CCFLAGS=
+CXXFLAGS=-std=c++14
+ASMFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
+
+################################################################################
+# Cross Flags
+################################################################################
+
+CROSS_CC=~/opt/cross/bin/x86_64-elf-gcc
+CROSS_CXX=~/opt/cross/bin/x86_64-elf-g++
+CROSS_ASM=~/opt/cross/bin/nasm
+CROSS_LD=~/opt/cross/bin/x86_64-elf-ld
+
+CROSS_CCFLAGS=
+CROSS_CXXFLAGS=-std=c++14
+CROSS_ASMFLAGS=-f elf64
+CROSS_LDFLAGS=
+
+CROSS_DEFINES=
+
+CROSS_OBJDIR=.build/cross
+CROSS_OUTDIR=../../../bin/cross
+
+################################################################################
+# Common
+################################################################################
+
+RM=rm -rf
+MD=mkdir -p
+
+################################################################################
+# Sources
+################################################################################
+
+TARGET_NAME=memory_manager
+TARGET_TYPE=lib
+TARGET_COMPILER=both
+
+SOURCES+=page.cpp
+SOURCES+=memory_manager.cpp
+HEADERS=
+
+LIBS=
+
+LIB_PATHS=
+INCLUDE_PATHS=./ ../../../include/ ../../../../include/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=../../../include/std/
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../../../common/common_target.mk

--- a/bfvmm/src/memory_manager/src/memory_manager.cpp
+++ b/bfvmm/src/memory_manager/src/memory_manager.cpp
@@ -1,0 +1,106 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <memory_manager/memory_manager.h>
+
+memory_manager &memory_manager::instance()
+{
+    static memory_manager self;
+    return self;
+}
+
+memory_manager_error::type
+memory_manager::init()
+{
+    auto blank_page = page();
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+        m_pages[i] = blank_page;
+
+    return memory_manager_error::success;
+}
+
+memory_manager_error::type
+memory_manager::add_page(page &pg)
+{
+    auto index = -1;
+
+    if (pg.is_valid() == false)
+        return memory_manager_error::failure;
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+    {
+        if (m_pages[i] == page())
+            index = i;
+
+        if (m_pages[i] == pg)
+            return memory_manager_error::already_added;
+    }
+
+    if (index < 0)
+        return memory_manager_error::full;
+
+    pg.free();
+    m_pages[index] = pg;
+
+    return memory_manager_error::success;
+}
+
+memory_manager_error::type
+memory_manager::alloc_page(page *pg)
+{
+    if (pg == 0)
+        return memory_manager_error::failure;
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+    {
+        if (m_pages[i].is_valid() == false)
+            continue;
+
+        if (m_pages[i].is_allocated() == true)
+            continue;
+
+        m_pages[i].allocate();
+        *pg = m_pages[i];
+
+        return memory_manager_error::success;
+    }
+
+    return memory_manager_error::out_of_memory;
+}
+
+void
+memory_manager::free_page(page &pg)
+{
+    if (pg.is_valid() == false)
+        return;
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+    {
+        if (m_pages[i] == pg)
+        {
+            pg.free();
+            m_pages[i] = pg;
+
+            return;
+        }
+    }
+}

--- a/bfvmm/src/memory_manager/src/page.cpp
+++ b/bfvmm/src/memory_manager/src/page.cpp
@@ -1,0 +1,104 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <memory_manager/page.h>
+
+page::page() :
+    m_phys(0),
+    m_virt(0),
+    m_size(0),
+    m_allocated(false)
+{
+}
+
+page::page(void *phys, void *virt, uint64_t size) :
+    m_phys(phys),
+    m_virt(virt),
+    m_size(size),
+    m_allocated(false)
+{
+}
+
+page::~page()
+{
+}
+
+bool page::is_valid() const
+{
+    return (m_phys != 0) &&
+           (m_virt != 0) &&
+           (m_size != 0);
+}
+
+bool page::is_allocated() const
+{
+    return m_allocated;
+}
+
+void page::allocate()
+{
+    m_allocated = true;
+}
+
+void page::free()
+{
+    m_allocated = false;
+}
+
+void *page::phys_addr() const
+{
+    return m_phys;
+}
+
+void *page::virt_addr() const
+{
+    return m_virt;
+}
+
+uint64_t page::size() const
+{
+    return m_size;
+}
+
+page::page(const page &other)
+{
+    *this = other;
+}
+
+void page::operator=(const page &other)
+{
+    m_phys = other.m_phys;
+    m_virt = other.m_virt;
+    m_size = other.m_size;
+    m_allocated = other.m_allocated;
+}
+
+bool page::operator==(const page &other)
+{
+    return m_phys == other.m_phys &&
+           m_virt == other.m_virt &&
+           m_size == other.m_size;
+}
+
+bool page::operator!=(const page &other)
+{
+    return !(*this == other);
+}

--- a/bfvmm/src/memory_manager/test/Makefile
+++ b/bfvmm/src/memory_manager/test/Makefile
@@ -20,20 +20,67 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 ################################################################################
-# Subdirs
+# Native Flags
 ################################################################################
 
-SUBDIRS += memory_manager
-SUBDIRS += debug_ring
-SUBDIRS += entry
-SUBDIRS += std
-SUBDIRS += serial
-SUBDIRS += vmm
-SUBDIRS += vmcs
-SUBDIRS += intrinsics
+CC=gcc
+CXX=g++
+ASM=nasm
+LD=g++
+
+CCFLAGS=
+CXXFLAGS=-std=c++14
+ASMFLAGS=
+LDFLAGS=
+
+DEFINES=
+
+OBJDIR=.build/native
+OUTDIR=../bin/native
 
 ################################################################################
 # Common
 ################################################################################
 
-include ../../common/common_subdir.mk
+RM=rm -rf
+MD=mkdir -p
+
+################################################################################
+# Sources
+################################################################################
+
+TARGET_NAME=test
+TARGET_TYPE=bin
+TARGET_COMPILER=native
+
+SOURCES+=test.cpp
+SOURCES+=test_page.cpp
+SOURCES+=test_memory_manager.cpp
+HEADERS=
+
+LIBS=memory_manager
+
+LIB_PATHS=../bin/native
+INCLUDE_PATHS=./ ../../../include/  ../../../../include/
+
+################################################################################
+# Environment Specific
+################################################################################
+
+VMM_SOURCES=
+VMM_INCLUDE_PATHS=
+
+WINDOWS_SOURCES=
+WINDOWS_INCLUDE_PATHS=
+
+LINUX_SOURCES=
+LINUX_INCLUDE_PATHS=
+
+OSX_SOURCES=
+OSX_INCLUDE_PATHS=
+
+################################################################################
+# Common
+################################################################################
+
+include ../../../../common/common_target.mk

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -1,0 +1,81 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <test.h>
+
+memory_manager_ut::memory_manager_ut()
+{
+}
+
+bool
+memory_manager_ut::init()
+{
+    return true;
+}
+
+bool
+memory_manager_ut::fini()
+{
+    return true;
+}
+
+bool
+memory_manager_ut::list()
+{
+    this->test_page_constructor_blank_page();
+    this->test_page_constructor_invalid_phys();
+    this->test_page_constructor_invalid_virt();
+    this->test_page_constructor_invalid_size();
+    this->test_page_constructor_valid_page();
+    this->test_page_allocated();
+    this->test_page_allocated_multiple_times();
+    this->test_page_phys();
+    this->test_page_virt();
+    this->test_page_size();
+    this->test_page_copy_constructor_copy_blank();
+    this->test_page_copy_constructor_copy_valid();
+    this->test_page_equal_operator_copy_blank();
+    this->test_page_equal_operator_copy_valid();
+    this->test_page_blank_equal_blank();
+    this->test_page_blank_equal_valid();
+    this->test_page_valid_equal_valid_different_phys();
+    this->test_page_valid_equal_valid_different_virt();
+    this->test_page_valid_equal_valid_different_size();
+    this->test_page_valid_equal_valid_same();
+
+    this->test_memory_manager_init();
+    this->test_memory_manager_add_invalid_page();
+    this->test_memory_manager_add_valid_page();
+    this->test_memory_manager_add_same_page();
+    this->test_memory_manager_add_too_many_pages();
+    this->test_memory_manager_alloc_page_null_arg();
+    this->test_memory_manager_alloc_page_too_many_pages();
+    this->test_memory_manager_alloc_page();
+    this->test_memory_manager_free_allocated_page();
+
+    return true;
+}
+
+int
+main(int argc, char *argv[])
+{
+    return RUN_ALL_TESTS(memory_manager_ut);
+}

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -1,0 +1,74 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef TEST_H
+#define TEST_H
+
+#include <unittest.h>
+
+class memory_manager_ut : public unittest
+{
+public:
+
+    memory_manager_ut();
+    ~memory_manager_ut() {}
+
+protected:
+
+    bool init() override;
+    bool fini() override;
+    bool list() override;
+
+private:
+
+    void test_page_constructor_blank_page();
+    void test_page_constructor_invalid_phys();
+    void test_page_constructor_invalid_virt();
+    void test_page_constructor_invalid_size();
+    void test_page_constructor_valid_page();
+    void test_page_allocated();
+    void test_page_allocated_multiple_times();
+    void test_page_phys();
+    void test_page_virt();
+    void test_page_size();
+    void test_page_copy_constructor_copy_blank();
+    void test_page_copy_constructor_copy_valid();
+    void test_page_equal_operator_copy_blank();
+    void test_page_equal_operator_copy_valid();
+    void test_page_blank_equal_blank();
+    void test_page_blank_equal_valid();
+    void test_page_valid_equal_valid_different_phys();
+    void test_page_valid_equal_valid_different_virt();
+    void test_page_valid_equal_valid_different_size();
+    void test_page_valid_equal_valid_same();
+
+    void test_memory_manager_init();
+    void test_memory_manager_add_invalid_page();
+    void test_memory_manager_add_valid_page();
+    void test_memory_manager_add_same_page();
+    void test_memory_manager_add_too_many_pages();
+    void test_memory_manager_alloc_page_null_arg();
+    void test_memory_manager_alloc_page_too_many_pages();
+    void test_memory_manager_alloc_page();
+    void test_memory_manager_free_allocated_page();
+};
+
+#endif

--- a/bfvmm/src/memory_manager/test/test_memory_manager.cpp
+++ b/bfvmm/src/memory_manager/test/test_memory_manager.cpp
@@ -1,0 +1,115 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <test.h>
+
+#include <memory_manager/memory_manager.h>
+
+void
+memory_manager_ut::test_memory_manager_init()
+{
+    EXPECT_TRUE(memory_manager::instance().init() == memory_manager_error::success);
+}
+
+void
+memory_manager_ut::test_memory_manager_add_invalid_page()
+{
+    page pg;
+    memory_manager::instance().init();
+
+    EXPECT_TRUE(memory_manager::instance().add_page(pg) == memory_manager_error::failure);
+}
+
+void
+memory_manager_ut::test_memory_manager_add_valid_page()
+{
+    page pg(this, this, 10);
+    memory_manager::instance().init();
+
+    EXPECT_TRUE(memory_manager::instance().add_page(pg) == memory_manager_error::success);
+}
+
+void
+memory_manager_ut::test_memory_manager_add_same_page()
+{
+    page pg(this, this, 10);
+    memory_manager::instance().init();
+    memory_manager::instance().add_page(pg);
+
+    EXPECT_TRUE(memory_manager::instance().add_page(pg) == memory_manager_error::already_added);
+}
+
+void
+memory_manager_ut::test_memory_manager_add_too_many_pages()
+{
+    page pg(this, this, MAX_PAGES + 1);
+    memory_manager::instance().init();
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+    {
+        page pg(this, this, i + 1);
+        memory_manager::instance().add_page(pg);
+    }
+
+    EXPECT_TRUE(memory_manager::instance().add_page(pg) == memory_manager_error::full);
+}
+
+void
+memory_manager_ut::test_memory_manager_alloc_page_null_arg()
+{
+    EXPECT_TRUE(memory_manager::instance().alloc_page(0) == memory_manager_error::failure);
+}
+
+void
+memory_manager_ut::test_memory_manager_alloc_page_too_many_pages()
+{
+    page pg(this, this, MAX_PAGES);
+    memory_manager::instance().init();
+    memory_manager::instance().add_page(pg);
+    memory_manager::instance().alloc_page(&pg);
+
+    EXPECT_TRUE(memory_manager::instance().alloc_page(&pg) == memory_manager_error::out_of_memory);
+}
+
+void
+memory_manager_ut::test_memory_manager_alloc_page()
+{
+    page pg(this, this, MAX_PAGES);
+    memory_manager::instance().init();
+    memory_manager::instance().add_page(pg);
+
+    EXPECT_TRUE(pg.is_allocated() == false);
+    EXPECT_TRUE(memory_manager::instance().alloc_page(&pg) == memory_manager_error::success);
+    EXPECT_TRUE(pg.is_allocated() == true);
+}
+
+void
+memory_manager_ut::test_memory_manager_free_allocated_page()
+{
+    page pg(this, this, MAX_PAGES);
+    memory_manager::instance().init();
+    memory_manager::instance().add_page(pg);
+    memory_manager::instance().alloc_page(&pg);
+
+    EXPECT_TRUE(pg.is_allocated() == true);
+    memory_manager::instance().free_page(pg);
+    EXPECT_TRUE(pg.is_allocated() == false);
+}

--- a/bfvmm/src/memory_manager/test/test_page.cpp
+++ b/bfvmm/src/memory_manager/test/test_page.cpp
@@ -1,0 +1,226 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <test.h>
+
+#include <memory_manager/page.h>
+
+void
+memory_manager_ut::test_page_constructor_blank_page()
+{
+    page pg;
+
+    EXPECT_TRUE(pg.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_constructor_invalid_phys()
+{
+    page pg(0, this, 10);
+
+    EXPECT_TRUE(pg.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_constructor_invalid_virt()
+{
+    page pg(this, 0, 10);
+
+    EXPECT_TRUE(pg.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_constructor_invalid_size()
+{
+    page pg(this, this, 0);
+
+    EXPECT_TRUE(pg.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_constructor_valid_page()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.is_valid() == true);
+}
+
+void
+memory_manager_ut::test_page_allocated()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.is_allocated() == false);
+
+    pg.allocate();
+
+    EXPECT_TRUE(pg.is_allocated() == true);
+
+    pg.free();
+
+    EXPECT_TRUE(pg.is_allocated() == false);
+}
+
+void
+memory_manager_ut::test_page_allocated_multiple_times()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.is_allocated() == false);
+
+    pg.allocate();
+    pg.allocate();
+
+    EXPECT_TRUE(pg.is_allocated() == true);
+
+    pg.free();
+    pg.free();
+
+    EXPECT_TRUE(pg.is_allocated() == false);
+}
+
+void
+memory_manager_ut::test_page_phys()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.phys_addr() == this);
+}
+
+void
+memory_manager_ut::test_page_virt()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.virt_addr() == this);
+}
+
+void
+memory_manager_ut::test_page_size()
+{
+    page pg(this, this, 10);
+
+    EXPECT_TRUE(pg.size() == 10);
+}
+
+void
+memory_manager_ut::test_page_copy_constructor_copy_blank()
+{
+    page pg1;
+    page pg2(pg1);
+
+    EXPECT_TRUE(pg2.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_copy_constructor_copy_valid()
+{
+    page pg1(this, this, 10);
+    page pg2(pg1);
+
+    EXPECT_TRUE(pg2.phys_addr() == this);
+    EXPECT_TRUE(pg2.virt_addr() == this);
+    EXPECT_TRUE(pg2.size() == 10);
+}
+
+void
+memory_manager_ut::test_page_equal_operator_copy_blank()
+{
+    page pg1;
+    page pg2;
+
+    pg2 = pg1;
+
+    EXPECT_TRUE(pg2.is_valid() == false);
+}
+
+void
+memory_manager_ut::test_page_equal_operator_copy_valid()
+{
+    page pg1(this, this, 10);
+    page pg2;
+
+    pg2 = pg1;
+
+    EXPECT_TRUE(pg2.phys_addr() == this);
+    EXPECT_TRUE(pg2.virt_addr() == this);
+    EXPECT_TRUE(pg2.size() == 10);
+}
+
+void
+memory_manager_ut::test_page_blank_equal_blank()
+{
+    page pg1;
+    page pg2;
+
+    EXPECT_TRUE(pg1 == pg2);
+    EXPECT_FALSE(pg1 != pg2);
+}
+
+void
+memory_manager_ut::test_page_blank_equal_valid()
+{
+    page pg1(this, this, 10);
+    page pg2;
+
+    EXPECT_FALSE(pg1 == pg2);
+    EXPECT_TRUE(pg1 != pg2);
+}
+
+void
+memory_manager_ut::test_page_valid_equal_valid_different_phys()
+{
+    page pg1(this, this, 10);
+    page pg2(&pg1, this, 10);
+
+    EXPECT_FALSE(pg1 == pg2);
+    EXPECT_TRUE(pg1 != pg2);
+}
+
+void
+memory_manager_ut::test_page_valid_equal_valid_different_virt()
+{
+    page pg1(this, this, 10);
+    page pg2(this, &pg1, 10);
+
+    EXPECT_FALSE(pg1 == pg2);
+    EXPECT_TRUE(pg1 != pg2);
+}
+
+void
+memory_manager_ut::test_page_valid_equal_valid_different_size()
+{
+    page pg1(this, this, 10);
+    page pg2(this, this, 20);
+
+    EXPECT_FALSE(pg1 == pg2);
+    EXPECT_TRUE(pg1 != pg2);
+}
+
+void
+memory_manager_ut::test_page_valid_equal_valid_same()
+{
+    page pg1(this, this, 10);
+    page pg2(this, this, 10);
+
+    EXPECT_TRUE(pg1 == pg2);
+    EXPECT_FALSE(pg1 != pg2);
+}

--- a/include/memory.h
+++ b/include/memory.h
@@ -1,0 +1,36 @@
+/*
+ * Bareflank Hypervisor
+ *
+ * Copyright (C) 2015 Assured Information Security, Inc.
+ * Author: Rian Quinn        <quinnr@ainfosec.com>
+ * Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef MEMORY_H
+#define MEMORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_PAGES 10
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
Adds a memory manager to the VMM. The driver entry code will
allocate pages, and provide this information through the
vmm_resources structure. Once the VMM entry point has
started, it will add these pages to the memory manager where
it can be used.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>