### PR TITLE
Support for VMXON

### DIFF
--- a/bfm/bin/native/run.sh
+++ b/bfm/bin/native/run.sh
@@ -1,0 +1,1 @@
+LD_LIBRARY_PATH=. ./bfm $@

--- a/bfm/bin/native/vmm.modules
+++ b/bfm/bin/native/vmm.modules
@@ -2,3 +2,6 @@
 ../../../bfvmm/bin/cross/libentry.so
 ../../../bfvmm/bin/cross/libstd.so
 ../../../bfvmm/bin/cross/libdebug_ring.so
+../../../bfvmm/bin/cross/libintrinsics.so
+../../../bfvmm/bin/cross/libvmm.so
+../../../bfvmm/bin/cross/libvcpu.so

--- a/bfm/main/main.cpp
+++ b/bfm/main/main.cpp
@@ -27,8 +27,27 @@
 #include <ioctl.h>
 #include <ioctl_driver.h>
 
+// REMOVEME: This is only here to temporarly ensure that the kernel is only
+//     executed on core 0. Once the Linux kernel can handle this itself,
+//     this code should be removed.
+
+#ifdef OS_LINUX
+#include <sched.h>
+#endif
+
 int main(int argc, const char *argv[])
 {
+
+    // REMOVEME: This is only here to temporarly ensure that the kernel is only
+    //     executed on core 0. Once the Linux kernel can handle this itself,
+    //     this code should be removed.
+#ifdef OS_LINUX
+    cpu_set_t set;
+    CPU_ZERO(&set);
+    CPU_SET(0, &set);
+    sched_setaffinity(0, sizeof(cpu_set_t), &set);
+#endif
+
     command_line_parser clp(argc, argv);
 
     if (clp.cmd() == command_line_parser_command::help)

--- a/bfvmm/include/debug_ring/debug_ring.h
+++ b/bfvmm/include/debug_ring/debug_ring.h
@@ -77,18 +77,6 @@ public:
     ///
     virtual debug_ring_error::type write(const char *str, int64_t len);
 
-    /// Copy Constructor
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    debug_ring(const debug_ring &) = delete;
-
-    /// Equality Operator
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    void operator=(const debug_ring &) = delete;
-
 private:
 
     bool m_is_valid;

--- a/bfvmm/include/entry/entry_factory.h
+++ b/bfvmm/include/entry/entry_factory.h
@@ -19,27 +19,31 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <vcpu/vcpu.h>
-#include <constants.h>
+#ifndef ENTRY_FACTORY_H
+#define ENTRY_FACTORY_H
 
-vcpu::vcpu() :
-    m_id(-1)
-{
-}
+#include <vcpu/vcpu_factory.h>
+#include <memory_manager/memory_manager.h>
 
-vcpu::vcpu(int64_t id) :
-    m_id(id)
+class entry_factory
 {
-}
+public:
 
-bool
-vcpu::is_valid() const
-{
-    return m_id >= 0 && m_id < MAX_VCPUS;
-}
+    entry_factory() {}
+    virtual ~entry_factory() {}
 
-int64_t
-vcpu::id() const
-{
-    return m_id;
-}
+    virtual vcpu_factory *get_vcpu_factory()
+    { return &m_vcpu_factory; }
+
+    virtual memory_manager *get_memory_manager()
+    { return &m_memory_manager; }
+
+private:
+
+    vcpu_factory m_vcpu_factory;
+    memory_manager m_memory_manager;
+};
+
+entry_factory *ef();
+
+#endif

--- a/bfvmm/include/intrinsics/intrinsics.h
+++ b/bfvmm/include/intrinsics/intrinsics.h
@@ -20,26 +20,15 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef STDINT_H
-#define STDINT_H
+#ifndef INTRINSICS_H
+#define INTRINSICS_H
 
-typedef char int8_t;
-typedef unsigned char uint8_t;
+class intrinsics
+{
+public:
 
-typedef short int int16_t;
-typedef unsigned short int uint16_t;
-
-typedef int int32_t;
-typedef unsigned int uint32_t;
-
-typedef long long int int64_t;
-typedef unsigned long long int uint64_t;
-
-typedef int64_t intptr_t;
-typedef uint64_t uintptr_t;
-
-#define INT64_MIN (-9223372036854775808)
-#define INT64_MAX (9223372036854775807)
-#define UINT64_MAX (18446744073709551615)
+    intrinsics() {}
+    virtual ~intrinsics() {}
+};
 
 #endif

--- a/bfvmm/include/intrinsics/intrinsics_intel_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_intel_x64.h
@@ -23,14 +23,37 @@
 #ifndef INTRINSICS_INTEL_X64_H
 #define INTRINSICS_INTEL_X64_H
 
+#include <stdint.h>
+#include <intrinsics/intrinsics_x64.h>
+
+// =============================================================================
+// Intrinsics
+// =============================================================================
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+uint64_t __vmxon(void *vmxon_region);
+uint64_t __vmxoff(void);
 
+// =============================================================================
+// C++ Wrapper
+// =============================================================================
 
 #ifdef __cplusplus
 }
 #endif
+
+class intrinsics_intel_x64 : public intrinsics_x64
+{
+public:
+
+    bool vmxon(void *vmxon_region)
+    { __vmxon(vmxon_region); }
+
+    bool vmxoff()
+    { __vmxoff(); }
+};
 
 #endif

--- a/bfvmm/include/intrinsics/intrinsics_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_x64.h
@@ -20,17 +20,152 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
-#ifndef INTRINSICS_H
-#define INTRINSICS_H
+#ifndef INTRINSICS_X64_H
+#define INTRINSICS_X64_H
+
+#include <stdint.h>
+#include <intrinsics/intrinsics.h>
+
+// =============================================================================
+// Intrinsics
+// =============================================================================
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
+uint32_t __cpuid_eax(uint32_t val);
+uint32_t __cpuid_ebx(uint32_t val);
+uint32_t __cpuid_ecx(uint32_t val);
+uint32_t __cpuid_edx(uint32_t val);
 
+uint64_t __read_rflags(void);
+
+uint64_t __read_msr(uint32_t msr);
+void __write_msr(uint32_t msr, uint64_t val);
+
+uint64_t __read_cr0();
+void __write_cr0(uint64_t val);
+
+uint64_t __read_cr4();
+void __write_cr4(uint64_t val);
 
 #ifdef __cplusplus
 }
 #endif
