### PR TITLE
Memory Manager Integration

### DIFF
--- a/bfvmm/include/memory_manager/page.h
+++ b/bfvmm/include/memory_manager/page.h
@@ -23,6 +23,7 @@
 #define PAGE_H
 
 #include <stdint.h>
+#include <memory.h>
 
 class page
 {
@@ -43,6 +44,16 @@ public:
     /// @param size the size of the page in bytes
     ///
     page(void *phys, void *virt, uint64_t size);
+
+    /// Valid Page Constructor
+    ///
+    /// If given a valid page struct, creates a valid page from a page struct
+    /// typically created by the driver entry
+    ///
+    /// @param pg page_t struct with the physical / virtual address and
+    ///     page size.
+    ///
+    page(struct page_t pg);
 
     /// Page Destructor
     ///

--- a/bfvmm/src/entry/src/entry.cpp
+++ b/bfvmm/src/entry/src/entry.cpp
@@ -24,6 +24,7 @@
 
 #include <std/iostream>
 #include <debug_ring/debug_ring.h>
+#include <memory_manager/memory_manager.h>
 
 // =============================================================================
 // Entry Functions
@@ -38,9 +39,20 @@ start_vmm(void *arg)
         return VMM_ERROR_INVALID_ARG;
 
     if (debug_ring::instance().init(vmmr->drr) != debug_ring_error::success)
-        return VMM_ERROR_INIT_FAILED;
+        return VMM_ERROR_DEBUG_RING_INIT_FAILED;
 
     std::cout.init();
+
+    if (memory_manager::instance().init() != memory_manager_error::success)
+        return VMM_ERROR_MEMORY_MANAGER_FAILED;
+
+    for (auto i = 0; i < MAX_PAGES; i++)
+    {
+        auto pg = page(vmmr->pages[i]);
+
+        if (memory_manager::instance().add_page(pg) != memory_manager_error::success)
+            return VMM_ERROR_INVALID_PAGES;
+    }
 
     return 0;
 }

--- a/bfvmm/src/memory_manager/src/page.cpp
+++ b/bfvmm/src/memory_manager/src/page.cpp
@@ -37,6 +37,14 @@ page::page(void *phys, void *virt, uint64_t size) :
 {
 }
 
+page::page(struct page_t pg) :
+    m_phys(pg.phys),
+    m_virt(pg.virt),
+    m_size(pg.size),
+    m_allocated(false)
+{
+}
+
 page::~page()
 {
 }

--- a/bfvmm/src/memory_manager/test/test_page.cpp
+++ b/bfvmm/src/memory_manager/test/test_page.cpp
@@ -34,33 +34,41 @@ memory_manager_ut::test_page_constructor_blank_page()
 void
 memory_manager_ut::test_page_constructor_invalid_phys()
 {
-    page pg(0, this, 10);
+    page pg1(0, this, 10);
+    page pg2(page_t({0, this, 10}));
 
-    EXPECT_TRUE(pg.is_valid() == false);
+    EXPECT_TRUE(pg1.is_valid() == false);
+    EXPECT_TRUE(pg2.is_valid() == false);
 }
 
 void
 memory_manager_ut::test_page_constructor_invalid_virt()
 {
-    page pg(this, 0, 10);
+    page pg1(this, 0, 10);
+    page pg2(page_t({this, 0, 10}));
 
-    EXPECT_TRUE(pg.is_valid() == false);
+    EXPECT_TRUE(pg1.is_valid() == false);
+    EXPECT_TRUE(pg2.is_valid() == false);
 }
 
 void
 memory_manager_ut::test_page_constructor_invalid_size()
 {
-    page pg(this, this, 0);
+    page pg1(this, this, 0);
+    page pg2(page_t({this, this, 0}));
 
-    EXPECT_TRUE(pg.is_valid() == false);
+    EXPECT_TRUE(pg1.is_valid() == false);
+    EXPECT_TRUE(pg2.is_valid() == false);
 }
 
 void
 memory_manager_ut::test_page_constructor_valid_page()
 {
-    page pg(this, this, 10);
+    page pg1(this, this, 10);
+    page pg2(page_t({this, this, 10}));
 
-    EXPECT_TRUE(pg.is_valid() == true);
+    EXPECT_TRUE(pg1.is_valid() == true);
+    EXPECT_TRUE(pg2.is_valid() == true);
 }
 
 void

--- a/driver_entry/include/platform.h
+++ b/driver_entry/include/platform.h
@@ -24,6 +24,7 @@
 #define PLATFORM_H
 
 #include <types.h>
+#include <memory.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,6 +53,18 @@ void *
 platform_alloc_exec(int64_t len);
 
 /**
+ * Allocate Page
+ *
+ * Used by the common code to allocate a page of memory. Note that the
+ * page of memory must also be page aligned.
+ *
+ * @return a page struct that must be filled in as the information in
+ *     this struct is used by the VMM to setup memory management.
+ */
+struct page_t
+platform_alloc_page(void);
+
+/**
  * Free Memory
  *
  * Used by the common code to free virtual memory that was allocated
@@ -72,6 +85,16 @@ platform_free(void *addr);
  */
 void
 platform_free_exec(void *addr, int64_t len);
+
+/**
+ * Free Page
+ *
+ * Used by the common code to free a page of memory.
+ *
+ * @param pg the page to free
+ */
+void
+platform_free_page(struct page_t pg);
 
 #ifdef __cplusplus
 }

--- a/driver_entry/src/arch/linux/platform.c
+++ b/driver_entry/src/arch/linux/platform.c
@@ -70,6 +70,18 @@ platform_alloc_exec(int64_t len)
     return addr;
 }
 
