### PR TITLE
VMCS Exception Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,10 @@ status: force
 	cd bfm/bin/native; \
 	sudo ./run.sh status
 
+quick: force
+	$(MAKE) load; \
+	$(MAKE) start
+
 loop: force
 	@for n in $(shell seq 1 $(NUM)); do \
 		echo $(CS_M)"cycle: $$n"$(CE); \

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,12 @@ Version 1.1 TODO:
   can be customized.
 - Need to rename the VCPU logic as it's really specific to Intel.
 - Add Windows support
+- Once we have our own GDT/IDT, part of the "promote" process needs to restore
+  the GDT/IDT which is not being done. The segment registers are swapped, but
+  we are not doing a sgdt or sidt to swap these.
+- CS, SS and TR need to be restored properly when promoting. This will be
+  really important once a new GDT is used in the host.
+- Provide APIs within the VMCS for setting / clearing traps to MSRs and IO
 
 Version 2.0 TODO:
 - Type 1 and Type 2 support

--- a/bfvmm/include/debug.h
+++ b/bfvmm/include/debug.h
@@ -38,6 +38,6 @@
 #define bfdebug std::cout << bfcolor_debug << "DEBUG" << bfcolor_end << ": "
 #define bfwarning std::cout << bfverbose << bfcolor_warning << "WARNING" << bfcolor_end << ": "
 #define bferror std::cout << bfcolor_error << "ERROR" << bfcolor_end << ": "
-#define bffatal std::cout << bfcolor_error << "ERROR" << bfcolor_end << ": "
+#define bffatal std::cout << bfcolor_error << "FATAL ERROR" << bfcolor_end << ": "
 
 #endif

--- a/bfvmm/include/intrinsics/intrinsics_intel_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_intel_x64.h
@@ -107,14 +107,22 @@ public:
 #define IA32_VMX_CR4_FIXED0_MSR                                   0x00000488
 #define IA32_VMX_CR4_FIXED1_MSR                                   0x00000489
 #define IA32_FEATURE_CONTROL_MSR                                  0x0000003A
-#define IA32_VMX_PINBASED_CTLS_MSR                                0x00000481
-#define IA32_VMX_PROCBASED_CTLS_MSR                               0x00000482
-#define IA32_VMX_EXIT_CTLS_MSR                                    0x00000483
-#define IA32_VMX_ENTRY_CTLS_MSR                                   0x00000484
 #define IA32_VMX_TRUE_PINBASED_CTLS_MSR                           0x0000048D
 #define IA32_VMX_TRUE_PROCBASED_CTLS_MSR                          0x0000048E
 #define IA32_VMX_TRUE_EXIT_CTLS_MSR                               0x0000048F
 #define IA32_VMX_TRUE_ENTRY_CTLS_MSR                              0x00000490
+
+#ifdef USE_INTEL_X64_LEGACY_CTLS
+#define IA32_VMX_PINBASED_CTLS_MSR                                0x00000481
+#define IA32_VMX_PROCBASED_CTLS_MSR                               0x00000482
+#define IA32_VMX_EXIT_CTLS_MSR                                    0x00000483
+#define IA32_VMX_ENTRY_CTLS_MSR                                   0x00000484
+#else
+#define IA32_VMX_PINBASED_CTLS_MSR IA32_VMX_TRUE_PINBASED_CTLS_MSR
+#define IA32_VMX_PROCBASED_CTLS_MSR IA32_VMX_TRUE_PROCBASED_CTLS_MSR
+#define IA32_VMX_EXIT_CTLS_MSR IA32_VMX_TRUE_EXIT_CTLS_MSR
+#define IA32_VMX_ENTRY_CTLS_MSR IA32_VMX_TRUE_ENTRY_CTLS_MSR
+#endif
 
 // The VMCS fields are defined in the intel's software developer's manual,
 // volumn 3, appendix B. An explaination of these fields can be found in

--- a/bfvmm/include/intrinsics/intrinsics_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_x64.h
@@ -67,6 +67,7 @@ uint16_t __read_es(void);
 void __write_es(uint16_t val);
 
 uint16_t __read_cs(void);
+void __write_cs(uint16_t val);
 
 uint16_t __read_ss(void);
 void __write_ss(uint16_t val);
@@ -192,6 +193,9 @@ public:
 
     virtual uint16_t read_cs()
     { return __read_cs(); }
+
+    virtual void write_cs(uint16_t val)
+    { __write_cs(val); }
 
     virtual uint16_t read_ss()
     { return __read_ss(); }

--- a/bfvmm/include/vmcs/bitmap.h
+++ b/bfvmm/include/vmcs/bitmap.h
@@ -19,8 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef BITMAP__H
-#define BITMAP__H
+#ifndef BITMAP_H
+#define BITMAP_H
 
 #include <stdint.h>
 #include <memory>
@@ -28,7 +28,9 @@
 class bitmap
 {
 public:
+
     /// Constructor
+    ///
     /// @param num_bits size of the bitmap in bits
     ///
     bitmap(uint32_t num_bits);
@@ -37,31 +39,44 @@ public:
     ///
     virtual ~bitmap() {}
 
-    /// address
-    /// @return the virtual address of the beginning
-    ///         of the bitmap
+    /// Virtual Address
     ///
-    uint8_t *address();
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t virt_addr() const noexcept
+    { return m_virt_addr; }
 
-    /// set_bit
+    /// Physical Address
+    ///
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t phys_addr() const noexcept
+    { return m_phys_addr; }
+
+    /// Set Bit
+    ///
     /// @param n nth bit to set in the bitmap
     ///
-    void set_bit(uint32_t n);
+    void set_bit(uint32_t n) noexcept;
 
-    /// reset_bit
+    /// Reset Bit
+    ///
     /// @param n nth bit to clear in the bitmap
     ///
-    void clear_bit(uint32_t n);
+    void clear_bit(uint32_t n) noexcept;
 
-    /// bit
+    /// Get Bit
+    ///
     /// @param n nth bit's status to return
     /// @return true if the bit is set, false otherwise
     ///
-    bool bit(uint32_t n);
+    bool bit(uint32_t n) const noexcept;
 
 private:
-    std::unique_ptr<uint8_t[]> m_bitmap;
     uint32_t m_length;
+    uint64_t m_virt_addr;
+    uint64_t m_phys_addr;
+    std::unique_ptr<uint8_t[]> m_bitmap;
 };
 
-#endif // BITMAP__H
+#endif