+
+// =============================================================================
+// C++ Wrapper
+// =============================================================================
+
+class intrinsics_x64 : public intrinsics
+{
+public:
+
+    intrinsics_x64() {}
+    virtual ~intrinsics_x64() {}
+
+    virtual uint32_t cpuid_eax(uint32_t val)
+    { return __cpuid_eax(val); }
+
+    virtual uint32_t cpuid_ebx(uint32_t val)
+    { return __cpuid_ebx(val); }
+
+    virtual uint32_t cpuid_ecx(uint32_t val)
+    { return __cpuid_ecx(val); }
+
+    virtual uint32_t cpuid_edx(uint32_t val)
+    { return __cpuid_edx(val); }
+
+    virtual uint64_t read_rflags(void)
+    { return __read_rflags(); }
+
+    virtual uint64_t read_msr(uint32_t msr)
+    { return __read_msr(msr); }
+
+    virtual void write_msr(uint32_t msr, uint64_t val)
+    { __write_msr(msr, val); }
+
+    virtual uint64_t read_cr0()
+    { return __read_cr0(); }
+
+    virtual void write_cr0(uint64_t val)
+    { __write_cr0(val); }
+
+    virtual uint64_t read_cr4()
+    { return __read_cr4(); }
+
+    virtual void write_cr4(uint64_t val)
+    { __write_cr4(val); }
+};
+
+// =============================================================================
+// Masks
+// =============================================================================
+
+// RFLAGS
+// 64-ia-32-architectures-software-developer-manual, section 3.4.3
+#define RFLAGS_CF_CARRY_FLAG (1 << 0)
+#define RFLAGS_PF_PARITY_FLAG (1 << 2)
+#define RFLAGS_AF_AUXILIARY_CARRY_FLAG (1 << 4)
+#define RFLAGS_ZF_ZERO_FLAG (1 << 6)
+#define RFLAGS_SF_SIGN_FLAG (1 << 7)
+#define RFLAGS_TF_TRAP_FLAG (1 << 8)
+#define RFLAGS_IF_INTERRUPT_ENABLE_FLAG (1 << 9)
+#define RFLAGS_DF_DIRECTION_FLAG (1 << 10)
+#define RFLAGS_OF_OVERFLOW_FLAG (1 << 11)
+#define RFLAGS_IOPL_PRIVILEGE_LEVEL (2 << 12)
+#define RFLAGS_NT_NESTED_TASK (1 << 14)
+#define RFLAGS_RF_RESUME_FLAG (1 << 16)
+#define RFLAGS_VM_VIRTUAL_8086_MODE (1 << 17)
+#define RFLAGS_AC_ALIGNMENT_CHECK_ACCESS_CONTROL (1 << 18)
+#define RFLAGS_VIF_VIRTUAL_INTERUPT_FLAG (1 << 19)
+#define RFLAGS_VIP_VIRTUAL_INTERUPT_PENDING (1 << 20)
+#define RFLAGS_ID_ID_FLAG (1 << 21)
+
+// CR0
+// 64-ia-32-architectures-software-developer-manual, section 2.5
+#define CRO_PE_PROTECTION_ENABLE (1 << 0)
+#define CR0_MP_MONITOR_COPROCESSOR (1 << 1)
+#define CR0_EM_EMULATION (1 << 2)
+#define CR0_TS_TASK_SWITCHED (1 << 3)
+#define CR0_ET_EXTENSION_TYPE (1 << 4)
+#define CR0_NE_NUMERIC_ERROR (1 << 5)
+#define CR0_WP_WRITE_PROTECT (1 << 16)
+#define CR0_AM_ALIGNMENT_MASK (1 << 18)
+#define CR0_NW_NOT_WRITE_THROUGH (1 << 29)
+#define CR0_CD_CACHE_DISABLE (1 << 30)
+#define CR0_PG_PAGING (1 << 31)
+
+// CR4
+// 64-ia-32-architectures-software-developer-manual, section 2.5
+#define CR4_VME_VIRTUAL8086_MODE_EXTENSIONS (1 << 0)
+#define CR4_PVI_PROTECTED_MODE_VIRTUAL_INTERRUPTS (1 << 1)
+#define CR4_TSD_TIME_STAMP_DISABLE (1 << 2)
+#define CR4_DE_DEBUGGING_EXTENSIONS (1 << 3)
+#define CR4_PSE_PAGE_SIZE_EXTENSIONS (1 << 4)
+#define CR4_PAE_PHYSICAL_ADDRESS_EXTENSIONS (1 << 5)
+#define CR4_MACHINE_CHECK_ENABLE (1 << 6)
+#define CR4_PGE_PAGE_GLOBAL_ENABLE (1 << 7)
+#define CR4_PCE_PERFORMANCE_MONITOR_COUNTER_ENABLE (1 << 8)
+#define CR4_OSFXSR (1 << 9)
+#define CR4_OSXMMEXCPT (1 << 10)
+#define CR4_VMXE_VMX_ENABLE_BIT (1 << 13)
+#define CR4_SMXE_SMX_ENABLE_BIT (1 << 14)
+#define CR4_FSGSBASE_FSGSBASE_ENABLE_BIT (1 << 16)
+#define CR4_PCIDE_PCID_ENABLE_BIT (1 << 17)
+#define CR4_OSXSAVE (1 << 18)
+#define CR4_SMEP_SMEP_ENABLE_BIT (1 << 20)
+#define CR4_SMAP_SMAP_ENABLE_BIT (1 << 21)
+#define CR4_PKE_PROTECTION_KEY_ENABLE_BIT (1 << 22)
+
+// VMX MSRs
+// 64-ia-32-architectures-software-developer-manual, appendix A.1
+#define IA32_VMX_BASIC_MSR (0x480)
+#define IA32_VMX_CR0_FIXED0_MSR (0x486)
+#define IA32_VMX_CR0_FIXED1_MSR (0x487)
+#define IA32_VMX_CR4_FIXED0_MSR (0x488)
+#define IA32_VMX_CR4_FIXED1_MSR (0x489)
+#define IA32_FEATURE_CONTROL (0x3A)
 
 #endif