+struct page_t
+platform_alloc_page(void)
+{
+    struct page_t pg = {0};
+
+    pg.virt = (void *)__get_free_page(GFP_KERNEL);
+    pg.phys = (void *)virt_to_phys(pg.virt);
+    pg.size = PAGE_SIZE;
+
+    return pg;
+}
+
 void
 platform_free(void *addr)
 {
@@ -92,4 +104,13 @@ platform_free_exec(void *addr, int64_t len)
     }
 
     vfree(addr);
+}
+
+void
+platform_free_page(struct page_t pg)
+{
+    if (pg.virt == 0)
+        return;
+
+    free_page((unsigned long)pg.virt);
 }

--- a/driver_entry/src/arch/test/platform.c
+++ b/driver_entry/src/arch/test/platform.c
@@ -37,6 +37,18 @@ platform_alloc_exec(int64_t len)
                 MAP_PRIVATE | MAP_ANON, -1, 0);
 }
 
+struct page_t
+platform_alloc_page(void)
+{
+    struct page_t pg;
+
+    pg.virt = (void *)48;
+    pg.phys = (void *)1516;
+    pg.size = 2342;
+
+    return pg;
+}
+
 void
 platform_free(void *addr)
 {
@@ -47,4 +59,9 @@ void
 platform_free_exec(void *addr, int64_t len)
 {
     munmap(addr, len);
+}
+
+void
+platform_free_page(struct page_t pg)
+{
 }

--- a/driver_entry/test/test.cpp
+++ b/driver_entry/test/test.cpp
@@ -132,7 +132,9 @@ driver_entry_ut::fini()
 bool
 driver_entry_ut::list()
 {
+    this->test_commit_init_invalid_vmmr();
     this->test_commit_init_failed_alloc();
+    this->test_commit_init_failed_alloc_page();
     this->test_commit_init_success();
     this->test_commit_init_success_multiple_times();
 

--- a/driver_entry/test/test.h
+++ b/driver_entry/test/test.h
@@ -39,7 +39,9 @@ protected:
 
 private:
 
+    void test_commit_init_invalid_vmmr();
     void test_commit_init_failed_alloc();
+    void test_commit_init_failed_alloc_page();
     void test_commit_init_success();
     void test_commit_init_success_multiple_times();
 

--- a/driver_entry/test/test_common_init.cpp
+++ b/driver_entry/test/test_common_init.cpp
@@ -24,6 +24,32 @@
 #include <common.h>
 #include <platform.h>
 
+// =============================================================================
+// Expose Private Functions
+// =============================================================================
+
+// In order to mock some of the C functions, we need to expose them. These are
+// private, so there is no need to test these functions, but we do need access
+// to them to mock them up to test the public functions.
+
+extern "C"
+{
+    struct vmm_resources_t *get_vmmr(void);
+}
+
+void
+driver_entry_ut::test_commit_init_invalid_vmmr()
+{
+    MockRepository mocks;
+
+    mocks.OnCallFunc(get_vmmr).Return(NULL);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_TRUE(common_init() == BF_ERROR_INVALID_ARG);
+    });
+}
+
 void
 driver_entry_ut::test_commit_init_failed_alloc()
 {
@@ -34,6 +60,20 @@ driver_entry_ut::test_commit_init_failed_alloc()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         EXPECT_TRUE(common_init() == BF_ERROR_FAILED_TO_ALLOC_DRR);
+    });
+}
+
+void
+driver_entry_ut::test_commit_init_failed_alloc_page()
+{
+    page_t pg = {0};
+    MockRepository mocks;
+
+    mocks.OnCallFunc(platform_alloc_page).Return(pg);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_TRUE(common_init() == BF_ERROR_OUT_OF_MEMORY);
     });
 }
 

--- a/include/memory.h
+++ b/include/memory.h
@@ -27,6 +27,13 @@
 extern "C" {
 #endif
 
+struct page_t
+{
+    void *phys;
+    void *virt;
+    unsigned long long size;
+};
+
 #define MAX_PAGES 10
 
 #ifdef __cplusplus

--- a/include/vmm_entry.h
+++ b/include/vmm_entry.h
@@ -23,6 +23,7 @@
 #ifndef VMM_ENTRY_INTERFACE_H
 #define VMM_ENTRY_INTERFACE_H
 
+#include <memory.h>
 #include <debug_ring_interface.h>
 
 /**
@@ -31,7 +32,9 @@
 #define VMM_SUCCESS 0
 #define VMM_ERROR_UNKNOWN ((void *)-1)
 #define VMM_ERROR_INVALID_ARG ((void *)-2)
-#define VMM_ERROR_INIT_FAILED ((void *)-3)
+#define VMM_ERROR_DEBUG_RING_INIT_FAILED ((void *)-3)
+#define VMM_ERROR_MEMORY_MANAGER_FAILED ((void *)-4)
+#define VMM_ERROR_INVALID_PAGES ((void *)-5)
 
 /**
  * Entry Point
@@ -56,7 +59,17 @@ typedef void *(*entry_point_t)(void *arg);
  */
 struct vmm_resources_t
 {
+    /*
+     * Debug ring structure used by the VMM to support debugging.
+     */
     struct debug_ring_resources *drr;
+
+    /*
+     * Array of pages that must be allocated by the driver entry to be
+     * used by the VMM's memory manager. If these are not filled in, the
+     * VMM entry will fail.
+     */
+    struct page_t pages[MAX_PAGES];
 };
 
 /**


### PR DESCRIPTION
This patch integrates the memory manager into the VMM and
driver entry. With this patch, the VMM now has access to
a pool of pages that it can use as needed.