--- a/bfvmm/include/vmcs/vmcs_exceptions_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_exceptions_intel_x64.h
@@ -1,0 +1,185 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_EXCEPTIONS_INTEL_X64_H
+#define VMCS_EXCEPTIONS_INTEL_X64_H
+
+#include <exception.h>
+
+namespace bfn
+{
+
+// -----------------------------------------------------------------------------
+// VMCS Invalid
+// -----------------------------------------------------------------------------
+
+class invalid_vmcs_error : public bfn::general_exception
+{
+public:
+    virtual std::ostream &print(std::ostream &os) const
+    { return os << "invalid vmcs"; }
+};
+
+#define invalid_vmcs() bfn::invalid_vmcs_error()
+
+// -----------------------------------------------------------------------------
+// VMCS Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_failure_error(const std::string &msg,
+                       const std::string &func,
+                       uint64_t line) :
+        m_msg(msg),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs failure:";
+        os << std::endl << "    - reason: " << m_msg;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    std::string m_msg;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_failure(a) \
+    bfn::vmcs_failure_error(a,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Read Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_read_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_read_failure_error(uint64_t field,
+                            const std::string &func,
+                            uint64_t line) :
+        m_field(field),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs read failure:";
+        os << std::endl << "    - field: " << (void *)m_field;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    uint64_t m_field;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_read_failure(a) \
+    bfn::vmcs_read_failure_error(a,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Write Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_write_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_write_failure_error(uint64_t field,
+                             uint64_t value,
+                             const std::string &func,
+                             uint64_t line) :
+        m_field(field),
+        m_value(value),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs write failure:";
+        os << std::endl << "    - field: " << (void *)m_field;
+        os << std::endl << "    - value: " << (void *)m_value;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    uint64_t m_field;
+    uint64_t m_value;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_write_failure(a,b) \
+    bfn::vmcs_write_failure_error(a,b,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Launch Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_launch_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_launch_failure_error(const std::string &msg,
+                              const std::string &func,
+                              uint64_t line) :
+        m_msg(msg),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs launch failure:";
+        os << std::endl << "    - reason: " << m_msg;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    std::string m_msg;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_launch_failure(a) \
+    bfn::vmcs_launch_failure_error(a,__func__,__LINE__)
+
+}
+
+#endif

--- a/bfvmm/include/vmcs/vmcs_state_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_state_intel_x64.h
@@ -1,0 +1,524 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_STATE_INTEL_X64_H
+#define VMCS_STATE_INTEL_X64_H
+
+#include <intrinsics/intrinsics_intel_x64.h>
+
+class vmcs_state_intel_x64
+{
+public:
+
+    vmcs_state_intel_x64() :
+        m_es(0),
+        m_cs(0),
+        m_ss(0),
+        m_ds(0),
+        m_fs(0),
+        m_gs(0),
+        m_tr(0),
+        m_cr0(0),
+        m_cr3(0),
+        m_cr4(0),
+        m_dr7(0),
+        m_rflags(0),
+        m_gdt_reg{},
+        m_idt_reg{},
+        m_es_limit(0),
+        m_cs_limit(0),
+        m_ss_limit(0),
+        m_ds_limit(0),
+        m_fs_limit(0),
+        m_gs_limit(0),
+        m_tr_limit(0),
+        m_es_access(0),
+        m_cs_access(0),
+        m_ss_access(0),
+        m_ds_access(0),
+        m_fs_access(0),
+        m_gs_access(0),
+        m_tr_access(0),
+        m_es_base(0),
+        m_cs_base(0),
+        m_ss_base(0),
+        m_ds_base(0),
+        m_fs_base(0),
+        m_gs_base(0),
+        m_tr_base(0),
+        m_ia32_debugctl_msr(0),
+        m_ia32_efer_msr(0),
+        m_ia32_pat_msr(0),
+        m_ia32_vmx_pinbased_ctls_msr(0),
+        m_ia32_vmx_procbased_ctls_msr(0),
+        m_ia32_vmx_exit_ctls_msr(0),
+        m_ia32_vmx_entry_ctls_msr(0),
+        m_ia32_sysenter_cs_msr(0),
+        m_ia32_sysenter_esp_msr(0),
+        m_ia32_sysenter_eip_msr(0),
+        m_ia32_fs_base_msr(0),
+        m_ia32_gs_base_msr(0)
+    {}
+
+    vmcs_state_intel_x64(intrinsics_intel_x64 *intrinsics) :
+        m_es(0),
+        m_cs(0),
+        m_ss(0),
+        m_ds(0),
+        m_fs(0),
+        m_gs(0),
+        m_tr(0),
+        m_cr0(0),
+        m_cr3(0),
+        m_cr4(0),
+        m_dr7(0),
+        m_rflags(0),
+        m_gdt_reg{},
+        m_idt_reg{},
+        m_es_limit(0),
+        m_cs_limit(0),
+        m_ss_limit(0),
+        m_ds_limit(0),
+        m_fs_limit(0),
+        m_gs_limit(0),
+        m_tr_limit(0),
+        m_es_access(0),
+        m_cs_access(0),
+        m_ss_access(0),
+        m_ds_access(0),
+        m_fs_access(0),
+        m_gs_access(0),
+        m_tr_access(0),
+        m_es_base(0),
+        m_cs_base(0),
+        m_ss_base(0),
+        m_ds_base(0),
+        m_fs_base(0),
+        m_gs_base(0),
+        m_tr_base(0),
+        m_ia32_debugctl_msr(0),
+        m_ia32_efer_msr(0),
+        m_ia32_pat_msr(0),
+        m_ia32_vmx_pinbased_ctls_msr(0),
+        m_ia32_vmx_procbased_ctls_msr(0),
+        m_ia32_vmx_exit_ctls_msr(0),
+        m_ia32_vmx_entry_ctls_msr(0),
+        m_ia32_sysenter_cs_msr(0),
+        m_ia32_sysenter_esp_msr(0),
+        m_ia32_sysenter_eip_msr(0),
+        m_ia32_fs_base_msr(0),
+        m_ia32_gs_base_msr(0)
+    {
+        m_es = intrinsics->read_es();
+        m_cs = intrinsics->read_cs();
+        m_ss = intrinsics->read_ss();
+        m_ds = intrinsics->read_ds();
+        m_fs = intrinsics->read_fs();
+        m_gs = intrinsics->read_gs();
+        m_tr = intrinsics->read_tr();
+
+        m_cr0 = intrinsics->read_cr0();
+        m_cr3 = intrinsics->read_cr3();
+        m_cr4 = intrinsics->read_cr4();
+        m_dr7 = intrinsics->read_dr7();
+
+        m_rflags = intrinsics->read_rflags();
+
+        intrinsics->read_gdt(&m_gdt_reg);
+        intrinsics->read_idt(&m_idt_reg);
+
+        m_es_limit = intrinsics->segment_descriptor_limit(m_es);
+        m_cs_limit = intrinsics->segment_descriptor_limit(m_cs);
+        m_ss_limit = intrinsics->segment_descriptor_limit(m_ss);
+        m_ds_limit = intrinsics->segment_descriptor_limit(m_ds);
+        m_fs_limit = intrinsics->segment_descriptor_limit(m_fs);
+        m_gs_limit = intrinsics->segment_descriptor_limit(m_gs);
+        m_tr_limit = intrinsics->segment_descriptor_limit(m_tr);
+
+        m_es_access = intrinsics->segment_descriptor_access(m_es);
+        m_cs_access = intrinsics->segment_descriptor_access(m_cs);
+        m_ss_access = intrinsics->segment_descriptor_access(m_ss);
+        m_ds_access = intrinsics->segment_descriptor_access(m_ds);
+        m_fs_access = intrinsics->segment_descriptor_access(m_fs);
+        m_gs_access = intrinsics->segment_descriptor_access(m_gs);
+        m_tr_access = intrinsics->segment_descriptor_access(m_tr);
+
+        m_es_base = intrinsics->segment_descriptor_base(m_es);
+        m_cs_base = intrinsics->segment_descriptor_base(m_cs);
+        m_ss_base = intrinsics->segment_descriptor_base(m_ss);
+        m_ds_base = intrinsics->segment_descriptor_base(m_ds);
+        m_fs_base = intrinsics->segment_descriptor_base(m_fs);
+        m_gs_base = intrinsics->segment_descriptor_base(m_gs);
+        m_tr_base = intrinsics->segment_descriptor_base(m_tr);
+
+        m_ia32_debugctl_msr = intrinsics->read_msr(IA32_DEBUGCTL_MSR);
+        m_ia32_efer_msr = intrinsics->read_msr(IA32_EFER_MSR);
+        m_ia32_pat_msr = intrinsics->read_msr(IA32_PAT_MSR);
+        m_ia32_sysenter_cs_msr = intrinsics->read_msr32(IA32_SYSENTER_CS_MSR);
+        m_ia32_sysenter_esp_msr = intrinsics->read_msr32(IA32_SYSENTER_ESP_MSR);
+        m_ia32_sysenter_eip_msr = intrinsics->read_msr32(IA32_SYSENTER_EIP_MSR);
+        m_ia32_fs_base_msr = intrinsics->read_msr(IA32_FS_BASE_MSR);
+        m_ia32_gs_base_msr = intrinsics->read_msr(IA32_GS_BASE_MSR);
+    }
+
+    ~vmcs_state_intel_x64() {}
+
+    uint16_t es() const
+    { return m_es; }
+
+    uint16_t cs() const
+    { return m_cs; }
+
+    uint16_t ss() const
+    { return m_ss; }
+
+    uint16_t ds() const
+    { return m_ds; }
+
+    uint16_t fs() const
+    { return m_fs; }
+
+    uint16_t gs() const
+    { return m_gs; }
+
+    uint16_t tr() const
+    { return m_tr; }
+
+    void set_es(uint16_t val)
+    { m_es = val; }
+
+    void set_cs(uint16_t val)
+    { m_cs = val; }
+
+    void set_ss(uint16_t val)
+    { m_ss = val; }
+
+    void set_ds(uint16_t val)
+    { m_ds = val; }
+
+    void set_fs(uint16_t val)
+    { m_fs = val; }
+
+    void set_gs(uint16_t val)
+    { m_gs = val; }
+
+    void set_tr(uint16_t val)
+    { m_tr = val; }
+
+    uint64_t cr0() const
+    { return m_cr0; }
+
+    uint64_t cr3() const
+    { return m_cr3; }
+
+    uint64_t cr4() const
+    { return m_cr4; }
+
+    uint64_t dr7() const
+    { return m_dr7; }
+
+    void set_cr0(uint64_t val)
+    { m_cr0 = val; }
+
+    void set_cr3(uint64_t val)
+    { m_cr3 = val; }
+
+    void set_cr4(uint64_t val)
+    { m_cr4 = val; }
+
+    void set_dr7(uint64_t val)
+    { m_dr7 = val; }
+
+    uint64_t rflags() const
+    { return m_rflags; }
+
+    void set_rflags(uint64_t val)
+    { m_rflags = val; }
+
+    gdt_t gdt() const
+    { return m_gdt_reg; }
+
+    idt_t idt() const
+    { return m_idt_reg; }
+
+    void set_gdt(gdt_t val)
+    { m_gdt_reg = val; }
+
+    void set_idt(idt_t val)
+    { m_idt_reg = val; }
+
+    uint32_t es_limit() const
+    { return m_es_limit; }
+
+    uint32_t cs_limit() const
+    { return m_cs_limit; }
+
+    uint32_t ss_limit() const
+    { return m_ss_limit; }
+
+    uint32_t ds_limit() const
+    { return m_ds_limit; }
+
+    uint32_t fs_limit() const
+    { return m_fs_limit; }
+
+    uint32_t gs_limit() const
+    { return m_gs_limit; }
+
+    uint32_t tr_limit() const
+    { return m_tr_limit; }
+
+    void set_es_limit(uint32_t val)
+    { m_es_limit = val; }
+
+    void set_cs_limit(uint32_t val)
+    { m_cs_limit = val; }
+
+    void set_ss_limit(uint32_t val)
+    { m_ss_limit = val; }
+
+    void set_ds_limit(uint32_t val)
+    { m_ds_limit = val; }
+
+    void set_fs_limit(uint32_t val)
+    { m_fs_limit = val; }
+
+    void set_gs_limit(uint32_t val)
+    { m_gs_limit = val; }
+
+    void set_tr_limit(uint32_t val)
+    { m_tr_limit = val; }
+
+    uint32_t es_access() const
+    { return m_es_access; }
+
+    uint32_t cs_access() const
+    { return m_cs_access; }
+
+    uint32_t ss_access() const
+    { return m_ss_access; }
+
+    uint32_t ds_access() const
+    { return m_ds_access; }
+
+    uint32_t fs_access() const
+    { return m_fs_access; }
+
+    uint32_t gs_access() const
+    { return m_gs_access; }
+
+    uint32_t tr_access() const
+    { return m_tr_access; }
+
+    void set_es_access(uint32_t val)
+    { m_es_access = val; }
+
+    void set_cs_access(uint32_t val)
+    { m_cs_access = val; }
+
+    void set_ss_access(uint32_t val)
+    { m_ss_access = val; }
+
+    void set_ds_access(uint32_t val)
+    { m_ds_access = val; }
+
+    void set_fs_access(uint32_t val)
+    { m_fs_access = val; }
+
+    void set_gs_access(uint32_t val)
+    { m_gs_access = val; }
+
+    void set_tr_access(uint32_t val)
+    { m_tr_access = val; }
+
+    uint64_t es_base() const
+    { return m_es_base; }
+
+    uint64_t cs_base() const
+    { return m_cs_base; }
+
+    uint64_t ss_base() const
+    { return m_ss_base; }
+
+    uint64_t ds_base() const
+    { return m_ds_base; }
+
+    uint64_t fs_base() const
+    { return m_fs_base; }
+
+    uint64_t gs_base() const
+    { return m_gs_base; }
+
+    uint64_t tr_base() const
+    { return m_tr_base; }
+
+    void set_es_base(uint64_t val)
+    { m_es_base = val; }
+
+    void set_cs_base(uint64_t val)
+    { m_cs_base = val; }
+
+    void set_ss_base(uint64_t val)
+    { m_ss_base = val; }
+
+    void set_ds_base(uint64_t val)
+    { m_ds_base = val; }
+
+    void set_fs_base(uint64_t val)
+    { m_fs_base = val; }
+
+    void set_gs_base(uint64_t val)
+    { m_gs_base = val; }
+
+    void set_tr_base(uint64_t val)
+    { m_tr_base = val; }
+
+    uint64_t ia32_debugctl_msr() const
+    { return m_ia32_debugctl_msr; }
+
+    uint64_t ia32_efer_msr() const
+    { return m_ia32_efer_msr; }
+
+    uint64_t ia32_pat_msr() const
+    { return m_ia32_pat_msr; }
+
+    uint64_t ia32_vmx_pinbased_ctls_msr() const
+    { return m_ia32_vmx_pinbased_ctls_msr; }
+
+    uint64_t ia32_vmx_procbased_ctls_msr() const
+    { return m_ia32_vmx_procbased_ctls_msr; }
+
+    uint64_t ia32_vmx_exit_ctls_msr() const
+    { return m_ia32_vmx_exit_ctls_msr; }
+
+    uint64_t ia32_vmx_entry_ctls_msr() const
+    { return m_ia32_vmx_entry_ctls_msr; }
+
+    uint64_t ia32_sysenter_cs_msr() const
+    { return m_ia32_sysenter_cs_msr; }
+
+    uint64_t ia32_sysenter_esp_msr() const
+    { return m_ia32_sysenter_esp_msr; }
+
+    uint64_t ia32_sysenter_eip_msr() const
+    { return m_ia32_sysenter_eip_msr; }
+
+    uint64_t ia32_fs_base_msr() const
+    { return m_ia32_fs_base_msr; }
+
+    uint64_t ia32_gs_base_msr() const
+    { return m_ia32_gs_base_msr; }
+
+    void set_ia32_debugctl_msr(uint64_t val)
+    { m_ia32_debugctl_msr = val; }
+
+    void set_ia32_efer_msr(uint64_t val)
+    { m_ia32_efer_msr = val; }
+
+    void set_ia32_pat_msr(uint64_t val)
+    { m_ia32_pat_msr = val; }
+
+    void set_ia32_vmx_pinbased_ctls_msr(uint64_t val)
+    { m_ia32_vmx_pinbased_ctls_msr = val; }
+
+    void set_ia32_vmx_procbased_ctls_msr(uint64_t val)
+    { m_ia32_vmx_procbased_ctls_msr = val; }
+
+    void set_ia32_vmx_exit_ctls_msr(uint64_t val)
+    { m_ia32_vmx_exit_ctls_msr = val; }
+
+    void set_ia32_vmx_entry_ctls_msr(uint64_t val)
+    { m_ia32_vmx_entry_ctls_msr = val; }
+
+    void set_ia32_sysenter_cs_msr(uint64_t val)
+    { m_ia32_sysenter_cs_msr = val; }
+
+    void set_ia32_sysenter_esp_msr(uint64_t val)
+    { m_ia32_sysenter_esp_msr = val; }
+
+    void set_ia32_sysenter_eip_msr(uint64_t val)
+    { m_ia32_sysenter_eip_msr = val; }
+
+    void set_ia32_fs_base_msr(uint64_t val)
+    { m_ia32_fs_base_msr = val; }
+
+    void set_ia32_gs_base_msr(uint64_t val)
+    { m_ia32_gs_base_msr = val; }
+
+private:
+
+    uint16_t m_es;
+    uint16_t m_cs;
+    uint16_t m_ss;
+    uint16_t m_ds;
+    uint16_t m_fs;
+    uint16_t m_gs;
+    uint16_t m_tr;
+
+    uint64_t m_cr0;
+    uint64_t m_cr3;
+    uint64_t m_cr4;
+    uint64_t m_dr7;
+
+    uint64_t m_rflags;
+
+    gdt_t m_gdt_reg;
+    idt_t m_idt_reg;
+
+    uint32_t m_es_limit;
+    uint32_t m_cs_limit;
+    uint32_t m_ss_limit;
+    uint32_t m_ds_limit;
+    uint32_t m_fs_limit;
+    uint32_t m_gs_limit;
+    uint32_t m_tr_limit;
+
+    uint32_t m_es_access;
+    uint32_t m_cs_access;
+    uint32_t m_ss_access;
+    uint32_t m_ds_access;
+    uint32_t m_fs_access;
+    uint32_t m_gs_access;
+    uint32_t m_tr_access;
+
+    uint64_t m_es_base;
+    uint64_t m_cs_base;
+    uint64_t m_ss_base;
+    uint64_t m_ds_base;
+    uint64_t m_fs_base;
+    uint64_t m_gs_base;
+    uint64_t m_tr_base;
+
+    uint64_t m_ia32_debugctl_msr;
+    uint64_t m_ia32_efer_msr;
+    uint64_t m_ia32_pat_msr;
+    uint64_t m_ia32_vmx_pinbased_ctls_msr;
+    uint64_t m_ia32_vmx_procbased_ctls_msr;
+    uint64_t m_ia32_vmx_exit_ctls_msr;
+    uint64_t m_ia32_vmx_entry_ctls_msr;
+    uint64_t m_ia32_sysenter_cs_msr;
+    uint64_t m_ia32_sysenter_esp_msr;
+    uint64_t m_ia32_sysenter_eip_msr;
+    uint64_t m_ia32_fs_base_msr;
+    uint64_t m_ia32_gs_base_msr;
+};
+
+#endif

--- a/bfvmm/include/vmxon/vmxon_exceptions_intel_x64.h
+++ b/bfvmm/include/vmxon/vmxon_exceptions_intel_x64.h
@@ -54,7 +54,6 @@ public:
         m_func(func),
         m_line(line)
     {}
-    virtual ~vmxon_failure_error() {}
 
     virtual std::ostream &print(std::ostream &os) const
     {
@@ -82,14 +81,14 @@ private:
 class vmxon_capabilities_failure_error : public bfn::general_exception
 {
 public:
-    vmxon_capabilities_failure_error(const std::string &msr_name,
-                                     const std::string &field_name,
+    vmxon_capabilities_failure_error(const std::string &msr_str,
+                                     const std::string &field_str,
                                      uint64_t msr,
                                      uint64_t field,
                                      const std::string &func,
                                      uint64_t line) :
-        m_msr_name(msr_name),
-        m_field_name(field_name),
+        m_msr_str(msr_str),
+        m_field_str(field_str),
         m_msr(msr),
         m_field(field),
         m_func(func),
@@ -99,8 +98,8 @@ public:
     virtual std::ostream &print(std::ostream &os) const
     {
         os << "vmxon capabilities not supported:";
-        os << std::endl << "    - " << m_msr_name << ": " << m_msr;
-        os << std::endl << "    - " << m_field_name << ": " << m_field;
+        os << std::endl << "    - " << m_msr_str << ": " << (void *)m_msr;
+        os << std::endl << "    - " << m_field_str << ": " << (void *)m_field;
         os << std::endl << "    - func: " << m_func;
         os << std::endl << "    - line: " << m_line;
 
@@ -108,8 +107,8 @@ public:
     }
 
 private:
-    std::string m_msr_name;
-    std::string m_field_name;
+    std::string m_msr_str;
+    std::string m_field_str;
     uint64_t m_msr;
     uint64_t m_field;
     std::string m_func;
@@ -126,17 +125,17 @@ private:
 class vmxon_fixed_msr_failure_error : public bfn::general_exception
 {
 public:
-    vmxon_fixed_msr_failure_error(const std::string &cr_name,
-                                  const std::string &fixed0_name,
-                                  const std::string &fixed1_name,
+    vmxon_fixed_msr_failure_error(const std::string &cr_str,
+                                  const std::string &fixed0_str,
+                                  const std::string &fixed1_str,
                                   uint64_t cr,
                                   uint64_t fixed0,
                                   uint64_t fixed1,
                                   const std::string &func,
                                   uint64_t line) :
-        m_cr_name(cr_name),
-        m_fixed0_name(fixed0_name),
-        m_fixed1_name(fixed1_name),
+        m_cr_str(cr_str),
+        m_fixed0_str(fixed0_str),
+        m_fixed1_str(fixed1_str),
         m_cr(cr),
         m_fixed0(fixed0),
         m_fixed1(fixed1),
@@ -147,21 +146,19 @@ public:
     virtual std::ostream &print(std::ostream &os) const
     {
         os << "vmxon fixed msr bits not supported:";
-        os << std::hex;
-        os << std::endl << "    - " << m_cr_name << ": " << m_cr;
-        os << std::endl << "    - " << m_fixed0_name << ": " << m_fixed0;
-        os << std::endl << "    - " << m_fixed1_name << ": " << m_fixed1;
+        os << std::endl << "    - " << m_cr_str << ": " << (void *)m_cr;
+        os << std::endl << "    - " << m_fixed0_str << ": " << (void *)m_fixed0;
+        os << std::endl << "    - " << m_fixed1_str << ": " << (void *)m_fixed1;
         os << std::endl << "    - func: " << m_func;
         os << std::endl << "    - line: " << m_line;
-        os << std::dec;
 
         return os;
     }
 
 private:
-    const std::string &m_cr_name;
-    const std::string &m_fixed0_name;
-    const std::string &m_fixed1_name;
+    const std::string &m_cr_str;
+    const std::string &m_fixed0_str;
+    const std::string &m_fixed1_str;
     uint64_t m_cr;
     uint64_t m_fixed0;
     uint64_t m_fixed1;

--- a/bfvmm/include/vmxon/vmxon_intel_x64.h
+++ b/bfvmm/include/vmxon/vmxon_intel_x64.h
@@ -23,7 +23,6 @@
 #define VMXON_INTEL_X64_H
 
 #include <memory>
-#include <memory_manager/memory_manager.h>
 #include <intrinsics/intrinsics_intel_x64.h>
 
 // -----------------------------------------------------------------------------

--- a/bfvmm/src/entry/src/Makefile
+++ b/bfvmm/src/entry/src/Makefile
@@ -60,6 +60,7 @@ CROSS_OUTDIR:=../../../bin
 ################################################################################
 
 SOURCES+=entry.cpp
+SOURCES+=entry_asm.asm
 
 INCLUDE_PATHS+=./
 INCLUDE_PATHS+=../../../include/

--- a/bfvmm/src/entry/src/entry_asm.asm
+++ b/bfvmm/src/entry/src/entry_asm.asm
@@ -1,0 +1,44 @@
+;
+; Bareflank Hypervisor
+;
+; Copyright (C) 2015 Assured Information Security, Inc.
+; Author: Rian Quinn        <quinnr@ainfosec.com>
+; Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+;
+; This library is free software; you can redistribute it and/or
+; modify it under the terms of the GNU Lesser General Public
+; License as published by the Free Software Foundation; either
+; version 2.1 of the License, or (at your option) any later version.
+;
+; This library is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+; Lesser General Public License for more details.
+;
+; You should have received a copy of the GNU Lesser General Public
+; License along with this library; if not, write to the Free Software
+; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+bits 64
+default rel
+
+global execute_with_stack:function
+
+section .text
+
+; int64_t execute_with_stack(entry_t func, void *stack, uint64_t size);
+execute_with_stack:
+    push rbp
+    mov rbp, rsp
+
+    mov rsp, rsi
+    add rsp, rdx
+    sub rsp, 1
+
+    call rdi
+
+    leave
+    ret
+
+
+

--- a/bfvmm/src/intrinsics/src/intrinsics_x64.asm
+++ b/bfvmm/src/intrinsics/src/intrinsics_x64.asm
@@ -40,6 +40,7 @@ global __write_dr7:function
 global __read_es:function
 global __write_es:function
 global __read_cs:function
+global __write_cs:function
 global __read_ss:function
 global __write_ss:function
 global __read_ds:function
@@ -235,6 +236,11 @@ __write_es:
 __read_cs:
     mov rax, 0
     mov ax, cs
+    ret
+
+; void __write_cs(uint16_t val)
+__write_cs:
+    mov cs, di
     ret
 
 ; uint16_t __read_ss(void)

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
@@ -19,137 +19,103 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <iomanip>
-#include <iostream>
-
 #include <vmcs/vmcs_intel_x64.h>
 
-void
+std::string
 vmcs_intel_x64::check_vm_instruction_error()
 {
-    auto check_vm_instruction = vmread(VMCS_VM_INSTRUCTION_ERROR);
-
-    if (check_vm_instruction == 0)
-        return;
-
-    // The following error codes are defined in the Intel Software Developers
-    // Manual, Chapter 3, Section 30.4.
-
-    std::cout << "VM Instruction Error:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    switch (check_vm_instruction)
+    switch (vmread(VMCS_VM_INSTRUCTION_ERROR))
     {
         case 1:
-            std::cout << "VMCALL executed in VMX root operation" << std::endl;
-            break;
+            return "VMCALL executed in VMX root operation";
 
         case 2:
-            std::cout << "VMCLEAR with invalid physical address" << std::endl;
-            break;
+            return "VMCLEAR with invalid physical address";
 
         case 3:
-            std::cout << "VMCLEAR with VMXON pointer" << std::endl;
-            break;
+            return "VMCLEAR with VMXON pointer";
 
         case 4:
-            std::cout << "VMLAUNCH with non-clear VMCS" << std::endl;
-            break;
+            return "VMLAUNCH with non-clear VMCS";
 
         case 5:
-            std::cout << "VMRESUME with non-launched VMCS" << std::endl;
-            break;
+            return "VMRESUME with non-launched VMCS";
 
         case 6:
-            std::cout << "VMRESUME after VMXOFF (VMXOFF and VMXON between VMLAUNCH and VMRESUME)" << std::endl;
-            break;
+            return "VMRESUME after VMXOFF (VMXOFF and VMXON between "
+                   "VMLAUNCH and VMRESUME)";
 
         case 7:
-            std::cout << "VM entry with invalid control field(s)" << std::endl;
-            break;
+            return "VM entry with invalid control field(s)";
 
         case 8:
-            std::cout << "VM entry with invalid host-state field(s)" << std::endl;
-            break;
+            return "VM entry with invalid host-state field(s)";
 
         case 9:
-            std::cout << "VMPTRLD with invalid physical address" << std::endl;
-            break;
+            return "VMPTRLD with invalid physical address";
 
         case 10:
-            std::cout << "VMPTRLD with VMXON pointer" << std::endl;
-            break;
+            return "VMPTRLD with VMXON pointer";
 
         case 11:
-            std::cout << "VMPTRLD with incorrect VMCS revision identifier" << std::endl;
-            break;
+            return "VMPTRLD with incorrect VMCS revision identifier";
 
         case 12:
-            std::cout << "VMREAD/VMWRITE from/to unsupported VMCS component" << std::endl;
-            break;
+            return "VMREAD/VMWRITE from/to unsupported VMCS component";
 
         case 13:
-            std::cout << "VMWRITE to read-only VMCS component" << std::endl;
-            break;
+            return "VMWRITE to read-only VMCS component";
 
         case 15:
-            std::cout << "VMXON executed in VMX root operation" << std::endl;
-            break;
+            return "VMXON executed in VMX root operation";
 
         case 16:
-            std::cout << "VM entry with invalid executive-VMCS pointer" << std::endl;
-            break;
+            return "VM entry with invalid executive-VMCS pointer";
 
         case 17:
-            std::cout << "VM entry with non-launched executive VMCS" << std::endl;
-            break;
+            return "VM entry with non-launched executive VMCS";
 
         case 18:
-            std::cout << "VM entry with executive-VMCS pointer not VMXON pointer (when attempting "
-                      << "to deactivate the dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VM entry with executive-VMCS pointer not VMXON "
+                   "pointer (when attempting to deactivate the "
+                   "dual-monitor treatment of SMIs and SMM)";
 
         case 19:
-            std::cout << "VMCALL with non-clear VMCS (when attempting to activate the dual-monitor "
-                      << "treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with non-clear VMCS (when attempting to "
+                   "activate the dual-monitor treatment of SMIs and "
+                   "SMM)";
 
         case 20:
-            std::cout << "VMCALL with invalid VM-exit control fields" << std::endl;
-            break;
+            return "VMCALL with invalid VM-exit control fields";
 
         case 22:
-            std::cout << "VMCALL with incorrect MSEG revision identifier (when attempting to "
-                      << "activate the dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with incorrect MSEG revision identifier "
+                   "(when attempting to activate the dual-monitor "
+                   "treatment of SMIs and SMM)";
 
         case 23:
-            std::cout << "VMXOFF under dual-monitor treatment of SMIs and SMM" << std::endl;
-            break;
+            return "VMXOFF under dual-monitor treatment of SMIs and "
+                   "SMM";
 
         case 24:
-            std::cout << "VMCALL with invalid SMM-monitor features (when attempting to activate the "
-                      << "dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with invalid SMM-monitor features (when "
+                   "attempting to activate the dual-monitor treatment "
+                   "of SMIs and SMM)";
 
         case 25:
-            std::cout << "VM entry with invalid VM-execution control fields in executive VMCS (when "
-                      << "attempting to return from SMM)" << std::endl;
-            break;
+            return "VM entry with invalid VM-execution control fields "
+                   "in executive VMCS (when attempting to return from "
+                   "SMM)";
 
         case 26:
-            std::cout << "VM entry with events blocked by MOV SS." << std::endl;
-            break;
+            return "VM entry with events blocked by MOV SS.";
 
         case 28:
-            std::cout << "Invalid operand to INVEPT/INVVPID." << std::endl;
-            break;
+            return "Invalid operand to INVEPT/INVVPID.";
 
         default:
-            std::cout << "Unknown vm instruction error: " << check_vm_instruction << std::endl;
+            return "Unknown vm instruction error";
     }
-
-    std::cout << std::endl;
 }
 
 bool

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
@@ -276,332 +276,332 @@ vmcs_intel_x64::dump_vmcs()
 #define PRINT_STATE(a) \
     std::cout << std::left << std::setw(55) << #a \
               << "0x" << a << std::endl;
-void
-vmcs_intel_x64::dump_state()
-{
-    std::cout << std::hex << std::endl;
-    std::cout << "State Dump:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    std::cout << std::endl;
-    std::cout << "Segment Selectors:" << std::endl;
-    PRINT_STATE(m_es);
-    PRINT_STATE(m_cs);
-    PRINT_STATE(m_ss);
-    PRINT_STATE(m_ds);
-    PRINT_STATE(m_fs);
-    PRINT_STATE(m_gs);
-    PRINT_STATE(m_tr);
-    PRINT_STATE(m_ldtr);
-
-    std::cout << std::endl;
-    std::cout << "Registers:" << std::endl;
-    PRINT_STATE(m_cr0);
-    PRINT_STATE(m_cr3);
-    PRINT_STATE(m_cr4);
-    PRINT_STATE(m_dr7);
-    PRINT_STATE(m_rflags);
-
-    std::cout << std::endl;
-    std::cout << "GDT/IDT:" << std::endl;
-    PRINT_STATE(m_gdt_reg.limit);
-    PRINT_STATE(m_gdt_reg.base);
-    PRINT_STATE(m_idt_reg.limit);
-    PRINT_STATE(m_idt_reg.base);
-
-    std::cout << std::endl;
-    std::cout << "Segment Limit:" << std::endl;
-    PRINT_STATE(m_es_limit);
-    PRINT_STATE(m_cs_limit);
-    PRINT_STATE(m_ss_limit);
-    PRINT_STATE(m_ds_limit);
-    PRINT_STATE(m_fs_limit);
-    PRINT_STATE(m_gs_limit);
-    PRINT_STATE(m_ldtr_limit);
-    PRINT_STATE(m_tr_limit);
-
-    std::cout << std::endl;
-    std::cout << "Segment Access:" << std::endl;
-    PRINT_STATE(m_es_access);
-    PRINT_STATE(m_cs_access);
-    PRINT_STATE(m_ss_access);
-    PRINT_STATE(m_ds_access);
-    PRINT_STATE(m_fs_access);
-    PRINT_STATE(m_gs_access);
-    PRINT_STATE(m_ldtr_access);
-    PRINT_STATE(m_tr_access);
-
-    std::cout << std::endl;
-    std::cout << "Segment Base:" << std::endl;
-    PRINT_STATE(m_es_base);
-    PRINT_STATE(m_cs_base);
-    PRINT_STATE(m_ss_base);
-    PRINT_STATE(m_ds_base);
-    PRINT_STATE(m_fs_base);
-    PRINT_STATE(m_gs_base);
-    PRINT_STATE(m_ldtr_base);
-    PRINT_STATE(m_tr_base);
-
-    std::cout << std::endl;
-    std::cout << "Segment Descriptors:" << std::endl;
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_es));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_cs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ss));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ds));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_fs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_gs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ldtr));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_tr));
-
-    std::cout << std::dec << std::left << std::endl;
-}
-
-void
-vmcs_intel_x64::print_execution_controls()
-{
-    print_pin_based_vm_execution_controls();
-    print_primary_processor_based_vm_execution_controls();
-    print_secondary_processor_based_vm_execution_controls();
-    print_vm_exit_control_fields();
-    print_vm_entry_control_fields();
-}
-
-void
-vmcs_intel_x64::print_pin_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS);
-
-    std::cout << std::hex << std::endl;
-    std::cout << "Pin-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    if ((controls & VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING" << std::endl;
+// void
+// vmcs_intel_x64::dump_state()
+// {
+//     std::cout << std::hex << std::endl;
+//     std::cout << "State Dump:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Selectors:" << std::endl;
+//     PRINT_STATE(m_es);
+//     PRINT_STATE(m_cs);
+//     PRINT_STATE(m_ss);
+//     PRINT_STATE(m_ds);
+//     PRINT_STATE(m_fs);
+//     PRINT_STATE(m_gs);
+//     PRINT_STATE(m_tr);
+//     PRINT_STATE(m_ldtr);
+
+//     std::cout << std::endl;
+//     std::cout << "Registers:" << std::endl;
+//     PRINT_STATE(m_cr0);
+//     PRINT_STATE(m_cr3);
+//     PRINT_STATE(m_cr4);
+//     PRINT_STATE(m_dr7);
+//     PRINT_STATE(m_rflags);
+
+//     std::cout << std::endl;
+//     std::cout << "GDT/IDT:" << std::endl;
+//     PRINT_STATE(m_gdt_reg.limit);
+//     PRINT_STATE(m_gdt_reg.base);
+//     PRINT_STATE(m_idt_reg.limit);
+//     PRINT_STATE(m_idt_reg.base);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Limit:" << std::endl;
+//     PRINT_STATE(m_es_limit);
+//     PRINT_STATE(m_cs_limit);
+//     PRINT_STATE(m_ss_limit);
+//     PRINT_STATE(m_ds_limit);
+//     PRINT_STATE(m_fs_limit);
+//     PRINT_STATE(m_gs_limit);
+//     PRINT_STATE(m_ldtr_limit);
+//     PRINT_STATE(m_tr_limit);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Access:" << std::endl;
+//     PRINT_STATE(m_es_access);
+//     PRINT_STATE(m_cs_access);
+//     PRINT_STATE(m_ss_access);
+//     PRINT_STATE(m_ds_access);
+//     PRINT_STATE(m_fs_access);
+//     PRINT_STATE(m_gs_access);
+//     PRINT_STATE(m_ldtr_access);
+//     PRINT_STATE(m_tr_access);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Base:" << std::endl;
+//     PRINT_STATE(m_es_base);
+//     PRINT_STATE(m_cs_base);
+//     PRINT_STATE(m_ss_base);
+//     PRINT_STATE(m_ds_base);
+//     PRINT_STATE(m_fs_base);
+//     PRINT_STATE(m_gs_base);
+//     PRINT_STATE(m_ldtr_base);
+//     PRINT_STATE(m_tr_base);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Descriptors:" << std::endl;
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_es));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_cs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ss));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ds));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_fs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_gs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ldtr));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_tr));
+
+//     std::cout << std::dec << std::left << std::endl;
+// }
+
+// void
+// vmcs_intel_x64::print_execution_controls()
+// {
+//     print_pin_based_vm_execution_controls();
+//     print_primary_processor_based_vm_execution_controls();
+//     print_secondary_processor_based_vm_execution_controls();
+//     print_vm_exit_control_fields();
+//     print_vm_entry_control_fields();
+// }
+
+// void
+// vmcs_intel_x64::print_pin_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS);
+
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Pin-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
+
+//     if ((controls & VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_NMI_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_NMI_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_NMI_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_NMI_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_VIRTUAL_NMIS) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_VIRTUAL_NMIS" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_VIRTUAL_NMIS) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_VIRTUAL_NMIS" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_primary_processor_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
+// void
+// vmcs_intel_x64::print_primary_processor_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "Primary Processor-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Primary Processor-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_HLT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_HLT_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_HLT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_HLT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_INVLPG_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_INVLPG_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_INVLPG_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_INVLPG_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MWAIT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MWAIT_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MWAIT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MWAIT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_RDPMC_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDPMC_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_RDPMC_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDPMC_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_RDTSC_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDTSC_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_RDTSC_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDTSC_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MOV_DR_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MOV_DR_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MOV_DR_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MOV_DR_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_PAUSE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_PAUSE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_PAUSE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_PAUSE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_secondary_processor_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
+// void
+// vmcs_intel_x64::print_secondary_processor_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "Secondary Processor-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Secondary Processor-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_EPT) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_EPT" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_EPT) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_EPT" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VPID) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VPID" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VPID) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VPID" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_WBINVD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_WBINVD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_WBINVD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_WBINVD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_RDRAND_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDRAND_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_RDRAND_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDRAND_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_INVPCID) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_INVPCID" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_INVPCID) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_INVPCID" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VMCS_SHADOWING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VMCS_SHADOWING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VMCS_SHADOWING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VMCS_SHADOWING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_RDSEED_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDSEED_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_RDSEED_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDSEED_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_vm_exit_control_fields()
-{
-    auto controls = vmread(VMCS_VM_EXIT_CONTROLS);
+// void
+// vmcs_intel_x64::print_vm_exit_control_fields()
+// {
+//     auto controls = vmread(VMCS_VM_EXIT_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "VM-Exit Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "VM-Exit Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_IA32_PAT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_PAT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_PAT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PAT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PAT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PAT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_IA32_EFER) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_EFER" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_EFER" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_EFER) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_EFER" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_EFER" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_vm_entry_control_fields()
-{
-    auto controls = vmread(VMCS_VM_ENTRY_CONTROLS);
+// void
+// vmcs_intel_x64::print_vm_entry_control_fields()
+// {
+//     auto controls = vmread(VMCS_VM_ENTRY_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "VM-Entry Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "VM-Entry Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_IA_32E_MODE_GUEST) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_IA_32E_MODE_GUEST" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_IA_32E_MODE_GUEST) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_IA_32E_MODE_GUEST" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_ENTRY_TO_SMM) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_ENTRY_TO_SMM" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_ENTRY_TO_SMM) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_ENTRY_TO_SMM" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PAT) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PAT" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PAT" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_EFER) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_EFER" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_EFER" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -22,6 +22,7 @@
 #include <commit_or_rollback.h>
 #include <vmxon/vmxon_intel_x64.h>
 #include <vmxon/vmxon_exceptions_intel_x64.h>
+#include <memory_manager/memory_manager.h>
 
 // =============================================================================
 //  Implementation

--- a/include/constants.h
+++ b/include/constants.h
@@ -167,4 +167,16 @@
 #define ALIGN_MEMORY __attribute__((aligned(MAX_CACHE_LINE_SIZE)))
 #endif
 
+/// Stack Size
+///
+/// Each entry function is guarded with a custom stack to prevent stack
+/// overflows from corrupting the kernel, as well as providing a larger stack
+/// that common in userspace code, but not in the kernel. If stack corruption
+/// is occuring, this function likely needs to be increased. Note one stack
+/// frame is allocated per CPU, so only increase this if needed.
+///
+/// Note: define in 64bits (i.e. an array of uint64_t)
+///
+#define STACK_SIZE 0x2000
+
 #endif

--- a/tools/scripts/bareflank-gcc-wrapper
+++ b/tools/scripts/bareflank-gcc-wrapper
@@ -113,7 +113,8 @@ done
 # only thing the hypervisor code should need from the sysroot is the includes.
 
 if [[ $BAREFLANK_WRAPPER_INCLUDE_LIBC == "true" ]]; then
-    SYSROOT_LIBS="-lc -lbfc -lbfunwind_static"
+    SYSROOT_LIBS+="-lc -lbfc -lbfunwind_static "
+    SYSROOT_LIBS+="-u __cxa_throw_bad_array_new_length"
 fi
 
 SYSROOT_LIB_PATH="-L$HOME/opt/cross/x86_64-elf/lib/"
@@ -123,16 +124,6 @@ SYSROOT_LIB_PATH="-L$HOME/opt/cross/x86_64-elf/lib/"
 # ------------------------------------------------------------------------------
 
 SYSROOT_INC_PATH="-I$HOME/opt/cross/x86_64-elf/include/ -I$HOME/opt/cross/x86_64-elf/include/c++/v1/ "
-
-# REMOVE ME
-#
-# For whatever reason, Libcxx is running a test during it's initial compilation
-# and it needs access to the includes, but doesn't supply them on the
-# command line. This fixes that issue for now.
-
-if [[ $BAREFLANK_WRAPPER_INCLUDE_TMPLIBCXX == "true" ]]; then
-    SYSROOT_INC_PATH+="-I$HOME/tmp-build-dir/libcxx/include/ "
-fi
 
 # ------------------------------------------------------------------------------
 # Libgcc


### PR DESCRIPTION
This patch provides VMCS exception support. During it's
development, it was also identified that the libc++ code can
overwrite the kernel's stack as it's expecting a much larger
stack than the Linux kernel is providing. To overcome this
issue, this patch also includes code to guard the kernel's
by using a different stack while the VMM is execuitng.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>