### PR TITLE
GCC No Red Zone Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,14 @@ before_install:
 - export SILENCE="defined"
 - export BINUTILS_PATH="http://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2"
 - if [ "$GCC_BASE" = "520" ]; then export GCC_PATH="https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2";  fi
+- if [ "$GCC_BASE" = "520" ]; then export GCC_PATCH="https://raw.githubusercontent.com/Bareflank/hypervisor/master/tools/patches/gcc-5.2.0_no-red-zone.patch";  fi
 - if [ "$GCC_BASE" = "530" ]; then export GCC_PATH="https://ftp.gnu.org/gnu/gcc/gcc-5.3.0/gcc-5.3.0.tar.bz2";  fi
+- if [ "$GCC_BASE" = "530" ]; then export GCC_PATCH="https://raw.githubusercontent.com/Bareflank/hypervisor/master/tools/patches/gcc-5.3.0_no-red-zone.patch";  fi
 
 install:
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get update
-- sudo apt-get install g++-5 nasm
+- sudo apt-get install g++-5 nasm --force-yes
 - sudo rm /usr/bin/gcc
 - sudo rm /usr/bin/g++
 - sudo ln -s /usr/bin/gcc-5 /usr/bin/gcc

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -255,6 +255,7 @@ NATIVE_CXXFLAGS+=$(addprefix -I, $(strip $(NATIVE_INCLUDE_PATHS)))
 ifeq ($(TARGET_CROSS_COMPILED), true)
 	CROSS_LIBRARY_PATHS+=$(LIBRARY_PATHS)
 	CROSS_LIBRARY_PATHS+=$(VMM_LIBRARY_PATHS)
+	CROSS_LIBRARY_PATHS+=$(dir $(shell $(CROSS_CC) -mno-red-zone -print-libgcc-file-name))
 endif
 
 ifeq ($(TARGET_NATIVE_COMPILED), true)
@@ -279,6 +280,7 @@ CROSS_LDFLAGS+=$(addprefix -L, $(strip $(CROSS_LIBRARY_PATHS)))
 ifeq ($(TARGET_CROSS_COMPILED), true)
 	CROSS_LIBS+=$(LIBS)
 	CROSS_LIBS+=$(VMM_LIBS)
+	CROSS_LIBS+=gcc
 endif
 
 ifeq ($(TARGET_NATIVE_COMPILED), true)

--- a/tools/scripts/debian-cross-compiler.sh
+++ b/tools/scripts/debian-cross-compiler.sh
@@ -1,11 +1,17 @@
 #!/bin/bash
 
+set -e
+
 if [ -z "$BINUTILS_PATH" ]; then
     export BINUTILS_PATH="http://ftp.gnu.org/gnu/binutils/binutils-2.25.1.tar.bz2"
 fi
 
 if [ -z "$GCC_PATH" ]; then
     export GCC_PATH="https://ftp.gnu.org/gnu/gcc/gcc-5.2.0/gcc-5.2.0.tar.bz2"
+fi
+
+if [ -z "$GCC_PATCH" ]; then
+    export GCC_PATCH="https://raw.githubusercontent.com/Bareflank/hypervisor/master/tools/patches/gcc-5.2.0_no-red-zone.patch"
 fi
 
 if [ -z "$NASM_PATH" ]; then
@@ -28,9 +34,9 @@ rm -Rf $TMPDIR
 mkdir -p $TMPDIR
 
 pushd $TMPDIR
-
 wget $BINUTILS_PATH
 wget $GCC_PATH
+wget $GCC_PATCH
 wget $NASM_PATH
 
 tar xvf binutils-*.tar.bz2
@@ -39,6 +45,11 @@ tar xvf nasm-*.tar.gz
 
 mkdir build-binutils
 mkdir build-gcc
+popd
+
+pushd $TMPDIR/gcc-*
+patch -p1 < ../gcc-*_no-red-zone.patch
+popd
 
 pushd $TMPDIR/build-binutils
 ../binutils-*/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
@@ -60,5 +71,4 @@ make -j2
 make install
 popd
 
-popd
 rm -Rf $TMPDIR


### PR DESCRIPTION
The following patch provides support for libgcc with no red zone.
We need libgcc to support C++, but we need to make sure that
everything we use is compiled with red zone turned off, include
GCC support libraries.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>