--- a/bfvmm/include/memory_manager/memory_manager.h
+++ b/bfvmm/include/memory_manager/memory_manager.h
@@ -42,23 +42,13 @@ class memory_manager
 {
 public:
 
-    /// Get Singleton Instance
+    /// Manager Constructor
     ///
-    /// @return an instance to this singleton class
-    ///
-    static memory_manager *instance();
+    memory_manager();
 
-    /// Memory Manager Destructor
+    /// Destructor
     ///
     ~memory_manager() {}
-
-    /// Init Memory Manager
-    ///
-    /// Initializes the memory manager.
-    ///
-    /// @return succss on success, failure otherwise
-    ///
-    memory_manager_error::type init();
 
     /// Add Page to Memory Manager
     ///
@@ -93,29 +83,6 @@ public:
     /// @param pg page to free
     ///
     void free_page(page &pg);
-
-private:
-
-    /// Private Memory Manager Constructor
-    ///
-    /// Since this is a singleton class, the constructor should not be used
-    /// directly. Instead, use instance()
-    ///
-    memory_manager() {}
-
-public:
-
-    /// Copy Constructor
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    memory_manager(const memory_manager &) = delete;
-
-    /// Equality Operator
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    void operator=(const memory_manager &) = delete;
 
 private:
 

--- a/bfvmm/include/std/iostream
+++ b/bfvmm/include/std/iostream
@@ -22,6 +22,8 @@
 #ifndef IOSTREAM_H
 #define IOSTREAM_H
 
+#include <stddef.h>
+
 namespace std
 {
 
@@ -52,6 +54,7 @@ public:
     ostream& operator<<(long long int val);
     ostream& operator<<(unsigned long long int val);
     ostream& operator<<(void *val);
+    ostream& operator<<(size_t val);
     ostream& operator<<(ostream_modifier modifier);
 
 private:

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -22,7 +22,15 @@
 #ifndef VCPU_H
 #define VCPU_H
 
+// TODO: This VCPU is specific to Intel x64. At some point we should
+//       abstract the VCPU such that it has a common interface, and then
+//       subclass for each arch (i.e. Intel, AMD and ARM)
+
 #include <stdint.h>
+
+#include <vmm/vmm_intel_x64.h>
+#include <debug_ring/debug_ring.h>
+#include <intrinsics/intrinsics_intel_x64.h>
 
 class vcpu
 {
@@ -44,7 +52,7 @@ public:
 
     /// Destructor
     ///
-    virtual ~vcpu();
+    virtual ~vcpu() {}
 
     /// Is Valid
     ///
@@ -61,9 +69,34 @@ public:
     ///
     virtual int64_t id() const;
 
+    /// Get VMM
+    ///
+    /// @return vmm (will never be NULL)
+    ///
+    virtual vmm *get_vmm()
+    { return &m_vmm; }
+
+    /// Get Debug Ring
+    ///
+    /// @return debug ring (will never be NULL)
+    ///
+    virtual debug_ring *get_debug_ring()
+    { return &m_debug_ring; }
+
+    /// Get Intrinsics
+    ///
+    /// @return intrinsics (will never be NULL)
+    ///
+    virtual intrinsics_intel_x64 *get_intrinsics()
+    { return &m_intrinsics; }
+
 private:
 
     int64_t m_id;
+
+    vmm_intel_x64 m_vmm;
+    debug_ring m_debug_ring;
+    intrinsics_intel_x64 m_intrinsics;
 };
 
 #endif

--- a/bfvmm/include/vcpu/vcpu_factory.h
+++ b/bfvmm/include/vcpu/vcpu_factory.h
@@ -40,13 +40,11 @@ class vcpu_factory
 {
 public:
 
-    /// Get Singleton Instance
+    /// Default Constructor
     ///
-    /// @return an instance to this singleton class
-    ///
-    static vcpu_factory *instance();
+    vcpu_factory() {}
 
-    /// VCPU Factory Destructor
+    /// Destructor
     ///
     ~vcpu_factory() {}
 
@@ -69,29 +67,6 @@ public:
     /// @return success on success, failure otherwise
     ///
     vcpu_factory_error::type add_vcpu(const vcpu &vc);
-
-private:
-
-    /// Private VCPU Factory Constructor
-    ///
-    /// Since this is a singleton class, the constructor should not be used
-    /// directly. Instead, use instance()
-    ///
-    vcpu_factory() {}
-
-public:
-
-    /// Copy Constructor
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    vcpu_factory(const vcpu_factory &) = delete;
-
-    /// Equality Operator
-    ///
-    /// Explicity deleted as copying this class is forbidden
-    ///
-    void operator=(const vcpu_factory &) = delete;
 
 private:
 

--- a/bfvmm/include/vmcs/vmcs.h
+++ b/bfvmm/include/vmcs/vmcs.h
@@ -22,9 +22,7 @@
 #ifndef VMCS_H
 #define VMCS_H
 
-#include <vmcs/vmcs_base.h>
-
-class vmcs : public vmcs_base
+class vmcs
 {
 public:
 

--- a/bfvmm/include/vmm/vmm.h
+++ b/bfvmm/include/vmm/vmm.h
@@ -22,12 +22,36 @@
 #ifndef VMM_H
 #define VMM_H
 
+#include <intrinsics/intrinsics.h>
+#include <memory_manager/memory_manager.h>
+
+namespace vmm_error
+{
+    enum type
+    {
+        success = 0,
+        failure = 1,
+        not_supported = 2,
+        out_of_memory = 3
+    };
+};
+
 class vmm
 {
 public:
 
     vmm() {}
     virtual ~vmm() {}
+
+    virtual vmm_error::type init(intrinsics *intrinsics,
+                                 memory_manager *memory_manager)
+    { return vmm_error::failure; }
+
+    virtual vmm_error::type start()
+    { return vmm_error::failure; }
+
+    virtual vmm_error::type stop()
+    { return vmm_error::failure; }
 };
 
 #endif

--- a/bfvmm/include/vmm/vmm_intel_x64.h
+++ b/bfvmm/include/vmm/vmm_intel_x64.h
@@ -23,13 +23,75 @@
 #define VMM_X86_64_H
 
 #include <vmm/vmm.h>
+#include <intrinsics/intrinsics_intel_x64.h>
 
 class vmm_intel_x64 : public vmm
 {
 public:
 
-    vmm_intel_x64();
-    ~vmm_intel_x64();
+    /// Default Constructor
+    ///
+    vmm_intel_x64() {}
+
+    /// Destructor
+    ///
+    ~vmm_intel_x64() {}
+
+    /// Init VMM
+    ///
+    /// Initializes the VMM. One of the goals of this function is to decouple
+    /// the intrinsics from the VMM so that the VMM can be tested.
+    ///
+    /// @param intrinsics the intrinsics class that this VMM will use
+    /// @return success on success, failure otherwise
+    vmm_error::type init(intrinsics *intrinsics,
+                         memory_manager *memory_manager) override;
+
+    /// Start VMM
+    ///
+    /// Starts the VMM. In the process of starting the VMM, several
+    /// compatibility tests will be run to ensure that the VMM can in fact
+    /// be used.
+    ///
+    /// @return not_supported if the compability tests fail, success on success
+    ///         and failure otherwise
+    vmm_error::type start() override;
+
+    /// Stop VMM
+    ///
+    /// Stops the VMM.
+    ///
+    /// @return success on success, failure otherwise
+    vmm_error::type stop() override;
+
+private:
+
+    vmm_error::type verify_cpuid_vmx_supported();
+    vmm_error::type verify_vmx_capabilities_msr();
+    vmm_error::type verify_ia32_vmx_cr0_fixed0_msr();
+    vmm_error::type verify_ia32_vmx_cr0_fixed1_msr();
+    vmm_error::type verify_ia32_vmx_cr4_fixed0_msr();
+    vmm_error::type verify_ia32_vmx_cr4_fixed1_msr();
+    vmm_error::type verify_ia32_feature_control_msr();
+    vmm_error::type verify_v8086_disabled();
+
+    vmm_error::type create_vmxon_region();
+    vmm_error::type release_vmxon_region();
+
+    vmm_error::type enable_vmx_operation();
+    vmm_error::type disable_vmx_operation();
+
+    vmm_error::type execute_vmxon();
+    vmm_error::type execute_vmxoff();
+
+    uint64_t vmxon_vmcs_region_size();
+
+private:
+
+    memory_manager *m_memory_manager;
+    intrinsics_intel_x64 *m_intrinsics;
+
+    page m_vmxon_page;
 };
 
 #endif

--- a/bfvmm/src/Makefile
+++ b/bfvmm/src/Makefile
@@ -28,9 +28,9 @@ SUBDIRS += debug_ring
 SUBDIRS += entry
 SUBDIRS += std
 SUBDIRS += serial
+SUBDIRS += intrinsics
 SUBDIRS += vmm
 SUBDIRS += vmcs
-SUBDIRS += intrinsics
 SUBDIRS += vcpu
 
 ################################################################################

--- a/bfvmm/src/entry/src/Makefile
+++ b/bfvmm/src/entry/src/Makefile
@@ -72,7 +72,10 @@ TARGET_NAME=entry
 TARGET_TYPE=lib
 TARGET_COMPILER=both
 
-SOURCES=entry.cpp
+SOURCES+=entry.cpp
+SOURCES+=entry_empty_c.c
+SOURCES+=entry_empty_cpp.cpp
+SOURCES+=entry_factory.cpp
 HEADERS=
 
 LIBS=

--- a/bfvmm/src/entry/src/entry_empty_c.c
+++ b/bfvmm/src/entry/src/entry_empty_c.c
@@ -19,27 +19,15 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <vcpu/vcpu.h>
-#include <constants.h>
+// =============================================================================
+// C Empty Symbols
+// =============================================================================
 
-vcpu::vcpu() :
-    m_id(-1)
+void __cxa_pure_virtual()
 {
 }
 
-vcpu::vcpu(int64_t id) :
-    m_id(id)
+int atexit(void (*func)(void))
 {
-}
-
-bool
-vcpu::is_valid() const
-{
-    return m_id >= 0 && m_id < MAX_VCPUS;
-}
-
-int64_t
-vcpu::id() const
-{
-    return m_id;
+    return 0;
 }

--- a/bfvmm/src/entry/src/entry_empty_cpp.cpp
+++ b/bfvmm/src/entry/src/entry_empty_cpp.cpp
@@ -19,15 +19,10 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef VMCS_BASE_H
-#define VMCS_BASE_H
-
-class vmcs_base
+void operator delete(void *ptr)
 {
-public:
+}
 
-    vmcs_base() {}
-    virtual ~vmcs_base() {}
-};
-
-#endif
+void operator delete[](void *p)
+{
+}

--- a/bfvmm/src/entry/src/entry_factory.cpp
+++ b/bfvmm/src/entry/src/entry_factory.cpp
@@ -19,27 +19,21 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <vcpu/vcpu.h>
-#include <constants.h>
+#ifdef CROSS_COMPILED
 
-vcpu::vcpu() :
-    m_id(-1)
+#include <entry/entry_factory.h>
+
+entry_factory *ef()
 {
+    // We use static local variable here instead of a global variable to
+    // ensure that the constructor / destructor are actually called, since
+    // we do not support global c++ objects in the cross compiled code. Note
+    // that this functions is only need by the cross compiler as native test
+    // code will create it's own version and export as needed (in order to
+    // fake the classes being returned)
+
+    static entry_factory ef;
+    return &ef;
 }
 
-vcpu::vcpu(int64_t id) :
-    m_id(id)
-{
-}
-
-bool
-vcpu::is_valid() const
-{
-    return m_id >= 0 && m_id < MAX_VCPUS;
-}
-
-int64_t
-vcpu::id() const
-{
-    return m_id;
-}
+#endif

--- a/bfvmm/src/intrinsics/src/intrinsics_intel_x64.asm
+++ b/bfvmm/src/intrinsics/src/intrinsics_intel_x64.asm
@@ -18,3 +18,30 @@
 ; You should have received a copy of the GNU Lesser General Public
 ; License along with this library; if not, write to the Free Software
 ; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+global __vmxon:function
+global __vmxoff:function
+
+section .text
+
+; uint64_t __vmxon(void *vmxon_region)
+__vmxon:
+    vmxon [rdi]
+    jbe __vmx_failure
+    jmp __vmx_success
+
+; uint64_t __vmxoff(void)
+__vmxoff:
+    vmxoff
+    jbe __vmx_failure
+    jmp __vmx_success
+
+; vmx instruction failed
+__vmx_failure:
+    mov rax, 0x1
+    ret
+
+; vmx instruction succeded
+__vmx_success:
+    mov rax, 0x1
+    ret

--- a/bfvmm/src/intrinsics/src/intrinsics_x64.asm
+++ b/bfvmm/src/intrinsics/src/intrinsics_x64.asm
@@ -18,3 +18,130 @@
 ; You should have received a copy of the GNU Lesser General Public
 ; License along with this library; if not, write to the Free Software
 ; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+global __cpuid_eax:function
+global __cpuid_ebx:function
+global __cpuid_ecx:function
+global __cpuid_edx:function
+global __read_rflags:function
+global __read_msr:function
+global __write_msr:function
+global __read_cr0:function
+global __write_cr0:function
+global __read_cr4:function
+global __write_cr4:function
+
+section .text
+
+; uint32_t cpuid_eax(uint32_t val)
+__cpuid_eax:
+    push rbx
+    push rcx
+    push rdx
+
+    mov eax, edi
+    cpuid
+
+    pop rdx
+    pop rcx
+    pop rbx
+    ret
+
+; uint32_t cpuid_ebx(uint32_t val)
+__cpuid_ebx:
+    push rbx
+    push rcx
+    push rdx
+
+    mov eax, edi
+    cpuid
+    mov eax, ebx
+
+    pop rdx
+    pop rcx
+    pop rbx
+    ret
+
+; uint32_t cpuid_ecx(uint32_t val)
+__cpuid_ecx:
+    push rbx
+    push rcx
+    push rdx
+
+    mov eax, edi
+    cpuid
+    mov eax, ecx
+
+    pop rdx
+    pop rcx
+    pop rbx
+    ret
+
+; uint32_t cpuid_edx(uint32_t val)
+__cpuid_edx:
+    push rbx
+    push rcx
+    push rdx
+
+    mov eax, edi
+    cpuid
+    mov eax, edx
+
+    pop rdx
+    pop rcx
+    pop rbx
+    ret
+
+; uint64_t read_rflags(void)
+__read_rflags:
+    pushfq
+    pop rax
+    ret
+
+; uint64_t __read_msr(uint32_t msr)
+__read_msr:
+    push rcx
+    push rdx
+
+    mov ecx, edi
+    rdmsr
+    shl rdx, 32
+    or rax, rdx
+
+    pop rdx
+    pop rcx
+    ret
+
+; void __write_msr(uint32_t msr, uint64_t val)
+__write_msr:
+    push rcx
+    push rdx
+
+    mov rax, rdi
+    mov rdx, rdi
+    shr rdx, 32
+    wrmsr
+
+    pop rdx
+    pop rcx
+    ret
+
+; uint64_t __read_cr0()
+__read_cr0:
+    mov rax, cr0
+    ret
+
+; void __write_cr0(uint64_t val)
+__write_cr0:
+    mov cr0, rdi
+    ret
+
+; uint64_t __read_cr4()
+__read_cr4:
+    mov rax, cr4
+    ret
+
+; void __write_cr4(uint64_t val)
+__write_cr4:
+    mov cr4, rdi
+    ret

--- a/bfvmm/src/memory_manager/src/memory_manager.cpp
+++ b/bfvmm/src/memory_manager/src/memory_manager.cpp
@@ -21,21 +21,12 @@
 
 #include <memory_manager/memory_manager.h>
 
-memory_manager *memory_manager::instance()
-{
-    static memory_manager self;
-    return &self;
-}
-
-memory_manager_error::type
-memory_manager::init()
+memory_manager::memory_manager()
 {
     auto blank_page = page();
 
     for (auto i = 0; i < MAX_PAGES; i++)
         m_pages[i] = blank_page;
-
-    return memory_manager_error::success;
 }
 
 memory_manager_error::type

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -61,7 +61,6 @@ memory_manager_ut::list()
     this->test_page_valid_equal_valid_different_size();
     this->test_page_valid_equal_valid_same();
 
-    this->test_memory_manager_init();
     this->test_memory_manager_add_invalid_page();
     this->test_memory_manager_add_valid_page();
     this->test_memory_manager_add_same_page();

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -60,7 +60,6 @@ private:
     void test_page_valid_equal_valid_different_size();
     void test_page_valid_equal_valid_same();
 
-    void test_memory_manager_init();
     void test_memory_manager_add_invalid_page();
     void test_memory_manager_add_valid_page();
     void test_memory_manager_add_same_page();

--- a/bfvmm/src/memory_manager/test/test_memory_manager.cpp
+++ b/bfvmm/src/memory_manager/test/test_memory_manager.cpp
@@ -20,84 +20,81 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <test.h>
-
 #include <memory_manager/memory_manager.h>
-
-void
-memory_manager_ut::test_memory_manager_init()
-{
-    EXPECT_TRUE(memory_manager::instance()->init() == memory_manager_error::success);
-}
 
 void
 memory_manager_ut::test_memory_manager_add_invalid_page()
 {
     page pg;
-    memory_manager::instance()->init();
+    memory_manager mm;
 
-    EXPECT_TRUE(memory_manager::instance()->add_page(pg) == memory_manager_error::failure);
+    EXPECT_TRUE(mm.add_page(pg) == memory_manager_error::failure);
 }
 
 void
 memory_manager_ut::test_memory_manager_add_valid_page()
 {
     page pg(this, this, 10);
-    memory_manager::instance()->init();
+    memory_manager mm;
 
-    EXPECT_TRUE(memory_manager::instance()->add_page(pg) == memory_manager_error::success);
+    EXPECT_TRUE(mm.add_page(pg) == memory_manager_error::success);
 }
 
 void
 memory_manager_ut::test_memory_manager_add_same_page()
 {
     page pg(this, this, 10);
-    memory_manager::instance()->init();
-    memory_manager::instance()->add_page(pg);
+    memory_manager mm;
 
-    EXPECT_TRUE(memory_manager::instance()->add_page(pg) == memory_manager_error::already_added);
+    mm.add_page(pg);
+
+    EXPECT_TRUE(mm.add_page(pg) == memory_manager_error::already_added);
 }
 
 void
 memory_manager_ut::test_memory_manager_add_too_many_pages()
 {
     page pg(this, this, MAX_PAGES + 1);
-    memory_manager::instance()->init();
+    memory_manager mm;
 
     for (auto i = 0; i < MAX_PAGES; i++)
     {
         page pg(this, this, i + 1);
-        memory_manager::instance()->add_page(pg);
+        mm.add_page(pg);
     }
 
-    EXPECT_TRUE(memory_manager::instance()->add_page(pg) == memory_manager_error::full);
+    EXPECT_TRUE(mm.add_page(pg) == memory_manager_error::full);
 }
 
 void
 memory_manager_ut::test_memory_manager_alloc_page_null_arg()
 {
-    EXPECT_TRUE(memory_manager::instance()->alloc_page(0) == memory_manager_error::failure);
+    memory_manager mm;
+    EXPECT_TRUE(mm.alloc_page(0) == memory_manager_error::failure);
 }
 
 void
 memory_manager_ut::test_memory_manager_alloc_page_too_many_pages()
 {
     page pg(this, this, MAX_PAGES);
-    memory_manager::instance()->init();
-    memory_manager::instance()->add_page(pg);
-    memory_manager::instance()->alloc_page(&pg);
+    memory_manager mm;
 
-    EXPECT_TRUE(memory_manager::instance()->alloc_page(&pg) == memory_manager_error::out_of_memory);
+    mm.add_page(pg);
+    mm.alloc_page(&pg);
+
+    EXPECT_TRUE(mm.alloc_page(&pg) == memory_manager_error::out_of_memory);
 }
 
 void
 memory_manager_ut::test_memory_manager_alloc_page()
 {
     page pg(this, this, MAX_PAGES);
-    memory_manager::instance()->init();
-    memory_manager::instance()->add_page(pg);
+    memory_manager mm;
+
+    mm.add_page(pg);
 
     EXPECT_TRUE(pg.is_allocated() == false);
-    EXPECT_TRUE(memory_manager::instance()->alloc_page(&pg) == memory_manager_error::success);
+    EXPECT_TRUE(mm.alloc_page(&pg) == memory_manager_error::success);
     EXPECT_TRUE(pg.is_allocated() == true);
 }
 
@@ -105,11 +102,12 @@ void
 memory_manager_ut::test_memory_manager_free_allocated_page()
 {
     page pg(this, this, MAX_PAGES);
-    memory_manager::instance()->init();
-    memory_manager::instance()->add_page(pg);
-    memory_manager::instance()->alloc_page(&pg);
+    memory_manager mm;
+
+    mm.add_page(pg);
+    mm.alloc_page(&pg);
 
     EXPECT_TRUE(pg.is_allocated() == true);
-    memory_manager::instance()->free_page(pg);
+    mm.free_page(pg);
     EXPECT_TRUE(pg.is_allocated() == false);
 }

--- a/bfvmm/src/std/src/iostream.cpp
+++ b/bfvmm/src/std/src/iostream.cpp
@@ -23,7 +23,7 @@
 
 #include <std/stdlib.h>
 #include <std/string.h>
-#include <debug_ring/debug_ring.h>
+#include <entry/entry_factory.h>
 
 // =============================================================================
 // Globals
@@ -40,17 +40,30 @@ namespace std
 
 namespace std
 {
-
     void
     ostream::init()
     {
-        m_base = 10;
+        static auto initialized = false;
+
+        if (initialized == false)
+        {
+            m_base = 10;
+            initialized = true;
+        }
     }
 
     ostream &
     ostream::operator<<(const char *str)
     {
-        // debug_ring::instance().write(str, strlen(str));
+        // TODO: We need to add multi-core suppor here. To do that, this code
+        //       will have to lookup the CPU that it's running on to know which
+        //       debug ring to dump the text to
+
+        auto vc = ef()->get_vcpu_factory()->get_vcpu(0);
+
+        if (vc != 0)
+            vc->get_debug_ring()->write(str, strlen(str));
+
         return *this;
     }
 
@@ -127,6 +140,13 @@ namespace std
     }
 
     ostream &
+    ostream::operator<<(size_t val)
+    {
+        char str[IOTA_MIN_BUF_SIZE];
+        return *this << itoa(val, str, m_base);
+    }
+
+    ostream &
     ostream::operator<<(ostream_modifier modifier)
     {
         switch (modifier)
@@ -148,5 +168,4 @@ namespace std
 
         return *this;
     }
-
 }

--- a/bfvmm/src/vcpu/bin/native/Makefile
+++ b/bfvmm/src/vcpu/bin/native/Makefile
@@ -19,4 +19,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+LIBRARY_PATHS := $(LIBRARY_PATHS):../../../vmm/bin/native/
+LIBRARY_PATHS := $(LIBRARY_PATHS):../../../debug_ring/bin/native/
+LIBRARY_PATHS := $(LIBRARY_PATHS):../../../memory_manager/bin/native/
+
 include ../../../../../common/common_test.mk

--- a/bfvmm/src/vcpu/src/vcpu_factory.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_factory.cpp
@@ -21,13 +21,6 @@
 
 #include <vcpu/vcpu_factory.h>
 
-vcpu_factory *
-vcpu_factory::instance()
-{
-    static vcpu_factory self;
-    return &self;
-}
-
 vcpu *
 vcpu_factory::get_vcpu(int64_t vcpuid)
 {

--- a/bfvmm/src/vcpu/test/Makefile
+++ b/bfvmm/src/vcpu/test/Makefile
@@ -58,9 +58,12 @@ SOURCES+=test_vcpu.cpp
 SOURCES+=test_vcpu_factory.cpp
 HEADERS=
 
-LIBS=vcpu
+LIBS=vcpu vmm debug_ring memory_manager
 
-LIB_PATHS=../bin/native
+LIB_PATHS+=../bin/native
+LIB_PATHS+=../../vmm/bin/native
+LIB_PATHS+=../../debug_ring/bin/native
+LIB_PATHS+=../../memory_manager/bin/native
 INCLUDE_PATHS=./ ../../../include/  ../../../../include/
 
 ################################################################################

--- a/bfvmm/src/vcpu/test/test_vcpu_factory.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_factory.cpp
@@ -25,25 +25,29 @@
 void
 vcpu_ut::test_vcpu_factory_get_vcpu_invalid_vcpuid()
 {
-    EXPECT_TRUE(vcpu_factory::instance()->get_vcpu(10000) == NULL);
+    auto vf = vcpu_factory();
+    EXPECT_TRUE(vf.get_vcpu(10000) == NULL);
 }
 
 void
 vcpu_ut::test_vcpu_factory_get_vcpu_valid_vcpuid()
 {
-    EXPECT_TRUE(vcpu_factory::instance()->get_vcpu(0) != NULL);
+    auto vf = vcpu_factory();
+    EXPECT_TRUE(vf.get_vcpu(0) != NULL);
 }
 
 void
 vcpu_ut::test_vcpu_factory_add_vcpu_invalid_vcpuid()
 {
     auto vc = vcpu(10000);
-    EXPECT_TRUE(vcpu_factory::instance()->add_vcpu(vc) == vcpu_factory_error::failure);
+    auto vf = vcpu_factory();
+    EXPECT_TRUE(vf.add_vcpu(vc) == vcpu_factory_error::failure);
 }
 
 void
 vcpu_ut::test_vcpu_factory_add_vcpu_success()
 {
     auto vc = vcpu(0);
-    EXPECT_TRUE(vcpu_factory::instance()->add_vcpu(vc) == vcpu_factory_error::success);
+    auto vf = vcpu_factory();
+    EXPECT_TRUE(vf.add_vcpu(vc) == vcpu_factory_error::success);
 }

--- a/bfvmm/src/vmm/bin/native/Makefile
+++ b/bfvmm/src/vmm/bin/native/Makefile
@@ -19,4 +19,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+LIBRARY_PATHS=../../../intrinsics/bin/native/
+
 include ../../../../../common/common_test.mk

--- a/bfvmm/src/vmm/src/vmm_intel_x64.cpp
+++ b/bfvmm/src/vmm/src/vmm_intel_x64.cpp
@@ -19,12 +19,490 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <iostream>
 #include <vmm/vmm_intel_x64.h>
 
-vmm_intel_x64::vmm_intel_x64()
+// =============================================================================
+//  Helper Structs
+// =============================================================================
+
+struct vmxon_region
 {
+    uint32_t revision_id;
+};
+
+// =============================================================================
+//  Implementation
+// =============================================================================
+
+vmm_error::type
+vmm_intel_x64::init(intrinsics *intrinsics,
+                    memory_manager *memory_manager)
+{
+    if (intrinsics == 0 || memory_manager == 0)
+        return vmm_error::failure;
+
+    // Ideally we would use dynamic_cast to get access to the intrinics
+    // for this archiecture, simply to validate that we were passed the
+    // correct class. Since the VMM does not have RTTI, we cannot use this
+    // function.
+
+    m_intrinsics = reinterpret_cast<intrinsics_intel_x64 *>(intrinsics);
+    m_memory_manager = memory_manager;
+
+    return vmm_error::success;
 }
 
-vmm_intel_x64::~vmm_intel_x64()
+vmm_error::type
+vmm_intel_x64::start()
 {
+    vmm_error::type ret;
+
+    if (m_intrinsics == 0 || m_memory_manager == 0)
+        return vmm_error::failure;
+
+    // The following process is documented in the Intel Software Developers
+    // Manual, Section 31.5 Setup VMM & Teardown.
+
+    ret = verify_cpuid_vmx_supported();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_vmx_capabilities_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = create_vmxon_region();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_ia32_vmx_cr0_fixed0_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_ia32_vmx_cr0_fixed1_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = enable_vmx_operation();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_ia32_vmx_cr4_fixed0_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_ia32_vmx_cr4_fixed1_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = verify_ia32_feature_control_msr();
+    if (ret != vmm_error::success)
+        return ret;
+
+    // The following are additional checks that are documented in the VMXON
+    // instructions itself in the Intel Software Developers Manual,
+    // Section 30.3
+
+    ret = verify_v8086_disabled();
+    if (ret != vmm_error::success)
+        return ret;
+
+    // Finally, execute the VMX on instruction to enter VMX operation.
+    // This places the host OS (code that is currently running) in VMX-root.
+    // The next step will be to launch the VMCS for the host OS, leaving only
+    // the VMM in VMX-root, and placing the host OS into VMX-nonroot.
+
+    ret = execute_vmxon();
+    if (ret != vmm_error::success)
+        return ret;
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::stop()
+{
+    vmm_error::type ret;
+
+    if (m_intrinsics == 0 || m_memory_manager == 0)
+        return vmm_error::failure;
+
+    ret = execute_vmxoff();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = disable_vmx_operation();
+    if (ret != vmm_error::success)
+        return ret;
+
+    ret = release_vmxon_region();
+    if (ret != vmm_error::success)
+        return ret;
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::create_vmxon_region()
+{
+    if (m_memory_manager->alloc_page(&m_vmxon_page) != memory_manager_error::success)
+        return vmm_error::out_of_memory;
+
+    if (m_vmxon_page.size() < vmxon_vmcs_region_size())
+    {
+        std::cout << "create_vmxon_region failed: "
+                  << "the allocated page is not large enough:" << std::endl
+                  << "    - page size: " << m_vmxon_page.size() << " "
+                  << "    - vmxon/vmcs region size: " << vmxon_vmcs_region_size()
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    if (((uintptr_t)m_vmxon_page.phys_addr() & 0x0000000000000FFF) != 0)
+    {
+        std::cout << "create_vmxon_region failed: "
+                  << "the allocated page is not page aligned:" << std::endl
+                  << "    - page phys: " << m_vmxon_page.phys_addr()
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    auto buf = (char *)m_vmxon_page.virt_addr();
+    auto reg = (vmxon_region *)m_vmxon_page.virt_addr();
+
+    // The information regading this MSR can be found in appendix A.1. For
+    // the VMX capabilities check, we need the following:
+    //
+    // - Bits 30:0 contain the 31-bit VMCS revision identifier used by the
+    //   processor. Processors that use the same VMCS revision identifier use
+    //   the same size for VMCS regions (see subsequent item on bits 44:32)
+
+    for (auto i = 0; i < m_vmxon_page.size(); i++)
+        buf[i] = 0;
+
+    reg->revision_id = m_intrinsics->read_msr(IA32_VMX_BASIC_MSR) & 0x7FFFFFFFF;
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::release_vmxon_region()
+{
+    m_memory_manager->free_page(m_vmxon_page);
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_cpuid_vmx_supported()
+{
+    auto cpuid_eax = m_intrinsics->cpuid_ecx(1);
+
+    // The CPUID instruction is huge, so we don't use macros here. For further
+    // information on how this works, see the Intel Software Developers Manual,
+    // CPUID instruction reference, table 3-19
+
+    if ((cpuid_eax & (1 << 5)) == 0)
+    {
+        std::cout << "verify_cpuid_vmx_supported failed: "
+                  << "VMX extensions not supported" << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_vmx_capabilities_msr()
+{
+    auto vmx_basic_msr = m_intrinsics->read_msr(IA32_VMX_BASIC_MSR);
+
+    // The information regading this MSR can be found in appendix A.1. For
+    // the VMX capabilities check, we need the following:
+    //
+    // - Bit 48 indicates the width of the physical addresses that may be
+    //   used for the VMXON region, each VMCS, and data structures referenced
+    //   by pointers in a VMCS (I/O bitmaps, virtual-APIC page, MSR areas for
+    //   VMX transi- tions). If the bit is 0, these addresses are limited to
+    //   the processor’s physical-address width. If the bit is 1, these
+    //   addresses are limited to 32 bits. This bit is always 0 for processors
+    //   that support Intel 64 architecture.
+    //
+    // - Bits 53:50 report the memory type that should be used for the VMCS,
+    //   for data structures referenced by pointers in the VMCS (I/O bitmaps,
+    //   virtual-APIC page, MSR areas for VMX transitions), and for the MSEG
+    //   header. If software needs to access these data structures (e.g., to
+    //   modify the contents of the MSR bitmaps), it can configure the paging
+    //   structures to map them into the linear-address space. If it does so,
+    //   it should establish mappings that use the memory type reported bits
+    //   53:50 in this MSR.3
+    //
+    //   0 = uncacheable
+    //   6 = writeback
+
+    auto physical_address_width = (vmx_basic_msr >> 48) & 0x1;
+    auto memory_type = (vmx_basic_msr >> 50) & 0xF;
+
+    if (physical_address_width != 0)
+    {
+        std::cout << "verify_vmx_capabilities_msr failed: "
+                  << "vmx capabilities MSR is reporting an unsupported physical address width: "
+                  << std::hex << physical_address_width << std::dec << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    if (memory_type != 6)
+    {
+        std::cout << "verify_vmx_capabilities_msr failed: "
+                  << "vmx capabilities MSR is reporting an unsupported memory type: "
+                  << std::hex << memory_type << std::dec << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_ia32_vmx_cr0_fixed0_msr()
+{
+    auto cr0 = m_intrinsics->read_cr0();
+    auto ia32_vmx_cr0_fixed0_msr = m_intrinsics->read_msr(IA32_VMX_CR0_FIXED0_MSR);
+
+    // The information regading this MSR can be found in appendix A.7.
+    //
+    // The IA32_VMX_CR0_FIXED0 MSR (index 486H) and IA32_VMX_CR0_FIXED1 MSR
+    // (index 487H) indicate how bits in CR0 may be set in VMX operation.
+    // They report on bits in CR0 that are allowed to be 0 and to be 1,
+    // respectively, in VMX operation. If bit X is 1 in IA32_VMX_CR0_FIXED0,
+    // then that bit of CR0 is fixed to 1 in VMX operation. Similarly, if
+    // bit X is 0 in IA32_VMX_CR0_FIXED1, then that bit of CR0 is fixed to 0
+    // in VMX operation.
+
+    if (((cr0 & ia32_vmx_cr0_fixed0_msr) & ~ia32_vmx_cr0_fixed0_msr) != 0)
+    {
+        std::cout << "verify_ia32_vmx_cr0_fixed0_msr failed: "
+                  << "cr0 incorrectly setup: "
+                  << "    - cr0: " << cr0 << " "
+                  << "    - ia32_vmx_cr0_fixed0_msr: " << ia32_vmx_cr0_fixed0_msr
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_ia32_vmx_cr0_fixed1_msr()
+{
+    auto cr0 = m_intrinsics->read_cr0();
+    auto ia32_vmx_cr0_fixed1_msr = m_intrinsics->read_msr(IA32_VMX_CR0_FIXED1_MSR);
+
+    // The information regading this MSR can be found in appendix A.7.
+    //
+    // The IA32_VMX_CR0_FIXED0 MSR (index 486H) and IA32_VMX_CR0_FIXED1 MSR
+    // (index 487H) indicate how bits in CR0 may be set in VMX operation.
+    // They report on bits in CR0 that are allowed to be 0 and to be 1,
+    // respectively, in VMX operation. If bit X is 1 in IA32_VMX_CR0_FIXED0,
+    // then that bit of CR0 is fixed to 1 in VMX operation. Similarly, if
+    // bit X is 0 in IA32_VMX_CR0_FIXED1, then that bit of CR0 is fixed to 0
+    // in VMX operation.
+
+    if (~((~cr0 & ~ia32_vmx_cr0_fixed1_msr) | ia32_vmx_cr0_fixed1_msr) != 0)
+    {
+        std::cout << "verify_ia32_vmx_cr0_fixed1_msr failed: "
+                  << "cr0 incorrectly setup: "
+                  << "    - cr0: " << cr0 << " "
+                  << "    - ia32_vmx_cr0_fixed1_msr: " << ia32_vmx_cr0_fixed1_msr
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_ia32_vmx_cr4_fixed0_msr()
+{
+    auto cr4 = m_intrinsics->read_cr4();
+    auto ia32_vmx_cr4_fixed0_msr = m_intrinsics->read_msr(IA32_VMX_CR4_FIXED0_MSR);
+
+    // The information regading this MSR can be found in appendix A.7.
+    //
+    // The IA32_VMX_CR4_FIXED0 MSR (index 488H) and IA32_VMX_CR4_FIXED1 MSR
+    // (index 489H) indicate how bits in CR4 may be set in VMX operation.
+    // They report on bits in CR4 that are allowed to be 0 and 1,
+    // respectively, in VMX operation. If bit X is 1 in IA32_VMX_CR4_FIXED0,
+    // then that bit of CR4 is fixed to 1 in VMX operation. Similarly, if
+    // bit X is 0 in IA32_VMX_CR4_FIXED1, then that bit of CR4 is fixed to 0
+    // in VMX operation.
+
+    if (((cr4 & ia32_vmx_cr4_fixed0_msr) & ~ia32_vmx_cr4_fixed0_msr) != 0)
+    {
+        std::cout << "verify_ia32_vmx_cr4_fixed0_msr failed: "
+                  << "cr4 incorrectly setup: "
+                  << "    - cr4: " << cr4 << " "
+                  << "    - ia32_vmx_cr4_fixed0_msr: " << ia32_vmx_cr4_fixed0_msr
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_ia32_vmx_cr4_fixed1_msr()
+{
+    auto cr4 = m_intrinsics->read_cr4();
+    auto ia32_vmx_cr4_fixed1_msr = m_intrinsics->read_msr(IA32_VMX_CR4_FIXED1_MSR);
+
+    // The information regading this MSR can be found in appendix A.7.
+    //
+    // The IA32_VMX_CR4_FIXED0 MSR (index 488H) and IA32_VMX_CR4_FIXED1 MSR
+    // (index 489H) indicate how bits in CR4 may be set in VMX operation.
+    // They report on bits in CR4 that are allowed to be 0 and 1,
+    // respectively, in VMX operation. If bit X is 1 in IA32_VMX_CR4_FIXED0,
+    // then that bit of CR4 is fixed to 1 in VMX operation. Similarly, if
+    // bit X is 0 in IA32_VMX_CR4_FIXED1, then that bit of CR4 is fixed to 0
+    // in VMX operation.
+
+    if (~((~cr4 & ~ia32_vmx_cr4_fixed1_msr) | ia32_vmx_cr4_fixed1_msr) != 0)
+    {
+        std::cout << "verify_ia32_vmx_cr4_fixed1_msr failed: "
+                  << "cr4 incorrectly setup: "
+                  << "    - cr4: " << cr4 << " "
+                  << "    - ia32_vmx_cr4_fixed1_msr: " << ia32_vmx_cr4_fixed1_msr
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_ia32_feature_control_msr()
+{
+    auto ia32_feature_control = m_intrinsics->read_msr(IA32_FEATURE_CONTROL);
+
+    if (ia32_feature_control & (1 << 0) == 0)
+    {
+        std::cout << "verify_ia32_feature_control_msr failed: "
+                  << "feature control MSR is reporting the lock bit is not set: "
+                  << std::hex << "0x" << ia32_feature_control << std::dec
+                  << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::verify_v8086_disabled()
+{
+    auto rflags = m_intrinsics->read_rflags();
+
+    if ((rflags & RFLAGS_VM_VIRTUAL_8086_MODE) != 0)
+    {
+        std::cout << "verify_v8086_disabled failed: "
+                  << "v8086 is currently enabled" << std::endl;
+        return vmm_error::not_supported;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::enable_vmx_operation()
+{
+    m_intrinsics->write_cr4(m_intrinsics->read_cr4() | CR4_VMXE_VMX_ENABLE_BIT);
+
+    if (m_intrinsics->read_cr4() & CR4_VMXE_VMX_ENABLE_BIT == 0)
+    {
+        std::cout << "enable_vmx_operation failed: "
+                  << "failed to set CR4_VMXE_VMX_ENABLE_BIT:" << std::endl;
+        return vmm_error::failure;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::disable_vmx_operation()
+{
+    m_intrinsics->write_cr4(m_intrinsics->read_cr4() & ~CR4_VMXE_VMX_ENABLE_BIT);
+
+    if (m_intrinsics->read_cr4() & CR4_VMXE_VMX_ENABLE_BIT != 0)
+    {
+        std::cout << "disable_vmx_operation failed: "
+                  << "failed to clear CR4_VMXE_VMX_ENABLE_BIT:" << std::endl;
+        return vmm_error::failure;
+    }
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::execute_vmxon()
+{
+    auto phys = m_vmxon_page.phys_addr();
+
+    // For some reason, the VMXON instruction takes the address of a memory
+    // location that has the address of the VMXON region, which sadly is not
+    // well documented in the Intel manual.
+
+    if (m_intrinsics->vmxon(&phys) == false)
+    {
+        std::cout << "execute_vmxon failed" << std::endl;
+        return vmm_error::failure;
+    }
+
+    std::cout << "vmxon: success" << std::endl;
+
+    return vmm_error::success;
+}
+
+vmm_error::type
+vmm_intel_x64::execute_vmxoff()
+{
+    // If the VMX enable bit was not already set, there is not need for use
+    // to execute the VMXOFF instruction.
+    if (m_intrinsics->read_cr4() & CR4_VMXE_VMX_ENABLE_BIT == 0)
+        return vmm_error::failure;
+
+    // The VMXOFF instruction requires that the CPU be in VMX root operation.
+    // If it is not, you can get an underfined intrustion error (or invalid
+    // opcode). If we are not in VMX root operation it means that VMXON was not
+    // run, was not successful, or was run on a different CPU that the one we
+    // are running VMXOFF on.
+
+    if (m_intrinsics->vmxoff() == false)
+    {
+        std::cout << "execute_vmxoff failed" << std::endl;
+        return vmm_error::failure;
+    }
+
+    std::cout << "vmxoff: success" << std::endl;
+
+    return vmm_error::success;
+}
+
+uint64_t
+vmm_intel_x64::vmxon_vmcs_region_size()
+{
+    auto vmx_basic_msr = m_intrinsics->read_msr(IA32_VMX_BASIC_MSR);
+
+    // The information regading this MSR can be found in appendix A.1. For
+    // the VMX capabilities check, we need the following:
+    //
+    // - Bits 44:32 report the number of bytes that software should allocate
+    //   for the VMXON region and any VMCS region. It is a value greater
+    //   than 0 and at most 4096 (bit 44 is set if and only if bits 43:32 are
+    //   clear).
+    //
+    //   Note: We basically ignore the above bits and just allocate 4K for each
+    //   VMX region. The only thing we do with this function is ensure that
+    //   the page that we were given is at least this big
+
+
+    return (vmx_basic_msr >> 32) & 0x1FFF;
 }

--- a/bfvmm/src/vmm/test/Makefile
+++ b/bfvmm/src/vmm/test/Makefile
@@ -57,9 +57,9 @@ SOURCES+=test.cpp
 SOURCES+=test_vmm.cpp
 HEADERS=
 
-LIBS=vmm
+LIBS=vmm intrinsics
 
-LIB_PATHS=../bin/native
+LIB_PATHS=../bin/native ../../intrinsics/bin/native/
 INCLUDE_PATHS=./ ../../../include/  ../../../../include/
 
 ################################################################################

--- a/bfvmm/src/vmm/test/test.cpp
+++ b/bfvmm/src/vmm/test/test.cpp
@@ -40,6 +40,8 @@ vmm_ut::fini()
 bool
 vmm_ut::list()
 {
+    this->test_check_support_v8086_enabled();
+
     return true;
 }
 

--- a/bfvmm/src/vmm/test/test.h
+++ b/bfvmm/src/vmm/test/test.h
@@ -38,6 +38,25 @@ protected:
     bool list() override;
 
 private:
+
+    void test_check_support_v8086_enabled();
+    // void test_check_support_long_mode_inactive();
+    // void test_check_support_long_mode_active_not_in_compatibility_mode();
+    // void test_check_support_cr0_protected_mode_disabled();
+    // void test_check_support_cr0_paging_disabled();
+    // void test_check_support_cr0_numeric_error_disabled();
+    // void test_check_support_cr0_vmx_extensions_disabled();
+    // void test_check_support_unsupported_cpuid_vmx();
+    // void test_check_support_ia32_vmx_cr0_fixed0_failed();
+    // void test_check_support_ia32_vmx_cr0_fixed1_failed();
+    // void test_check_support_unsupported_physical_address_width();
+    // void test_check_support_unsupported_memory_type();
+    // void test_check_support_ia32_vmx_cr4_fixed0_failed();
+    // void test_check_support_ia32_vmx_cr4_fixed1_failed();
+    // void test_check_support_();
+    // void test_check_support_();
+    // void test_check_support_();
 };
+
 
 #endif

--- a/bfvmm/src/vmm/test/test_vmm.cpp
+++ b/bfvmm/src/vmm/test/test_vmm.cpp
@@ -20,3 +20,20 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <test.h>
+#include <vmm/vmm_intel_x64.h>
+
+void
+vmm_ut::test_check_support_v8086_enabled()
+{
+    // MockRepository mocks;
+    // intrinsics_intel_x64 *intrinsics = mocks.Mock<intrinsics_intel_x64>();
+
+    // mocks.OnCall(intrinsics, intrinsics_intel_x64::read_rflags).Return(5);
+
+    // RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    // {
+    //     vmm_intel_x64::instance().init(intrinsics);
+
+    //     EXPECT_TRUE(vmm_intel_x64::instance().start() == vmm_error::success);
+    // });
+}

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -146,12 +146,11 @@ endif
 
 ifeq ($(TARGET_TYPE),bin)
 	ifeq ($(TARGET_CROSS_COMPILED),true)
-		CROSS_LDFLAGS+=-Wl,--unresolved-symbols=ignore-in-shared-libs
 		CROSS_LD_OPTION=-o
 		CROSS_TARGET=$(patsubst %,$(CROSS_OUTDIR)/%$(CROSS_BIN_EXT),$(TARGET_NAME))
 	endif
 	ifeq ($(TARGET_NATIVE_COMPILED),true)
-		LDFLAGS+=-Wl,--unresolved-symbols=ignore-in-shared-libs
+		LDFLAGS+=-Wl,--unresolved-symbols=ignore-all
 		LD_OPTION=-o
 		TARGET=$(patsubst %,$(OUTDIR)/%$(BIN_EXT),$(TARGET_NAME))
 	endif

--- a/driver_entry/src/arch/linux/platform.c
+++ b/driver_entry/src/arch/linux/platform.c
@@ -23,6 +23,7 @@
 #include <platform.h>
 
 #include <debug.h>
+#include <linux/slab.h>
 #include <linux/module.h>
 #include <linux/vmalloc.h>
 
@@ -75,7 +76,7 @@ platform_alloc_page(void)
 {
     struct page_t pg = {0};
 
-    pg.virt = (void *)__get_free_page(GFP_KERNEL);
+    pg.virt = kmalloc(PAGE_SIZE, GFP_KERNEL);
     pg.phys = (void *)virt_to_phys(pg.virt);
     pg.size = PAGE_SIZE;
 
@@ -112,5 +113,5 @@ platform_free_page(struct page_t pg)
     if (pg.virt == 0)
         return;
 
-    free_page((unsigned long)pg.virt);
+    kfree(pg.virt);
 }

--- a/driver_entry/src/common.c
+++ b/driver_entry/src/common.c
@@ -424,12 +424,12 @@ common_dump_vmm(void)
     if (debug_ring_read(g_drr, rb, DEBUG_RING_SIZE) < 0)
         ALERT("dump_vmm: failed to read debug ring\n");
 
-    INFO("\n");
-    INFO("VMM DUMP:\n");
-    INFO("============================================================\n");
-    INFO("\n%s\n", rb);
-    INFO("============================================================\n");
-    INFO("\n");
+    DEBUG("\n");
+    DEBUG("VMM DUMP:\n");
+    DEBUG("===========================================================\n"
+          "\n%s\n", rb);
+    DEBUG("===========================================================\n");
+    DEBUG("\n");
 
     if (rb != 0)
         platform_free(rb);

--- a/include/vmm_entry.h
+++ b/include/vmm_entry.h
@@ -33,9 +33,12 @@
 #define VMM_SUCCESS 0
 #define VMM_ERROR_UNKNOWN ((void *)-1)
 #define VMM_ERROR_INVALID_ARG ((void *)-2)
-#define VMM_ERROR_DEBUG_RING_INIT_FAILED ((void *)-3)
-#define VMM_ERROR_MEMORY_MANAGER_FAILED ((void *)-4)
-#define VMM_ERROR_INVALID_PAGES ((void *)-5)
+#define VMM_ERROR_INVALID_PAGES ((void *)-3)
+#define VMM_ERROR_INVALID_ENTRY_FACTORY ((void *)-4)
+#define VMM_ERROR_INVALID_DRR ((void *)-5)
+#define VMM_ERROR_VMM_INIT_FAILED ((void *)-10)
+#define VMM_ERROR_VMM_START_FAILED ((void *)-20)
+#define VMM_ERROR_VMM_STOP_FAILED ((void *)-30)
 
 /**
  * Entry Point


### PR DESCRIPTION
This patch contains support for VMXON. A couple of notes include:
- With this patch, when you run ./bfm start vmm.modules you will
  enable VMXON and if you run ./bfm stop, you will disable VMXON
- There was a great deal of rework to remove the need for global
  objects while still maintaining seems for unit testing.
- There are no unit tests for the entry code, or VMM code.
  This code will be coming soon.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>