### PR TITLE
VMCS Exception Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,11 +43,14 @@ CS_M='\033[1;95m'
 
 .PHONY: debian_load
 .PHONY: debian_unload
+.PHONY: debian_clean
 .PHONY: load
 .PHONY: unload
 .PHONY: start
 .PHONY: stop
 .PHONY: dump
+.PHONY: status
+.PHONY: quick
 .PHONY: loop
 
 debian_load: force
@@ -61,6 +64,9 @@ debian_unload: force
 	cd driver_entry/src/arch/linux; \
 	sudo make unload; \
 	make clean
+
+debian_clean: force
+	$(MAKE) debian_unload
 
 load: force
 	cd bfm/bin/native; \
@@ -85,6 +91,10 @@ dump: force
 status: force
 	cd bfm/bin/native; \
 	sudo ./run.sh status
+
+quick: force
+	$(MAKE) load; \
+	$(MAKE) start
 
 loop: force
 	@for n in $(shell seq 1 $(NUM)); do \

--- a/TODO.md
+++ b/TODO.md
@@ -33,6 +33,12 @@ Version 1.1 TODO:
   can be customized.
 - Need to rename the VCPU logic as it's really specific to Intel.
 - Add Windows support
+- Once we have our own GDT/IDT, part of the "promote" process needs to restore
+  the GDT/IDT which is not being done. The segment registers are swapped, but
+  we are not doing a sgdt or sidt to swap these.
+- CS, SS and TR need to be restored properly when promoting. This will be
+  really important once a new GDT is used in the host.
+- Provide APIs within the VMCS for setting / clearing traps to MSRs and IO
 
 Version 2.0 TODO:
 - Type 1 and Type 2 support

--- a/bfvmm/include/debug.h
+++ b/bfvmm/include/debug.h
@@ -38,6 +38,6 @@
 #define bfdebug std::cout << bfcolor_debug << "DEBUG" << bfcolor_end << ": "
 #define bfwarning std::cout << bfverbose << bfcolor_warning << "WARNING" << bfcolor_end << ": "
 #define bferror std::cout << bfcolor_error << "ERROR" << bfcolor_end << ": "
-#define bffatal std::cout << bfcolor_error << "ERROR" << bfcolor_end << ": "
+#define bffatal std::cout << bfcolor_error << "FATAL ERROR" << bfcolor_end << ": "
 
 #endif

--- a/bfvmm/include/intrinsics/intrinsics_intel_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_intel_x64.h
@@ -107,14 +107,35 @@ public:
 #define IA32_VMX_CR4_FIXED0_MSR                                   0x00000488
 #define IA32_VMX_CR4_FIXED1_MSR                                   0x00000489
 #define IA32_FEATURE_CONTROL_MSR                                  0x0000003A
-#define IA32_VMX_PINBASED_CTLS_MSR                                0x00000481
-#define IA32_VMX_PROCBASED_CTLS_MSR                               0x00000482
-#define IA32_VMX_EXIT_CTLS_MSR                                    0x00000483
-#define IA32_VMX_ENTRY_CTLS_MSR                                   0x00000484
 #define IA32_VMX_TRUE_PINBASED_CTLS_MSR                           0x0000048D
 #define IA32_VMX_TRUE_PROCBASED_CTLS_MSR                          0x0000048E
 #define IA32_VMX_TRUE_EXIT_CTLS_MSR                               0x0000048F
 #define IA32_VMX_TRUE_ENTRY_CTLS_MSR                              0x00000490
+#define IA32_VMX_PROCBASED_CTLS2_MSR                              0x0000048B
+
+#ifdef USE_INTEL_X64_LEGACY_CTLS
+#define IA32_VMX_PINBASED_CTLS_MSR                                0x00000481
+#define IA32_VMX_PROCBASED_CTLS_MSR                               0x00000482
+#define IA32_VMX_EXIT_CTLS_MSR                                    0x00000483
+#define IA32_VMX_ENTRY_CTLS_MSR                                   0x00000484
+#else
+#define IA32_VMX_PINBASED_CTLS_MSR IA32_VMX_TRUE_PINBASED_CTLS_MSR
+#define IA32_VMX_PROCBASED_CTLS_MSR IA32_VMX_TRUE_PROCBASED_CTLS_MSR
+#define IA32_VMX_EXIT_CTLS_MSR IA32_VMX_TRUE_EXIT_CTLS_MSR
+#define IA32_VMX_ENTRY_CTLS_MSR IA32_VMX_TRUE_ENTRY_CTLS_MSR
+#endif
+
+#ifdef USE_INTEL_X64_LEGACY_CTLS
+#define IA32_VMX_PINBASED_CTLS_MSR                                0x00000481
+#define IA32_VMX_PROCBASED_CTLS_MSR                               0x00000482
+#define IA32_VMX_EXIT_CTLS_MSR                                    0x00000483
+#define IA32_VMX_ENTRY_CTLS_MSR                                   0x00000484
+#else
+#define IA32_VMX_PINBASED_CTLS_MSR IA32_VMX_TRUE_PINBASED_CTLS_MSR
+#define IA32_VMX_PROCBASED_CTLS_MSR IA32_VMX_TRUE_PROCBASED_CTLS_MSR
+#define IA32_VMX_EXIT_CTLS_MSR IA32_VMX_TRUE_EXIT_CTLS_MSR
+#define IA32_VMX_ENTRY_CTLS_MSR IA32_VMX_TRUE_ENTRY_CTLS_MSR
+#endif
 
 // The VMCS fields are defined in the intel's software developer's manual,
 // volumn 3, appendix B. An explaination of these fields can be found in
@@ -337,78 +358,78 @@ public:
 
 // Pin-Based VM-Execution Controls
 // intel's software developers manual, volume 3, chapter 24.6.1.
-#define VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING              (1 << 0)
-#define VM_EXEC_PIN_BASED_NMI_EXITING                             (1 << 3)
-#define VM_EXEC_PIN_BASED_VIRTUAL_NMIS                            (1 << 5)
-#define VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER           (1 << 6)
-#define VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS               (1 << 7)
+#define VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING              (1ULL << 0)
+#define VM_EXEC_PIN_BASED_NMI_EXITING                             (1ULL << 3)
+#define VM_EXEC_PIN_BASED_VIRTUAL_NMIS                            (1ULL << 5)
+#define VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER           (1ULL << 6)
+#define VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS               (1ULL << 7)
 
 // Primary Processor-Based VM-Execution Controls
 // intel's software developers manual, volume 3, chapter 24.6.2
-#define VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING             (1 << 2)
-#define VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING                   (1 << 3)
-#define VM_EXEC_P_PROC_BASED_HLT_EXITING                          (1 << 7)
-#define VM_EXEC_P_PROC_BASED_INVLPG_EXITING                       (1 << 9)
-#define VM_EXEC_P_PROC_BASED_MWAIT_EXITING                        (1 << 10)
-#define VM_EXEC_P_PROC_BASED_RDPMC_EXITING                        (1 << 11)
-#define VM_EXEC_P_PROC_BASED_RDTSC_EXITING                        (1 << 12)
-#define VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING                     (1 << 15)
-#define VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING                    (1 << 16)
-#define VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING                     (1 << 19)
-#define VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING                    (1 << 20)
-#define VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW                       (1 << 21)
-#define VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING                   (1 << 22)
-#define VM_EXEC_P_PROC_BASED_MOV_DR_EXITING                       (1 << 23)
-#define VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING             (1 << 24)
-#define VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS                       (1 << 25)
-#define VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG                    (1 << 27)
-#define VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS                      (1 << 28)
-#define VM_EXEC_P_PROC_BASED_MONITOR_EXITING                      (1 << 29)
-#define VM_EXEC_P_PROC_BASED_PAUSE_EXITING                        (1 << 30)
-#define VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS          (1 << 31)
+#define VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING             (1ULL << 2)
+#define VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING                   (1ULL << 3)
+#define VM_EXEC_P_PROC_BASED_HLT_EXITING                          (1ULL << 7)
+#define VM_EXEC_P_PROC_BASED_INVLPG_EXITING                       (1ULL << 9)
+#define VM_EXEC_P_PROC_BASED_MWAIT_EXITING                        (1ULL << 10)
+#define VM_EXEC_P_PROC_BASED_RDPMC_EXITING                        (1ULL << 11)
+#define VM_EXEC_P_PROC_BASED_RDTSC_EXITING                        (1ULL << 12)
+#define VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING                     (1ULL << 15)
+#define VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING                    (1ULL << 16)
+#define VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING                     (1ULL << 19)
+#define VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING                    (1ULL << 20)
+#define VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW                       (1ULL << 21)
+#define VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING                   (1ULL << 22)
+#define VM_EXEC_P_PROC_BASED_MOV_DR_EXITING                       (1ULL << 23)
+#define VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING             (1ULL << 24)
+#define VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS                       (1ULL << 25)
+#define VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG                    (1ULL << 27)
+#define VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS                      (1ULL << 28)
+#define VM_EXEC_P_PROC_BASED_MONITOR_EXITING                      (1ULL << 29)
+#define VM_EXEC_P_PROC_BASED_PAUSE_EXITING                        (1ULL << 30)
+#define VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS          (1ULL << 31)
 
 // Secondary Processor-Based VM-Execution Controls
 // intel's software developers manual, volume 3, chapter 24.6.2
-#define VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES             (1 << 0)
-#define VM_EXEC_S_PROC_BASED_ENABLE_EPT                           (1 << 1)
-#define VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING             (1 << 2)
-#define VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP                        (1 << 3)
-#define VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE               (1 << 4)
-#define VM_EXEC_S_PROC_BASED_ENABLE_VPID                          (1 << 5)
-#define VM_EXEC_S_PROC_BASED_WBINVD_EXITING                       (1 << 6)
-#define VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST                   (1 << 7)
-#define VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION         (1 << 8)
-#define VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY           (1 << 9)
-#define VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING                   (1 << 10)
-#define VM_EXEC_S_PROC_BASED_RDRAND_EXITING                       (1 << 11)
-#define VM_EXEC_S_PROC_BASED_ENABLE_INVPCID                       (1 << 12)
-#define VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS                  (1 << 13)
-#define VM_EXEC_S_PROC_BASED_VMCS_SHADOWING                       (1 << 14)
-#define VM_EXEC_S_PROC_BASED_RDSEED_EXITING                       (1 << 16)
-#define VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE                     (1 << 18)
-#define VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS                (1 << 20)
+#define VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES             (1ULL << 0)
+#define VM_EXEC_S_PROC_BASED_ENABLE_EPT                           (1ULL << 1)
+#define VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING             (1ULL << 2)
+#define VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP                        (1ULL << 3)
+#define VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE               (1ULL << 4)
+#define VM_EXEC_S_PROC_BASED_ENABLE_VPID                          (1ULL << 5)
+#define VM_EXEC_S_PROC_BASED_WBINVD_EXITING                       (1ULL << 6)
+#define VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST                   (1ULL << 7)
+#define VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION         (1ULL << 8)
+#define VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY           (1ULL << 9)
+#define VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING                   (1ULL << 10)
+#define VM_EXEC_S_PROC_BASED_RDRAND_EXITING                       (1ULL << 11)
+#define VM_EXEC_S_PROC_BASED_ENABLE_INVPCID                       (1ULL << 12)
+#define VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS                  (1ULL << 13)
+#define VM_EXEC_S_PROC_BASED_VMCS_SHADOWING                       (1ULL << 14)
+#define VM_EXEC_S_PROC_BASED_RDSEED_EXITING                       (1ULL << 16)
+#define VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE                     (1ULL << 18)
+#define VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS                (1ULL << 20)
 
 // VM-Exit Control Fields
 // intel's software developers manual, volume 3, chapter 24.7.1
-#define VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS                       (1 << 2)
-#define VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE                   (1 << 9)
-#define VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL                (1 << 12)
-#define VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT             (1 << 15)
-#define VM_EXIT_CONTROL_SAVE_IA32_PAT                             (1 << 18)
-#define VM_EXIT_CONTROL_LOAD_IA32_PAT                             (1 << 19)
-#define VM_EXIT_CONTROL_SAVE_IA32_EFER                            (1 << 20)
-#define VM_EXIT_CONTROL_LOAD_IA32_EFER                            (1 << 21)
-#define VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE           (1 << 22)
+#define VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS                       (1ULL << 2)
+#define VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE                   (1ULL << 9)
+#define VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL                (1ULL << 12)
+#define VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT             (1ULL << 15)
+#define VM_EXIT_CONTROL_SAVE_IA32_PAT                             (1ULL << 18)
+#define VM_EXIT_CONTROL_LOAD_IA32_PAT                             (1ULL << 19)
+#define VM_EXIT_CONTROL_SAVE_IA32_EFER                            (1ULL << 20)
+#define VM_EXIT_CONTROL_LOAD_IA32_EFER                            (1ULL << 21)
+#define VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE           (1ULL << 22)
 
 // VM-Entry Control Fields
 // intel's software developers manual, volume 3, chapter 24.8.1
-#define VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS                      (1 << 2)
-#define VM_ENTRY_CONTROL_IA_32E_MODE_GUEST                        (1 << 9)
-#define VM_ENTRY_CONTROL_ENTRY_TO_SMM                             (1 << 10)
-#define VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT        (1 << 11)
-#define VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL               (1 << 13)
-#define VM_ENTRY_CONTROL_LOAD_IA32_PAT                            (1 << 14)
-#define VM_ENTRY_CONTROL_LOAD_IA32_EFER                           (1 << 15)
+#define VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS                      (1ULL << 2)
+#define VM_ENTRY_CONTROL_IA_32E_MODE_GUEST                        (1ULL << 9)
+#define VM_ENTRY_CONTROL_ENTRY_TO_SMM                             (1ULL << 10)
+#define VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT        (1ULL << 11)
+#define VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL               (1ULL << 13)
+#define VM_ENTRY_CONTROL_LOAD_IA32_PAT                            (1ULL << 14)
+#define VM_ENTRY_CONTROL_LOAD_IA32_EFER                           (1ULL << 15)
 
 // VM Exit Reasons
 // intel's software developers manual, volume 3, appendix c

--- a/bfvmm/include/intrinsics/intrinsics_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_x64.h
@@ -67,6 +67,7 @@ uint16_t __read_es(void);
 void __write_es(uint16_t val);
 
 uint16_t __read_cs(void);
+void __write_cs(uint16_t val);
 
 uint16_t __read_ss(void);
 void __write_ss(uint16_t val);
@@ -192,6 +193,9 @@ public:
 
     virtual uint16_t read_cs()
     { return __read_cs(); }
+
+    virtual void write_cs(uint16_t val)
+    { __write_cs(val); }
 
     virtual uint16_t read_ss()
     { return __read_ss(); }

--- a/bfvmm/include/vmcs/bitmap.h
+++ b/bfvmm/include/vmcs/bitmap.h
@@ -19,8 +19,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef BITMAP__H
-#define BITMAP__H
+#ifndef BITMAP_H
+#define BITMAP_H
 
 #include <stdint.h>
 #include <memory>
@@ -28,7 +28,9 @@
 class bitmap
 {
 public:
+
     /// Constructor
+    ///
     /// @param num_bits size of the bitmap in bits
     ///
     bitmap(uint32_t num_bits);
@@ -37,31 +39,44 @@ public:
     ///
     virtual ~bitmap() {}
 
-    /// address
-    /// @return the virtual address of the beginning
-    ///         of the bitmap
+    /// Virtual Address
     ///
-    uint8_t *address();
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t virt_addr() const noexcept
+    { return m_virt_addr; }
 
-    /// set_bit
+    /// Physical Address
+    ///
+    /// @return the virtual address of the beginning of the bitmap
+    ///
+    uint64_t phys_addr() const noexcept
+    { return m_phys_addr; }
+
+    /// Set Bit
+    ///
     /// @param n nth bit to set in the bitmap
     ///
-    void set_bit(uint32_t n);
+    void set_bit(uint32_t n) noexcept;
 
-    /// reset_bit
+    /// Reset Bit
+    ///
     /// @param n nth bit to clear in the bitmap
     ///
-    void clear_bit(uint32_t n);
+    void clear_bit(uint32_t n) noexcept;
 
-    /// bit
+    /// Get Bit
+    ///
     /// @param n nth bit's status to return
     /// @return true if the bit is set, false otherwise
     ///
-    bool bit(uint32_t n);
+    bool bit(uint32_t n) const noexcept;
 
 private:
-    std::unique_ptr<uint8_t[]> m_bitmap;
     uint32_t m_length;
+    uint64_t m_virt_addr;
+    uint64_t m_phys_addr;
+    std::unique_ptr<uint8_t[]> m_bitmap;
 };
 
-#endif // BITMAP__H
+#endif

--- a/bfvmm/include/vmcs/vmcs_exceptions_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_exceptions_intel_x64.h
@@ -1,0 +1,185 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_EXCEPTIONS_INTEL_X64_H
+#define VMCS_EXCEPTIONS_INTEL_X64_H
+
+#include <exception.h>
+
+namespace bfn
+{
+
+// -----------------------------------------------------------------------------
+// VMCS Invalid
+// -----------------------------------------------------------------------------
+
+class invalid_vmcs_error : public bfn::general_exception
+{
+public:
+    virtual std::ostream &print(std::ostream &os) const
+    { return os << "invalid vmcs"; }
+};
+
+#define invalid_vmcs() bfn::invalid_vmcs_error()
+
+// -----------------------------------------------------------------------------
+// VMCS Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_failure_error(const std::string &msg,
+                       const std::string &func,
+                       uint64_t line) :
+        m_msg(msg),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs failure:";
+        os << std::endl << "    - reason: " << m_msg;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    std::string m_msg;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_failure(a) \
+    bfn::vmcs_failure_error(a,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Read Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_read_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_read_failure_error(uint64_t field,
+                            const std::string &func,
+                            uint64_t line) :
+        m_field(field),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs read failure:";
+        os << std::endl << "    - field: " << (void *)m_field;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    uint64_t m_field;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_read_failure(a) \
+    bfn::vmcs_read_failure_error(a,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Write Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_write_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_write_failure_error(uint64_t field,
+                             uint64_t value,
+                             const std::string &func,
+                             uint64_t line) :
+        m_field(field),
+        m_value(value),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs write failure:";
+        os << std::endl << "    - field: " << (void *)m_field;
+        os << std::endl << "    - value: " << (void *)m_value;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    uint64_t m_field;
+    uint64_t m_value;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_write_failure(a,b) \
+    bfn::vmcs_write_failure_error(a,b,__func__,__LINE__)
+
+// -----------------------------------------------------------------------------
+// VMCS Launch Failure
+// -----------------------------------------------------------------------------
+
+class vmcs_launch_failure_error : public bfn::general_exception
+{
+public:
+    vmcs_launch_failure_error(const std::string &msg,
+                              const std::string &func,
+                              uint64_t line) :
+        m_msg(msg),
+        m_func(func),
+        m_line(line)
+    {}
+
+    virtual std::ostream &print(std::ostream &os) const
+    {
+        os << "vmcs launch failure:";
+        os << std::endl << "    - reason: " << m_msg;
+        os << std::endl << "    - func: " << m_func;
+        os << std::endl << "    - line: " << m_line;
+
+        return os;
+    }
+
+private:
+    std::string m_msg;
+    std::string m_func;
+    uint64_t m_line;
+};
+
+#define vmcs_launch_failure(a) \
+    bfn::vmcs_launch_failure_error(a,__func__,__LINE__)
+
+}
+
+#endif

--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -22,20 +22,9 @@
 #ifndef VMCS_INTEL_X64_H
 #define VMCS_INTEL_X64_H
 
-#include <intrinsics/intrinsics_intel_x64.h>
-#include <memory_manager/memory_manager.h>
 #include <vmcs/bitmap.h>
-
-namespace vmcs_error
-{
-enum type
-{
-    success = 0,
-    failure = 1,
-    not_supported = 2,
-    out_of_memory = 3
-};
-}
+#include <vmcs/vmcs_state_intel_x64.h>
+#include <intrinsics/intrinsics_intel_x64.h>
 
 class vmcs_intel_x64
 {
@@ -49,70 +38,104 @@ public:
     ///
     virtual ~vmcs_intel_x64() {}
 
-    /// Launch VMM
+    /// Launch
     ///
     /// Launches the VMCS. Note that this will create a new guest VM when
     /// it is complete.
     ///
-    /// @return success on success, out_of_memory is the provided memory
-    ///     manager is out of memory, not_supported if the current hardware
-    ///     and/or software configuration is not supported, failure otherwise
+    /// @throws invalid_vmcs thrown if the VMCS was created without
+    ///     intrinsics
     ///
-    virtual vmcs_error::type launch();
+    virtual void launch(const vmcs_state_intel_x64 &host_state,
+                        const vmcs_state_intel_x64 &guest_state);
 
-    virtual vmcs_error::type unlaunch();
-    virtual vmcs_error::type clear_vmcs_region();
+    /// Promote
+    ///
+    /// Promotes this guest to VMX root. This is used to transition out of
+    /// VMX operation as the guest that this VMCS defines is likely about to
+    /// disable VMX operation, and needs to be in VMX root to do so. Note
+    /// that this function doesn't actually return if it is successful.
+    /// Instead, the CPU resumes execution on the last instruction executed
+    /// by the guest.
+    ///
+    /// If this function fails in the middle of it's execution, it calls
+    /// abort. This is done because the process of promoting sets the CPU
+    /// state, and if it dies in the middle, the CPU is left in a corrupt
+    /// state.
+    ///
+    /// @throws invalid_vmcs thrown if the VMCS was created without
+    ///     intrinsics
+    ///
+    virtual void promote();
 
 protected:
 
-    virtual vmcs_error::type launch_vmcs();
-    virtual vmcs_error::type resume_vmcs();
-
-    virtual vmcs_error::type save_state();
-
-    virtual vmcs_error::type create_vmcs_region();
-    virtual vmcs_error::type release_vmxon_region();
-    virtual vmcs_error::type load_vmcs_region();
-
-    virtual uint64_t vmcs_region_size();
-
-    virtual vmcs_error::type write_16bit_control_fields();
-    virtual vmcs_error::type write_16bit_guest_state_fields();
-    virtual vmcs_error::type write_16bit_host_state_fields();
-    virtual vmcs_error::type write_64bit_control_fields();
-    virtual vmcs_error::type write_64bit_guest_state_fields();
-    virtual vmcs_error::type write_64bit_host_state_fields();
-    virtual vmcs_error::type write_32bit_control_fields();
-    virtual vmcs_error::type write_32bit_guest_state_fields();
-    virtual vmcs_error::type write_32bit_host_state_fields();
-    virtual vmcs_error::type write_natural_width_control_fields();
-    virtual vmcs_error::type write_natural_width_guest_state_fields();
-    virtual vmcs_error::type write_natural_width_host_state_fields();
-
-    virtual vmcs_error::type default_pin_based_vm_execution_controls();
-    virtual vmcs_error::type default_primary_processor_based_vm_execution_controls();
-    virtual vmcs_error::type default_secondary_processor_based_vm_execution_controls();
-    virtual vmcs_error::type default_vm_exit_controls();
-    virtual vmcs_error::type default_vm_entry_controls();
-
-    virtual void vmwrite(uint64_t field, uint64_t value);
+    /// VM Read
+    ///
+    /// This is the same as intrinsics->vmread, but throws if an error
+    /// occurs.
+    ///
+    /// @param field the vmcs field to read
+    /// @return the value of the vmcs field
+    ///
+    /// @throws vmcs_read_failure_error thrown if the vmread fails
+    ///
     virtual uint64_t vmread(uint64_t field);
 
+    /// VM Write
+    ///
+    /// This is the same as intrinsics->vmwrite, but throws if an error
+    /// occurs.
+    ///
+    /// @param field the vmcs field to read
+    /// @param value the value to write to the vmcs field
+    ///
+    /// @throws vmcs_write_failure_error thrown if the vmwrite fails
+    ///
+    virtual void vmwrite(uint64_t field, uint64_t value);
+
+private:
+
+    void create_vmcs_region();
+    void release_vmcs_region();
+
+    void write_16bit_control_state(const vmcs_state_intel_x64 &state);
+    void write_64bit_control_state(const vmcs_state_intel_x64 &state);
+    void write_32bit_control_state(const vmcs_state_intel_x64 &state);
+    void write_natural_control_state(const vmcs_state_intel_x64 &state);
+
+    void write_16bit_guest_state(const vmcs_state_intel_x64 &state);
+    void write_64bit_guest_state(const vmcs_state_intel_x64 &state);
+    void write_32bit_guest_state(const vmcs_state_intel_x64 &state);
+    void write_natural_guest_state(const vmcs_state_intel_x64 &state);
+
+    void write_16bit_host_state(const vmcs_state_intel_x64 &state);
+    void write_64bit_host_state(const vmcs_state_intel_x64 &state);
+    void write_32bit_host_state(const vmcs_state_intel_x64 &state);
+    void write_natural_host_state(const vmcs_state_intel_x64 &state);
+
+    void promote_16bit_guest_state();
+    void promote_64bit_guest_state();
+    void promote_32bit_guest_state();
+    void promote_natural_guest_state();
+
+    void default_pin_based_vm_execution_controls();
+    void default_primary_processor_based_vm_execution_controls();
+    void default_secondary_processor_based_vm_execution_controls();
+    void default_vm_exit_controls();
+    void default_vm_entry_controls();
+
+protected:
+
     virtual void dump_vmcs();
-    virtual void dump_state();
 
-    virtual void print_execution_controls();
-    virtual void print_pin_based_vm_execution_controls();
-    virtual void print_primary_processor_based_vm_execution_controls();
-    virtual void print_secondary_processor_based_vm_execution_controls();
-    virtual void print_vm_exit_control_fields();
-    virtual void print_vm_entry_control_fields();
-
-    virtual void check_vm_instruction_error();
+    virtual std::string check_vm_instruction_error();
     virtual bool check_is_address_canonical(uint64_t addr);
     virtual bool check_vmcs_host_state();
     virtual bool check_vmcs_guest_state();
     virtual bool check_vmcs_control_state();
+
+    virtual bool supports_vpid();
 
     virtual bool check_host_control_registers_and_msrs();
     virtual bool check_host_cr0_for_unsupported_bits();
@@ -298,56 +321,17 @@ private:
     friend class vmcs_ut;
 
     bitmap m_msr_bitmap;
+    bitmap m_io_bitmap_a;
+    bitmap m_io_bitmap_b;
 
-    uint16_t m_es;
-    uint16_t m_cs;
-    uint16_t m_ss;
-    uint16_t m_ds;
-    uint16_t m_fs;
-    uint16_t m_gs;
-    uint16_t m_tr;
-    uint16_t m_ldtr;
-
-    uint64_t m_cr0;
-    uint64_t m_cr3;
-    uint64_t m_cr4;
-    uint64_t m_dr7;
-    uint64_t m_rflags;
-
-    gdt_t m_gdt_reg;
-    idt_t m_idt_reg;
-
-    uint32_t m_es_limit;
-    uint32_t m_cs_limit;
-    uint32_t m_ss_limit;
-    uint32_t m_ds_limit;
-    uint32_t m_fs_limit;
-    uint32_t m_gs_limit;
-    uint32_t m_ldtr_limit;
-    uint32_t m_tr_limit;
-
-    uint32_t m_es_access;
-    uint32_t m_cs_access;
-    uint32_t m_ss_access;
-    uint32_t m_ds_access;
-    uint32_t m_fs_access;
-    uint32_t m_gs_access;
-    uint32_t m_ldtr_access;
-    uint32_t m_tr_access;
-
-    uint64_t m_es_base;
-    uint64_t m_cs_base;
-    uint64_t m_ss_base;
-    uint64_t m_ds_base;
-    uint64_t m_fs_base;
-    uint64_t m_gs_base;
-    uint64_t m_ldtr_base;
-    uint64_t m_tr_base;
-
-    bool m_valid;
-    std::unique_ptr<char[]> m_vmcs_region;
+    uint64_t m_msr_bitmap_phys;
+    uint64_t m_io_bitmap_a_phys;
+    uint64_t m_io_bitmap_b_phys;
 
     intrinsics_intel_x64 *m_intrinsics;
+
+    uint64_t m_vmcs_region_phys;
+    std::unique_ptr<char[]> m_vmcs_region;
 };
 
 #endif

--- a/bfvmm/include/vmcs/vmcs_state_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_state_intel_x64.h
@@ -1,0 +1,524 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_STATE_INTEL_X64_H
+#define VMCS_STATE_INTEL_X64_H
+
+#include <intrinsics/intrinsics_intel_x64.h>
+
+class vmcs_state_intel_x64
+{
+public:
+
+    vmcs_state_intel_x64() :
+        m_es(0),
+        m_cs(0),
+        m_ss(0),
+        m_ds(0),
+        m_fs(0),
+        m_gs(0),
+        m_tr(0),
+        m_cr0(0),
+        m_cr3(0),
+        m_cr4(0),
+        m_dr7(0),
+        m_rflags(0),
+        m_gdt_reg{},
+        m_idt_reg{},
+        m_es_limit(0),
+        m_cs_limit(0),
+        m_ss_limit(0),
+        m_ds_limit(0),
+        m_fs_limit(0),
+        m_gs_limit(0),
+        m_tr_limit(0),
+        m_es_access(0),
+        m_cs_access(0),
+        m_ss_access(0),
+        m_ds_access(0),
+        m_fs_access(0),
+        m_gs_access(0),
+        m_tr_access(0),
+        m_es_base(0),
+        m_cs_base(0),
+        m_ss_base(0),
+        m_ds_base(0),
+        m_fs_base(0),
+        m_gs_base(0),
+        m_tr_base(0),
+        m_ia32_debugctl_msr(0),
+        m_ia32_efer_msr(0),
+        m_ia32_pat_msr(0),
+        m_ia32_vmx_pinbased_ctls_msr(0),
+        m_ia32_vmx_procbased_ctls_msr(0),
+        m_ia32_vmx_exit_ctls_msr(0),
+        m_ia32_vmx_entry_ctls_msr(0),
+        m_ia32_sysenter_cs_msr(0),
+        m_ia32_sysenter_esp_msr(0),
+        m_ia32_sysenter_eip_msr(0),
+        m_ia32_fs_base_msr(0),
+        m_ia32_gs_base_msr(0)
+    {}
+
+    vmcs_state_intel_x64(intrinsics_intel_x64 *intrinsics) :
+        m_es(0),
+        m_cs(0),
+        m_ss(0),
+        m_ds(0),
+        m_fs(0),
+        m_gs(0),
+        m_tr(0),
+        m_cr0(0),
+        m_cr3(0),
+        m_cr4(0),
+        m_dr7(0),
+        m_rflags(0),
+        m_gdt_reg{},
+        m_idt_reg{},
+        m_es_limit(0),
+        m_cs_limit(0),
+        m_ss_limit(0),
+        m_ds_limit(0),
+        m_fs_limit(0),
+        m_gs_limit(0),
+        m_tr_limit(0),
+        m_es_access(0),
+        m_cs_access(0),
+        m_ss_access(0),
+        m_ds_access(0),
+        m_fs_access(0),
+        m_gs_access(0),
+        m_tr_access(0),
+        m_es_base(0),
+        m_cs_base(0),
+        m_ss_base(0),
+        m_ds_base(0),
+        m_fs_base(0),
+        m_gs_base(0),
+        m_tr_base(0),
+        m_ia32_debugctl_msr(0),
+        m_ia32_efer_msr(0),
+        m_ia32_pat_msr(0),
+        m_ia32_vmx_pinbased_ctls_msr(0),
+        m_ia32_vmx_procbased_ctls_msr(0),
+        m_ia32_vmx_exit_ctls_msr(0),
+        m_ia32_vmx_entry_ctls_msr(0),
+        m_ia32_sysenter_cs_msr(0),
+        m_ia32_sysenter_esp_msr(0),
+        m_ia32_sysenter_eip_msr(0),
+        m_ia32_fs_base_msr(0),
+        m_ia32_gs_base_msr(0)
+    {
+        m_es = intrinsics->read_es();
+        m_cs = intrinsics->read_cs();
+        m_ss = intrinsics->read_ss();
+        m_ds = intrinsics->read_ds();
+        m_fs = intrinsics->read_fs();
+        m_gs = intrinsics->read_gs();
+        m_tr = intrinsics->read_tr();
+
+        m_cr0 = intrinsics->read_cr0();
+        m_cr3 = intrinsics->read_cr3();
+        m_cr4 = intrinsics->read_cr4();
+        m_dr7 = intrinsics->read_dr7();
+
+        m_rflags = intrinsics->read_rflags();
+
+        intrinsics->read_gdt(&m_gdt_reg);
+        intrinsics->read_idt(&m_idt_reg);
+
+        m_es_limit = intrinsics->segment_descriptor_limit(m_es);
+        m_cs_limit = intrinsics->segment_descriptor_limit(m_cs);
+        m_ss_limit = intrinsics->segment_descriptor_limit(m_ss);
+        m_ds_limit = intrinsics->segment_descriptor_limit(m_ds);
+        m_fs_limit = intrinsics->segment_descriptor_limit(m_fs);
+        m_gs_limit = intrinsics->segment_descriptor_limit(m_gs);
+        m_tr_limit = intrinsics->segment_descriptor_limit(m_tr);
+
+        m_es_access = intrinsics->segment_descriptor_access(m_es);
+        m_cs_access = intrinsics->segment_descriptor_access(m_cs);
+        m_ss_access = intrinsics->segment_descriptor_access(m_ss);
+        m_ds_access = intrinsics->segment_descriptor_access(m_ds);
+        m_fs_access = intrinsics->segment_descriptor_access(m_fs);
+        m_gs_access = intrinsics->segment_descriptor_access(m_gs);
+        m_tr_access = intrinsics->segment_descriptor_access(m_tr);
+
+        m_es_base = intrinsics->segment_descriptor_base(m_es);
+        m_cs_base = intrinsics->segment_descriptor_base(m_cs);
+        m_ss_base = intrinsics->segment_descriptor_base(m_ss);
+        m_ds_base = intrinsics->segment_descriptor_base(m_ds);
+        m_fs_base = intrinsics->segment_descriptor_base(m_fs);
+        m_gs_base = intrinsics->segment_descriptor_base(m_gs);
+        m_tr_base = intrinsics->segment_descriptor_base(m_tr);
+
+        m_ia32_debugctl_msr = intrinsics->read_msr(IA32_DEBUGCTL_MSR);
+        m_ia32_efer_msr = intrinsics->read_msr(IA32_EFER_MSR);
+        m_ia32_pat_msr = intrinsics->read_msr(IA32_PAT_MSR);
+        m_ia32_sysenter_cs_msr = intrinsics->read_msr32(IA32_SYSENTER_CS_MSR);
+        m_ia32_sysenter_esp_msr = intrinsics->read_msr32(IA32_SYSENTER_ESP_MSR);
+        m_ia32_sysenter_eip_msr = intrinsics->read_msr32(IA32_SYSENTER_EIP_MSR);
+        m_ia32_fs_base_msr = intrinsics->read_msr(IA32_FS_BASE_MSR);
+        m_ia32_gs_base_msr = intrinsics->read_msr(IA32_GS_BASE_MSR);
+    }
+
+    ~vmcs_state_intel_x64() {}
+
+    uint16_t es() const
+    { return m_es; }
+
+    uint16_t cs() const
+    { return m_cs; }
+
+    uint16_t ss() const
+    { return m_ss; }
+
+    uint16_t ds() const
+    { return m_ds; }
+
+    uint16_t fs() const
+    { return m_fs; }
+
+    uint16_t gs() const
+    { return m_gs; }
+
+    uint16_t tr() const
+    { return m_tr; }
+
+    void set_es(uint16_t val)
+    { m_es = val; }
+
+    void set_cs(uint16_t val)
+    { m_cs = val; }
+
+    void set_ss(uint16_t val)
+    { m_ss = val; }
+
+    void set_ds(uint16_t val)
+    { m_ds = val; }
+
+    void set_fs(uint16_t val)
+    { m_fs = val; }
+
+    void set_gs(uint16_t val)
+    { m_gs = val; }
+
+    void set_tr(uint16_t val)
+    { m_tr = val; }
+
+    uint64_t cr0() const
+    { return m_cr0; }
+
+    uint64_t cr3() const
+    { return m_cr3; }
+
+    uint64_t cr4() const
+    { return m_cr4; }
+
+    uint64_t dr7() const
+    { return m_dr7; }
+
+    void set_cr0(uint64_t val)
+    { m_cr0 = val; }
+
+    void set_cr3(uint64_t val)
+    { m_cr3 = val; }
+
+    void set_cr4(uint64_t val)
+    { m_cr4 = val; }
+
+    void set_dr7(uint64_t val)
+    { m_dr7 = val; }
+
+    uint64_t rflags() const
+    { return m_rflags; }
+
+    void set_rflags(uint64_t val)
+    { m_rflags = val; }
+
+    gdt_t gdt() const
+    { return m_gdt_reg; }
+
+    idt_t idt() const
+    { return m_idt_reg; }
+
+    void set_gdt(gdt_t val)
+    { m_gdt_reg = val; }
+
+    void set_idt(idt_t val)
+    { m_idt_reg = val; }
+
+    uint32_t es_limit() const
+    { return m_es_limit; }
+
+    uint32_t cs_limit() const
+    { return m_cs_limit; }
+
+    uint32_t ss_limit() const
+    { return m_ss_limit; }
+
+    uint32_t ds_limit() const
+    { return m_ds_limit; }
+
+    uint32_t fs_limit() const
+    { return m_fs_limit; }
+
+    uint32_t gs_limit() const
+    { return m_gs_limit; }
+
+    uint32_t tr_limit() const
+    { return m_tr_limit; }
+
+    void set_es_limit(uint32_t val)
+    { m_es_limit = val; }
+
+    void set_cs_limit(uint32_t val)
+    { m_cs_limit = val; }
+
+    void set_ss_limit(uint32_t val)
+    { m_ss_limit = val; }
+
+    void set_ds_limit(uint32_t val)
+    { m_ds_limit = val; }
+
+    void set_fs_limit(uint32_t val)
+    { m_fs_limit = val; }
+
+    void set_gs_limit(uint32_t val)
+    { m_gs_limit = val; }
+
+    void set_tr_limit(uint32_t val)
+    { m_tr_limit = val; }
+
+    uint32_t es_access() const
+    { return m_es_access; }
+
+    uint32_t cs_access() const
+    { return m_cs_access; }
+
+    uint32_t ss_access() const
+    { return m_ss_access; }
+
+    uint32_t ds_access() const
+    { return m_ds_access; }
+
+    uint32_t fs_access() const
+    { return m_fs_access; }
+
+    uint32_t gs_access() const
+    { return m_gs_access; }
+
+    uint32_t tr_access() const
+    { return m_tr_access; }
+
+    void set_es_access(uint32_t val)
+    { m_es_access = val; }
+
+    void set_cs_access(uint32_t val)
+    { m_cs_access = val; }
+
+    void set_ss_access(uint32_t val)
+    { m_ss_access = val; }
+
+    void set_ds_access(uint32_t val)
+    { m_ds_access = val; }
+
+    void set_fs_access(uint32_t val)
+    { m_fs_access = val; }
+
+    void set_gs_access(uint32_t val)
+    { m_gs_access = val; }
+
+    void set_tr_access(uint32_t val)
+    { m_tr_access = val; }
+
+    uint64_t es_base() const
+    { return m_es_base; }
+
+    uint64_t cs_base() const
+    { return m_cs_base; }
+
+    uint64_t ss_base() const
+    { return m_ss_base; }
+
+    uint64_t ds_base() const
+    { return m_ds_base; }
+
+    uint64_t fs_base() const
+    { return m_fs_base; }
+
+    uint64_t gs_base() const
+    { return m_gs_base; }
+
+    uint64_t tr_base() const
+    { return m_tr_base; }
+
+    void set_es_base(uint64_t val)
+    { m_es_base = val; }
+
+    void set_cs_base(uint64_t val)
+    { m_cs_base = val; }
+
+    void set_ss_base(uint64_t val)
+    { m_ss_base = val; }
+
+    void set_ds_base(uint64_t val)
+    { m_ds_base = val; }
+
+    void set_fs_base(uint64_t val)
+    { m_fs_base = val; }
+
+    void set_gs_base(uint64_t val)
+    { m_gs_base = val; }
+
+    void set_tr_base(uint64_t val)
+    { m_tr_base = val; }
+
+    uint64_t ia32_debugctl_msr() const
+    { return m_ia32_debugctl_msr; }
+
+    uint64_t ia32_efer_msr() const
+    { return m_ia32_efer_msr; }
+
+    uint64_t ia32_pat_msr() const
+    { return m_ia32_pat_msr; }
+
+    uint64_t ia32_vmx_pinbased_ctls_msr() const
+    { return m_ia32_vmx_pinbased_ctls_msr; }
+
+    uint64_t ia32_vmx_procbased_ctls_msr() const
+    { return m_ia32_vmx_procbased_ctls_msr; }
+
+    uint64_t ia32_vmx_exit_ctls_msr() const
+    { return m_ia32_vmx_exit_ctls_msr; }
+
+    uint64_t ia32_vmx_entry_ctls_msr() const
+    { return m_ia32_vmx_entry_ctls_msr; }
+
+    uint64_t ia32_sysenter_cs_msr() const
+    { return m_ia32_sysenter_cs_msr; }
+
+    uint64_t ia32_sysenter_esp_msr() const
+    { return m_ia32_sysenter_esp_msr; }
+
+    uint64_t ia32_sysenter_eip_msr() const
+    { return m_ia32_sysenter_eip_msr; }
+
+    uint64_t ia32_fs_base_msr() const
+    { return m_ia32_fs_base_msr; }
+
+    uint64_t ia32_gs_base_msr() const
+    { return m_ia32_gs_base_msr; }
+
+    void set_ia32_debugctl_msr(uint64_t val)
+    { m_ia32_debugctl_msr = val; }
+
+    void set_ia32_efer_msr(uint64_t val)
+    { m_ia32_efer_msr = val; }
+
+    void set_ia32_pat_msr(uint64_t val)
+    { m_ia32_pat_msr = val; }
+
+    void set_ia32_vmx_pinbased_ctls_msr(uint64_t val)
+    { m_ia32_vmx_pinbased_ctls_msr = val; }
+
+    void set_ia32_vmx_procbased_ctls_msr(uint64_t val)
+    { m_ia32_vmx_procbased_ctls_msr = val; }
+
+    void set_ia32_vmx_exit_ctls_msr(uint64_t val)
+    { m_ia32_vmx_exit_ctls_msr = val; }
+
+    void set_ia32_vmx_entry_ctls_msr(uint64_t val)
+    { m_ia32_vmx_entry_ctls_msr = val; }
+
+    void set_ia32_sysenter_cs_msr(uint64_t val)
+    { m_ia32_sysenter_cs_msr = val; }
+
+    void set_ia32_sysenter_esp_msr(uint64_t val)
+    { m_ia32_sysenter_esp_msr = val; }
+
+    void set_ia32_sysenter_eip_msr(uint64_t val)
+    { m_ia32_sysenter_eip_msr = val; }
+
+    void set_ia32_fs_base_msr(uint64_t val)
+    { m_ia32_fs_base_msr = val; }
+
+    void set_ia32_gs_base_msr(uint64_t val)
+    { m_ia32_gs_base_msr = val; }
+
+private:
+
+    uint16_t m_es;
+    uint16_t m_cs;
+    uint16_t m_ss;
+    uint16_t m_ds;
+    uint16_t m_fs;
+    uint16_t m_gs;
+    uint16_t m_tr;
+
+    uint64_t m_cr0;
+    uint64_t m_cr3;
+    uint64_t m_cr4;
+    uint64_t m_dr7;
+
+    uint64_t m_rflags;
+
+    gdt_t m_gdt_reg;
+    idt_t m_idt_reg;
+
+    uint32_t m_es_limit;
+    uint32_t m_cs_limit;
+    uint32_t m_ss_limit;
+    uint32_t m_ds_limit;
+    uint32_t m_fs_limit;
+    uint32_t m_gs_limit;
+    uint32_t m_tr_limit;
+
+    uint32_t m_es_access;
+    uint32_t m_cs_access;
+    uint32_t m_ss_access;
+    uint32_t m_ds_access;
+    uint32_t m_fs_access;
+    uint32_t m_gs_access;
+    uint32_t m_tr_access;
+
+    uint64_t m_es_base;
+    uint64_t m_cs_base;
+    uint64_t m_ss_base;
+    uint64_t m_ds_base;
+    uint64_t m_fs_base;
+    uint64_t m_gs_base;
+    uint64_t m_tr_base;
+
+    uint64_t m_ia32_debugctl_msr;
+    uint64_t m_ia32_efer_msr;
+    uint64_t m_ia32_pat_msr;
+    uint64_t m_ia32_vmx_pinbased_ctls_msr;
+    uint64_t m_ia32_vmx_procbased_ctls_msr;
+    uint64_t m_ia32_vmx_exit_ctls_msr;
+    uint64_t m_ia32_vmx_entry_ctls_msr;
+    uint64_t m_ia32_sysenter_cs_msr;
+    uint64_t m_ia32_sysenter_esp_msr;
+    uint64_t m_ia32_sysenter_eip_msr;
+    uint64_t m_ia32_fs_base_msr;
+    uint64_t m_ia32_gs_base_msr;
+};
+
+#endif

--- a/bfvmm/include/vmxon/vmxon_exceptions_intel_x64.h
+++ b/bfvmm/include/vmxon/vmxon_exceptions_intel_x64.h
@@ -54,7 +54,6 @@ public:
         m_func(func),
         m_line(line)
     {}
-    virtual ~vmxon_failure_error() {}
 
     virtual std::ostream &print(std::ostream &os) const
     {
@@ -82,14 +81,14 @@ private:
 class vmxon_capabilities_failure_error : public bfn::general_exception
 {
 public:
-    vmxon_capabilities_failure_error(const std::string &msr_name,
-                                     const std::string &field_name,
+    vmxon_capabilities_failure_error(const std::string &msr_str,
+                                     const std::string &field_str,
                                      uint64_t msr,
                                      uint64_t field,
                                      const std::string &func,
                                      uint64_t line) :
-        m_msr_name(msr_name),
-        m_field_name(field_name),
+        m_msr_str(msr_str),
+        m_field_str(field_str),
         m_msr(msr),
         m_field(field),
         m_func(func),
@@ -99,8 +98,8 @@ public:
     virtual std::ostream &print(std::ostream &os) const
     {
         os << "vmxon capabilities not supported:";
-        os << std::endl << "    - " << m_msr_name << ": " << m_msr;
-        os << std::endl << "    - " << m_field_name << ": " << m_field;
+        os << std::endl << "    - " << m_msr_str << ": " << (void *)m_msr;
+        os << std::endl << "    - " << m_field_str << ": " << (void *)m_field;
         os << std::endl << "    - func: " << m_func;
         os << std::endl << "    - line: " << m_line;
 
@@ -108,8 +107,8 @@ public:
     }
 
 private:
-    std::string m_msr_name;
-    std::string m_field_name;
+    std::string m_msr_str;
+    std::string m_field_str;
     uint64_t m_msr;
     uint64_t m_field;
     std::string m_func;
@@ -126,17 +125,17 @@ private:
 class vmxon_fixed_msr_failure_error : public bfn::general_exception
 {
 public:
-    vmxon_fixed_msr_failure_error(const std::string &cr_name,
-                                  const std::string &fixed0_name,
-                                  const std::string &fixed1_name,
+    vmxon_fixed_msr_failure_error(const std::string &cr_str,
+                                  const std::string &fixed0_str,
+                                  const std::string &fixed1_str,
                                   uint64_t cr,
                                   uint64_t fixed0,
                                   uint64_t fixed1,
                                   const std::string &func,
                                   uint64_t line) :
-        m_cr_name(cr_name),
-        m_fixed0_name(fixed0_name),
-        m_fixed1_name(fixed1_name),
+        m_cr_str(cr_str),
+        m_fixed0_str(fixed0_str),
+        m_fixed1_str(fixed1_str),
         m_cr(cr),
         m_fixed0(fixed0),
         m_fixed1(fixed1),
@@ -147,21 +146,19 @@ public:
     virtual std::ostream &print(std::ostream &os) const
     {
         os << "vmxon fixed msr bits not supported:";
-        os << std::hex;
-        os << std::endl << "    - " << m_cr_name << ": " << m_cr;
-        os << std::endl << "    - " << m_fixed0_name << ": " << m_fixed0;
-        os << std::endl << "    - " << m_fixed1_name << ": " << m_fixed1;
+        os << std::endl << "    - " << m_cr_str << ": " << (void *)m_cr;
+        os << std::endl << "    - " << m_fixed0_str << ": " << (void *)m_fixed0;
+        os << std::endl << "    - " << m_fixed1_str << ": " << (void *)m_fixed1;
         os << std::endl << "    - func: " << m_func;
         os << std::endl << "    - line: " << m_line;
-        os << std::dec;
 
         return os;
     }
 
 private:
-    const std::string &m_cr_name;
-    const std::string &m_fixed0_name;
-    const std::string &m_fixed1_name;
+    const std::string &m_cr_str;
+    const std::string &m_fixed0_str;
+    const std::string &m_fixed1_str;
     uint64_t m_cr;
     uint64_t m_fixed0;
     uint64_t m_fixed1;

--- a/bfvmm/include/vmxon/vmxon_intel_x64.h
+++ b/bfvmm/include/vmxon/vmxon_intel_x64.h
@@ -23,7 +23,6 @@
 #define VMXON_INTEL_X64_H
 
 #include <memory>
-#include <memory_manager/memory_manager.h>
 #include <intrinsics/intrinsics_intel_x64.h>
 
 // -----------------------------------------------------------------------------

--- a/bfvmm/src/entry/src/Makefile
+++ b/bfvmm/src/entry/src/Makefile
@@ -60,6 +60,7 @@ CROSS_OUTDIR:=../../../bin
 ################################################################################
 
 SOURCES+=entry.cpp
+SOURCES+=entry_asm.asm
 
 INCLUDE_PATHS+=./
 INCLUDE_PATHS+=../../../include/

--- a/bfvmm/src/entry/src/entry_asm.asm
+++ b/bfvmm/src/entry/src/entry_asm.asm
@@ -1,0 +1,44 @@
+;
+; Bareflank Hypervisor
+;
+; Copyright (C) 2015 Assured Information Security, Inc.
+; Author: Rian Quinn        <quinnr@ainfosec.com>
+; Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+;
+; This library is free software; you can redistribute it and/or
+; modify it under the terms of the GNU Lesser General Public
+; License as published by the Free Software Foundation; either
+; version 2.1 of the License, or (at your option) any later version.
+;
+; This library is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+; Lesser General Public License for more details.
+;
+; You should have received a copy of the GNU Lesser General Public
+; License along with this library; if not, write to the Free Software
+; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+bits 64
+default rel
+
+global execute_with_stack:function
+
+section .text
+
+; int64_t execute_with_stack(entry_t func, void *stack, uint64_t size);
+execute_with_stack:
+    push rbp
+    mov rbp, rsp
+
+    mov rsp, rsi
+    add rsp, rdx
+    sub rsp, 1
+
+    call rdi
+
+    leave
+    ret
+
+
+

--- a/bfvmm/src/intrinsics/src/intrinsics_x64.asm
+++ b/bfvmm/src/intrinsics/src/intrinsics_x64.asm
@@ -40,6 +40,7 @@ global __write_dr7:function
 global __read_es:function
 global __write_es:function
 global __read_cs:function
+global __write_cs:function
 global __read_ss:function
 global __write_ss:function
 global __read_ds:function
@@ -235,6 +236,11 @@ __write_es:
 __read_cs:
     mov rax, 0
     mov ax, cs
+    ret
+
+; void __write_cs(uint16_t val)
+__write_cs:
+    mov cs, di
     ret
 
 ; uint16_t __read_ss(void)

--- a/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
@@ -19,6 +19,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <commit_or_rollback.h>
 #include <vcpu/vcpu_intel_x64.h>
 
 
@@ -26,6 +27,9 @@
 //     if possible (maybe shared if we have to pass them around)
 //
 // TODO: Change to exception logic
+//
+// TODO: If the launch fails, it still tries to "request" a teardown, and
+// crashes with an invalid opcode.
 
 
 
@@ -64,10 +68,17 @@ vcpu_intel_x64::vcpu_intel_x64(int64_t id,
 vcpu_error::type
 vcpu_intel_x64::start()
 {
+    auto cor1 = commit_or_rollback([&]
+    { m_vmxon->stop(); });
+
     m_vmxon->start();
 
-    if (m_vmcs->launch() != vmcs_error::success)
-        return vcpu_error::failure;
+    auto host_state = vmcs_state_intel_x64(m_intrinsics);
+    auto guest_state = vmcs_state_intel_x64(m_intrinsics);
+
+    m_vmcs->launch(host_state, guest_state);
+
+    cor1.commit();
 
     return vcpu_error::success;
 }
@@ -83,8 +94,6 @@ vcpu_intel_x64::dispatch()
 vcpu_error::type
 vcpu_intel_x64::stop()
 {
-    m_vmcs->clear_vmcs_region();
-
     m_vmxon->stop();
 
     return vcpu_error::success;
@@ -93,7 +102,8 @@ vcpu_intel_x64::stop()
 vcpu_error::type
 vcpu_intel_x64::promote()
 {
-    m_vmcs->unlaunch();
+    m_vmcs->promote();
+
     return vcpu_error::success;
 }
 
@@ -102,12 +112,10 @@ vcpu_intel_x64::request_teardown()
 {
     if (vcpu_error::success == m_intrinsics->vmcall(VMCS_PROMOTION))
     {
-        std::cout << "Promoted guest to VMX Root" << std::endl;
         return vcpu_error::success;
     }
     else
     {
-        std::cout << "Invalid vmcall id" << std::endl;
         return vcpu_error::success;
     }
 

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -19,447 +19,144 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <iomanip>
-#include <iostream>
-
+#include <debug.h>
+#include <commit_or_rollback.h>
 #include <vmcs/vmcs_intel_x64.h>
+#include <vmcs/vmcs_exceptions_intel_x64.h>
 #include <exit_handler/exit_handler.h>
-
-// =============================================================================
-//  Helper Structs
-// =============================================================================
-
-struct vmcs_region
-{
-    uint32_t revision_id;
-};
+#include <memory_manager/memory_manager.h>
 
 // =============================================================================
 //  Implementation
 // =============================================================================
 
 vmcs_intel_x64::vmcs_intel_x64(intrinsics_intel_x64 *intrinsics) :
-    m_msr_bitmap(4096 * 8), m_intrinsics(intrinsics)
+    m_msr_bitmap(4096 * 8),
+    m_io_bitmap_a(4096 * 8),
+    m_io_bitmap_b(4096 * 8),
+    m_intrinsics(intrinsics)
 {
-
+    m_msr_bitmap_phys = m_msr_bitmap.phys_addr();
+    m_io_bitmap_a_phys = m_io_bitmap_a.phys_addr();
+    m_io_bitmap_b_phys = m_io_bitmap_b.phys_addr();
 }
 
-vmcs_error::type
-vmcs_intel_x64::launch()
+void
+vmcs_intel_x64::launch(const vmcs_state_intel_x64 &host_state,
+                       const vmcs_state_intel_x64 &guest_state)
 {
-    vmcs_error::type ret;
+    if (m_intrinsics == NULL)
+        throw invalid_vmcs();
 
-    if (m_intrinsics == 0)
-        return vmcs_error::failure;
+    auto cor1 = commit_or_rollback([&]
+    { this->release_vmcs_region(); });
 
-    // Before we can do anything, we need to save the state of the CPU. This
-    // information will be used to fill in the VMCS fields, and prevents a
-    // lot of duplication.
+    this->create_vmcs_region();
 
-    ret = save_state();
-    if (ret != vmcs_error::success)
-        return ret;
+    if (m_intrinsics->vmclear(&m_vmcs_region_phys) == false)
+        throw vmcs_failure("failed to clear vmcs");
 
-    // The process for luanching a virtual machine can be found in the
-    // Intel Software Developers Manual, in section 31.6. This process is
-    // a complete nightmare, so make sure you take a look at this
-    // documentation for trying to make sense of the code in this class.
+    if (m_intrinsics->vmptrld(&m_vmcs_region_phys) == false)
+        throw vmcs_failure("failed to load vmcs");
 
-    ret = create_vmcs_region();
-    if (ret != vmcs_error::success)
-        return ret;
+    this->write_16bit_guest_state(guest_state);
+    this->write_64bit_guest_state(guest_state);
+    this->write_32bit_guest_state(guest_state);
+    this->write_natural_guest_state(guest_state);
 
-    ret = clear_vmcs_region();
-    if (ret != vmcs_error::success)
-        return ret;
+    this->write_16bit_control_state(host_state);
+    this->write_64bit_control_state(host_state);
+    this->write_32bit_control_state(host_state);
+    this->write_natural_control_state(host_state);
 
-    ret = load_vmcs_region();
-    if (ret != vmcs_error::success)
-        return ret;
+    this->write_16bit_host_state(host_state);
+    this->write_64bit_host_state(host_state);
+    this->write_32bit_host_state(host_state);
+    this->write_natural_host_state(host_state);
 
-    // The next set of steps fills in the previously loaded VMCS with
-    // information about the guest / host. In this case, the guest is the
-    // host OS that is running this code, and the host, is the VMM exit
-    // handler that we provide. Note that if something goes wrong, it's
-    // likely in the code below. For more information about how to debug
-    // issues with this code, see Chapter 27 in the Intel Software Developers
-    // Manual.
-
-    // Also, note that the VMCS fields are fully documented in appendix
-    // B of the Intel Software Developers Manual.
-
-    ret = write_16bit_control_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_16bit_guest_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_16bit_host_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_64bit_control_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_64bit_guest_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_64bit_host_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_32bit_control_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_32bit_guest_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_32bit_host_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_natural_width_control_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_natural_width_guest_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = write_natural_width_host_state_fields();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    // Once the VMCS is setup, we need to turn on certain bits within the VMCS
-    // that tell VT-x how to treat out VMM as well as the guest VM that we plan
-    // to launch. Note that we could put these calls in the above code, but
-    // this makes it more explicit about what we plan to enable, outside of
-    // the bare minimum, which is what the above code is doing.
-
-    ret = default_pin_based_vm_execution_controls();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = default_primary_processor_based_vm_execution_controls();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = default_secondary_processor_based_vm_execution_controls();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = default_vm_exit_controls();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    ret = default_vm_entry_controls();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    // =========================================================================
-    // CLEAN ME UP
-    // =========================================================================
-    vmwrite(VMCS_ADDRESS_OF_MSR_BITMAPS_FULL, (uint64_t)g_mm->virt_to_phys(m_msr_bitmap.address()));
-
-    // =========================================================================
-    // CLEAN ME UP
-    // =========================================================================
-
-    // Before we attempt to launch the VMM, we run a bunch of tests on the
-    // VMCS to verify that the state of the VMCS is valid. These checks come
-    // from the intel software developer's manual, volume 3, chapter 26. Most
-    // of these checks are in the same order as the documentation.
-
-    // if (check_vmcs_host_state() == false)
-    //     return vmcs_error::failure;
-
-    // if (check_vmcs_guest_state() == false)
-    //     return vmcs_error::failure;
-
-    // if (check_vmcs_control_state() == false)
-    //     return vmcs_error::failure;
-
-    // If there happens to be an issue with the VMCS, you can use these
-    // functions to print out the state of the VMCS, as well as the internal
-    // state of this object so that you can check to see if there are any
-    // issues.
-
-    // dump_vmcs();
-    // dump_state();
-
-    // The last step is to launch the VMCS. If the launch fails, we must
-    // go through a series of error checks to identify why the failure
-    // occured. If the launch succeeds, we should continue execution as
-    // normal, not this code will be in a virtual machine when finished.
-    ret = launch_vmcs();
-    if (ret != vmcs_error::success)
-        return ret;
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::launch_vmcs()
-{
-    if (m_valid == false)
-    {
-        std::cout << "unable to launch VMCS, a failure invalidated the VMCS.";
-        std::cout << std::endl;
-
-        return vmcs_error::failure;
-    }
+    this->default_pin_based_vm_execution_controls();
+    this->default_primary_processor_based_vm_execution_controls();
+    this->default_secondary_processor_based_vm_execution_controls();
+    this->default_vm_exit_controls();
+    this->default_vm_entry_controls();
 
     if (m_intrinsics->vmlaunch() == false)
+        throw vmcs_launch_failure(this->check_vm_instruction_error());
+
+    cor1.commit();
+}
+
+void
+vmcs_intel_x64::promote()
+{
+    if (m_intrinsics == NULL)
+        throw invalid_vmcs();
+
+    auto cor1 = commit_or_rollback([&]
     {
-        std::cout << "vmlaunch instruction failed ";
-        std::cout << std::endl;
+        bffatal << "promote failed. unable to rollback state" << bfendl;
+        abort();
+    });
 
-        return vmcs_error::failure;
-    }
-
-    std::cout << "WOOT, launch was succesfull!!!" << std::endl;
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::resume_vmcs()
-{
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::save_state()
-{
-    m_es = m_intrinsics->read_es();
-    m_cs = m_intrinsics->read_cs();
-    m_ss = m_intrinsics->read_ss();
-    m_ds = m_intrinsics->read_ds();
-    m_fs = m_intrinsics->read_fs();
-    m_gs = m_intrinsics->read_gs();
-    m_ldtr = m_intrinsics->read_ldtr();
-    m_tr = m_intrinsics->read_tr();
-
-    m_cr0 = m_intrinsics->read_cr0();
-    m_cr3 = m_intrinsics->read_cr3();
-    m_cr4 = m_intrinsics->read_cr4();
-    m_dr7 = m_intrinsics->read_dr7();
-    m_rflags = m_intrinsics->read_rflags();
-
-    m_intrinsics->read_gdt(&m_gdt_reg);
-    m_intrinsics->read_idt(&m_idt_reg);
-
-    m_es_limit = m_intrinsics->segment_descriptor_limit(m_es);
-    m_cs_limit = m_intrinsics->segment_descriptor_limit(m_cs);
-    m_ss_limit = m_intrinsics->segment_descriptor_limit(m_ss);
-    m_ds_limit = m_intrinsics->segment_descriptor_limit(m_ds);
-    m_fs_limit = m_intrinsics->segment_descriptor_limit(m_fs);
-    m_gs_limit = m_intrinsics->segment_descriptor_limit(m_gs);
-    m_ldtr_limit = m_intrinsics->segment_descriptor_limit(m_ldtr);
-    m_tr_limit = m_intrinsics->segment_descriptor_limit(m_tr);
-
-    m_es_access = m_intrinsics->segment_descriptor_access(m_es);
-    m_cs_access = m_intrinsics->segment_descriptor_access(m_cs);
-    m_ss_access = m_intrinsics->segment_descriptor_access(m_ss);
-    m_ds_access = m_intrinsics->segment_descriptor_access(m_ds);
-    m_fs_access = m_intrinsics->segment_descriptor_access(m_fs);
-    m_gs_access = m_intrinsics->segment_descriptor_access(m_gs);
-    m_ldtr_access = m_intrinsics->segment_descriptor_access(m_ldtr);
-    m_tr_access = m_intrinsics->segment_descriptor_access(m_tr);
-
-    m_es_base = m_intrinsics->segment_descriptor_base(m_es);
-    m_cs_base = m_intrinsics->segment_descriptor_base(m_cs);
-    m_ss_base = m_intrinsics->segment_descriptor_base(m_ss);
-    m_ds_base = m_intrinsics->segment_descriptor_base(m_ds);
-    m_fs_base = m_intrinsics->segment_descriptor_base(m_fs);
-    m_gs_base = m_intrinsics->segment_descriptor_base(m_gs);
-    m_ldtr_base = m_intrinsics->segment_descriptor_base(m_ldtr);
-    m_tr_base = m_intrinsics->segment_descriptor_base(m_tr);
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::unlaunch()
-{
-    m_intrinsics->write_es(vmread(VMCS_GUEST_ES_SELECTOR));
-    m_intrinsics->write_ds(vmread(VMCS_GUEST_DS_SELECTOR));
-    m_intrinsics->write_fs(vmread(VMCS_GUEST_FS_SELECTOR));
-    m_intrinsics->write_gs(vmread(VMCS_GUEST_GS_SELECTOR));
-    m_intrinsics->write_msr(IA32_EFER_MSR, vmread(VMCS_GUEST_IA32_EFER_FULL));
-    m_intrinsics->write_msr(IA32_PAT_MSR, vmread(VMCS_GUEST_IA32_PAT_FULL));
-    m_intrinsics->write_msr(IA32_SYSENTER_CS_MSR, vmread(VMCS_GUEST_IA32_SYSENTER_CS));
-    m_intrinsics->write_msr(IA32_FS_BASE_MSR, vmread(VMCS_GUEST_FS_BASE));
-    m_intrinsics->write_msr(IA32_GS_BASE_MSR, vmread(VMCS_GUEST_GS_BASE));
-    m_intrinsics->write_msr(IA32_SYSENTER_ESP_MSR, vmread(VMCS_GUEST_IA32_SYSENTER_ESP));
-    m_intrinsics->write_msr(IA32_SYSENTER_EIP_MSR, vmread(VMCS_GUEST_IA32_SYSENTER_EIP));
-    m_intrinsics->write_cr3(vmread(VMCS_GUEST_CR3));
+    this->promote_16bit_guest_state();
+    this->promote_64bit_guest_state();
+    this->promote_32bit_guest_state();
+    this->promote_natural_guest_state();
 
     promote_vmcs_to_root();
-
-    // This doesn't actually get returned
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
 vmcs_intel_x64::create_vmcs_region()
 {
-    // Note: This relies on make_unique returning an already
-    // zeroed-out buffer (think calloc not malloc.)
+    auto cor1 = commit_or_rollback([&]
+    { this->release_vmcs_region(); });
+
     m_vmcs_region = std::make_unique<char[]>(4096);
+    m_vmcs_region_phys = (uintptr_t)g_mm->virt_to_phys(m_vmcs_region.get());
 
-    if (!m_vmcs_region)
+    if ((m_vmcs_region_phys & 0x0000000000000FFF) != 0)
+        throw invalid_alignmnet(
+            "vmxon region not page aligned", m_vmcs_region_phys);
+
+    auto region = (uint32_t *)m_vmcs_region.get();
+    region[0] = m_intrinsics->read_msr(IA32_VMX_BASIC_MSR) & 0x7FFFFFFFF;
+
+    cor1.commit();
+}
+
+void
+vmcs_intel_x64::release_vmcs_region()
+{
+    if (m_vmcs_region_phys != 0)
     {
-        std::cout << "create_vmcs_region failed: "
-                  << "out of memory" << std::endl;
-        return vmcs_error::out_of_memory;
+        if (m_intrinsics->vmclear(&m_vmcs_region_phys) == false)
+            throw vmcs_failure("failed to clear vmcs");
+
+        m_vmcs_region.reset();
+        m_vmcs_region_phys = 0;
     }
-
-    if ((((uintptr_t)g_mm->virt_to_phys(m_vmcs_region.get())) & 0x0000000000000FFF) != 0)
-    {
-        std::cout << "create_vmcs_region failed: "
-                  << "the allocated page is not page aligned:" << std::endl
-                  << "    - page phys: " << g_mm->virt_to_phys(m_vmcs_region.get())
-                  << std::endl;
-        return vmcs_error::not_supported;
-    }
-
-    auto reg = (vmcs_region *)m_vmcs_region.get();
-
-    // // The information regading this MSR can be found in appendix A.1. For
-    // // the VMX capabilities check, we need the following:
-    // //
-    // // - Bits 30:0 contain the 31-bit VMCS revision identifier used by the
-    // //   processor. Processors that use the same VMCS revision identifier use
-    // //   the same size for VMCS regions (see subsequent item on bits 44:32)
-
-    reg->revision_id = (m_intrinsics->read_msr(IA32_VMX_BASIC_MSR) & 0x7FFFFFFFF);
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::release_vmxon_region()
+void
+vmcs_intel_x64::write_16bit_control_state(const vmcs_state_intel_x64 &state)
 {
-    // This function should probably go away now.
-    return vmcs_error::success;
-}
+    (void) state;
 
-vmcs_error::type
-vmcs_intel_x64::clear_vmcs_region()
-{
-    auto phys = g_mm->virt_to_phys(m_vmcs_region.get());
-
-    // For some reason, the VMCLEAR instruction takes the address of a memory
-    // location that has the address of the VMCS region, which sadly is not
-    // well documented in the Intel manual.
-
-    if (m_intrinsics->vmclear(&phys) == false)
-    {
-        std::cout << "vmclear failed" << std::endl;
-        return vmcs_error::failure;
-    }
-
-    m_valid = true;
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::load_vmcs_region()
-{
-    auto phys = g_mm->virt_to_phys(m_vmcs_region.get());
-
-    // For some reason, the VMPTRLD instruction takes the address of a memory
-    // location that has the address of the VMCS region, which sadly is not
-    // well documented in the Intel manual.
-
-    if (m_intrinsics->vmptrld(&phys) == false)
-    {
-        std::cout << "vmptrld failed" << std::endl;
-        return vmcs_error::failure;
-    }
-
-    return vmcs_error::success;
-}
-
-uint64_t
-vmcs_intel_x64::vmcs_region_size()
-{
-    auto vmx_basic_msr = m_intrinsics->read_msr(IA32_VMX_BASIC_MSR);
-
-    // The information regading this MSR can be found in appendix A.1. For
-    // the VMX capabilities check, we need the following:
-    //
-    // - Bits 44:32 report the number of bytes that software should allocate
-    //   for the VMXON region and any VMCS region. It is a value greater
-    //   than 0 and at most 4096 (bit 44 is set if and only if bits 43:32 are
-    //   clear).
-    //
-    //   Note: We basically ignore the above bits and just allocate 4K for each
-    //   VMX region. The only thing we do with this function is ensure that
-    //   the page that we were given is at least this big
-
-    return (vmx_basic_msr >> 32) & 0x1FFF;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_16bit_control_fields()
-{
     // unused: VMCS_VIRTUAL_PROCESSOR_IDENTIFIER
     // unused: VMCS_POSTED_INTERRUPT_NOTIFICATION_VECTOR
     // unused: VMCS_EPTP_INDEX
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::write_16bit_guest_state_fields()
+void
+vmcs_intel_x64::write_64bit_control_state(const vmcs_state_intel_x64 &state)
 {
-    vmwrite(VMCS_GUEST_ES_SELECTOR, m_es);
-    vmwrite(VMCS_GUEST_CS_SELECTOR, m_cs);
-    vmwrite(VMCS_GUEST_SS_SELECTOR, m_ss);
-    vmwrite(VMCS_GUEST_DS_SELECTOR, m_ds);
-    vmwrite(VMCS_GUEST_FS_SELECTOR, m_fs);
-    vmwrite(VMCS_GUEST_GS_SELECTOR, m_gs);
-    vmwrite(VMCS_GUEST_LDTR_SELECTOR, m_ldtr);
-    vmwrite(VMCS_GUEST_TR_SELECTOR, m_tr);
+    (void) state;
 
-    // unused: VMCS_GUEST_INTERRUPT_STATUS
+    vmwrite(VMCS_ADDRESS_OF_MSR_BITMAPS_FULL, m_msr_bitmap_phys);
+    vmwrite(VMCS_ADDRESS_OF_IO_BITMAP_A_FULL, m_io_bitmap_a_phys);
+    vmwrite(VMCS_ADDRESS_OF_IO_BITMAP_B_FULL, m_io_bitmap_b_phys);
 
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_16bit_host_state_fields()
-{
-    vmwrite(VMCS_HOST_CS_SELECTOR, m_cs);
-    vmwrite(VMCS_HOST_SS_SELECTOR, m_ss);
-    vmwrite(VMCS_HOST_TR_SELECTOR, m_tr);
-
-    // unused: VMCS_HOST_ES_SELECTOR
-    // unused: VMCS_HOST_DS_SELECTOR
-    // unused: VMCS_HOST_FS_SELECTOR
-    // unused: VMCS_HOST_GS_SELECTOR
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_64bit_control_fields()
-{
-    // Note: Since we are in 64bit mode, we do not need to load both the
-    //       high and full fields. We simply need to load the full field
-    //       with 64bit writes, which will fill in the high field for us.
-
-    // unused: VMCS_ADDRESS_OF_IO_BITMAP_A_FULL
-    // unused: VMCS_ADDRESS_OF_IO_BITMAP_B_FULL
-    // unused: VMCS_ADDRESS_OF_MSR_BITMAPS_FULL
     // unused: VMCS_VM_EXIT_MSR_STORE_ADDRESS_FULL
     // unused: VMCS_VM_EXIT_MSR_LOAD_ADDRESS_FULL
     // unused: VMCS_VM_ENTRY_MSR_LOAD_ADDRESS_FULL
@@ -479,82 +176,39 @@ vmcs_intel_x64::write_64bit_control_fields()
     // unused: VMCS_VMWRITE_BITMAP_ADDRESS_FULL
     // unused: VMCS_VIRTUALIZATION_EXCEPTION_INFORMATION_ADDRESS_FULL
     // unused: VMCS_XSS_EXITING_BITMAP_FULL
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::write_64bit_guest_state_fields()
+void
+vmcs_intel_x64::write_32bit_control_state(const vmcs_state_intel_x64 &state)
 {
-    // Note: Since we are in 64bit mode, we do not need to load both the
-    //       high and full fields. We simply need to load the full field
-    //       with 64bit writes, which will fill in the high field for us.
+    (void) state;
 
-    vmwrite(VMCS_VMCS_LINK_POINTER_FULL, 0xFFFFFFFFFFFFFFFF);
-    vmwrite(VMCS_GUEST_IA32_DEBUGCTL_FULL, m_intrinsics->read_msr(IA32_DEBUGCTL_MSR));
-    vmwrite(VMCS_GUEST_IA32_EFER_FULL, m_intrinsics->read_msr(IA32_EFER_MSR));
-    vmwrite(VMCS_GUEST_IA32_PAT_FULL, m_intrinsics->read_msr(IA32_PAT_MSR));
-
-    // unused: VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
-    // unused: VMCS_GUEST_PDPTE0_FULL
-    // unused: VMCS_GUEST_PDPTE1_FULL
-    // unused: VMCS_GUEST_PDPTE2_FULL
-    // unused: VMCS_GUEST_PDPTE3_FULL
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_64bit_host_state_fields()
-{
-    // Note: Since we are in 64bit mode, we do not need to load both the
-    //       high and full fields. We simply need to load the full field
-    //       with 64bit writes, which will fill in the high field for us.
-
-    // unused: VMCS_HOST_IA32_PAT_FULL
-    // unused: VMCS_HOST_IA32_EFER_FULL
-    // unused: VMCS_HOST_IA32_PERF_GLOBAL_CTRL_FULL
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_32bit_control_fields()
-{
     uint64_t lower;
     uint64_t upper;
 
-    // For the following fields, there is a complex, algorithm that is used
-    // to determine what these values of these fields actually should be.
-    //
-    // - VMCS_PIN_BASED_VM_EXECUTION_CONTROLS
-    // - VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS
-    // - VMCS_VM_EXIT_CONTROLS
-    // - VMCS_VM_ENTRY_CONTROLS
-    //
-    // These algorithms are defined in section 31.5.1 Algorithms for
-    // Determining VMX Capabilities. We use a subset of algorithm #3.
-    //
-    // Basically, the way this works is for each of the fields is:
-    //     - a 1 in the lower 32bits of the associated MSR means that the
-    //       field must contain a 1.
-    //     - a 0 in the upper 32bits of the associated MSR means that the
-    //       field must contain a 0.
+    auto ia32_vmx_pinbased_ctls_msr =
+        m_intrinsics->read_msr(IA32_VMX_PINBASED_CTLS_MSR);
+    auto ia32_vmx_procbased_ctls_msr =
+        m_intrinsics->read_msr(IA32_VMX_PROCBASED_CTLS_MSR);
+    auto ia32_vmx_exit_ctls_msr =
+        m_intrinsics->read_msr(IA32_VMX_EXIT_CTLS_MSR);
+    auto ia32_vmx_entry_ctls_msr =
+        m_intrinsics->read_msr(IA32_VMX_ENTRY_CTLS_MSR);
 
-    lower = ((m_intrinsics->read_msr(IA32_VMX_PINBASED_CTLS_MSR) >> 0) & 0x00000000FFFFFFFF);
-    upper = ((m_intrinsics->read_msr(IA32_VMX_PINBASED_CTLS_MSR) >> 32) & 0x00000000FFFFFFFF);
+    lower = ((ia32_vmx_pinbased_ctls_msr >> 0) & 0x00000000FFFFFFFF);
+    upper = ((ia32_vmx_pinbased_ctls_msr >> 32) & 0x00000000FFFFFFFF);
     vmwrite(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS, lower & upper);
 
-    lower = ((m_intrinsics->read_msr(IA32_VMX_PROCBASED_CTLS_MSR) >> 0) & 0x00000000FFFFFFFF);
-    upper = ((m_intrinsics->read_msr(IA32_VMX_PROCBASED_CTLS_MSR) >> 32) & 0x00000000FFFFFFFF);
+    lower = ((ia32_vmx_procbased_ctls_msr >> 0) & 0x00000000FFFFFFFF);
+    upper = ((ia32_vmx_procbased_ctls_msr >> 32) & 0x00000000FFFFFFFF);
     vmwrite(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, lower & upper);
 
-    lower = ((m_intrinsics->read_msr(IA32_VMX_EXIT_CTLS_MSR) >> 0) & 0x00000000FFFFFFFF);
-    upper = ((m_intrinsics->read_msr(IA32_VMX_EXIT_CTLS_MSR) >> 32) & 0x00000000FFFFFFFF);
+    lower = ((ia32_vmx_exit_ctls_msr >> 0) & 0x00000000FFFFFFFF);
+    upper = ((ia32_vmx_exit_ctls_msr >> 32) & 0x00000000FFFFFFFF);
     vmwrite(VMCS_VM_EXIT_CONTROLS, lower & upper);
 
-    lower = ((m_intrinsics->read_msr(IA32_VMX_ENTRY_CTLS_MSR) >> 0) & 0x00000000FFFFFFFF);
-    upper = ((m_intrinsics->read_msr(IA32_VMX_ENTRY_CTLS_MSR) >> 32) & 0x00000000FFFFFFFF);
+    lower = ((ia32_vmx_entry_ctls_msr >> 0) & 0x00000000FFFFFFFF);
+    upper = ((ia32_vmx_entry_ctls_msr >> 32) & 0x00000000FFFFFFFF);
     vmwrite(VMCS_VM_ENTRY_CONTROLS, lower & upper);
 
     // unused: VMCS_EXCEPTION_BITMAP
@@ -571,58 +225,13 @@ vmcs_intel_x64::write_32bit_control_fields()
     // unused: VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS
     // unused: VMCS_PLE_GAP
     // unused: VMCS_PLE_WINDOW
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::write_32bit_guest_state_fields()
+void
+vmcs_intel_x64::write_natural_control_state(const vmcs_state_intel_x64 &state)
 {
-    // Not sure why but the limit is always set to all f's for both the guest
-    // and the host. Both VMXCPU, and KVM do this.
+    (void) state;
 
-    vmwrite(VMCS_GUEST_ES_LIMIT, m_es_limit);
-    vmwrite(VMCS_GUEST_CS_LIMIT, m_cs_limit);
-    vmwrite(VMCS_GUEST_SS_LIMIT, m_ss_limit);
-    vmwrite(VMCS_GUEST_DS_LIMIT, m_ds_limit);
-    vmwrite(VMCS_GUEST_FS_LIMIT, m_fs_limit);
-    vmwrite(VMCS_GUEST_GS_LIMIT, m_gs_limit);
-    vmwrite(VMCS_GUEST_LDTR_LIMIT, m_ldtr_limit);
-    vmwrite(VMCS_GUEST_TR_LIMIT, m_tr_limit);
-
-    vmwrite(VMCS_GUEST_GDTR_LIMIT, m_gdt_reg.limit);
-    vmwrite(VMCS_GUEST_IDTR_LIMIT, m_idt_reg.limit);
-
-    vmwrite(VMCS_GUEST_ES_ACCESS_RIGHTS, m_es_access);
-    vmwrite(VMCS_GUEST_CS_ACCESS_RIGHTS, m_cs_access);
-    vmwrite(VMCS_GUEST_SS_ACCESS_RIGHTS, m_ss_access);
-    vmwrite(VMCS_GUEST_DS_ACCESS_RIGHTS, m_ds_access);
-    vmwrite(VMCS_GUEST_FS_ACCESS_RIGHTS, m_fs_access);
-    vmwrite(VMCS_GUEST_GS_ACCESS_RIGHTS, m_gs_access);
-    vmwrite(VMCS_GUEST_LDTR_ACCESS_RIGHTS, m_ldtr_access);
-    vmwrite(VMCS_GUEST_TR_ACCESS_RIGHTS, m_tr_access);
-
-    vmwrite(VMCS_GUEST_IA32_SYSENTER_CS, m_intrinsics->read_msr32(IA32_SYSENTER_CS_MSR));
-
-    // unused: VMCS_GUEST_INTERRUPTIBILITY_STATE
-    // unused: VMCS_GUEST_ACTIVITY_STATE
-    // unused: VMCS_GUEST_SMBASE
-    // unused: VMCS_VMX_PREEMPTION_TIMER_VALUE
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_32bit_host_state_fields()
-{
-    // unused: VMCS_HOST_IA32_SYSENTER_CS
-
-    return vmcs_error::success;
-}
-
-vmcs_error::type
-vmcs_intel_x64::write_natural_width_control_fields()
-{
     // unused: VMCS_CR0_GUEST_HOST_MASK
     // unused: VMCS_CR4_GUEST_HOST_MASK
     // unused: VMCS_CR0_READ_SHADOW
@@ -631,52 +240,143 @@ vmcs_intel_x64::write_natural_width_control_fields()
     // unused: VMCS_CR3_TARGET_VALUE_1
     // unused: VMCS_CR3_TARGET_VALUE_2
     // unused: VMCS_CR3_TARGET_VALUE_31
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::write_natural_width_guest_state_fields()
+void
+vmcs_intel_x64::write_16bit_guest_state(const vmcs_state_intel_x64 &state)
 {
-    vmwrite(VMCS_GUEST_CR0, m_cr0);
-    vmwrite(VMCS_GUEST_CR3, m_cr3);
-    vmwrite(VMCS_GUEST_CR4, m_cr4);
-    vmwrite(VMCS_GUEST_ES_BASE, m_es_base);
-    vmwrite(VMCS_GUEST_CS_BASE, m_cs_base);
-    vmwrite(VMCS_GUEST_SS_BASE, m_ss_base);
-    vmwrite(VMCS_GUEST_DS_BASE, m_ds_base);
-    vmwrite(VMCS_GUEST_FS_BASE, m_intrinsics->read_msr(IA32_FS_BASE_MSR));
-    vmwrite(VMCS_GUEST_GS_BASE, m_intrinsics->read_msr(IA32_GS_BASE_MSR));
-    vmwrite(VMCS_GUEST_LDTR_BASE, m_ldtr_base);
-    vmwrite(VMCS_GUEST_TR_BASE, m_tr_base);
+    vmwrite(VMCS_GUEST_ES_SELECTOR, state.es());
+    vmwrite(VMCS_GUEST_CS_SELECTOR, state.cs());
+    vmwrite(VMCS_GUEST_SS_SELECTOR, state.ss());
+    vmwrite(VMCS_GUEST_DS_SELECTOR, state.ds());
+    vmwrite(VMCS_GUEST_FS_SELECTOR, state.fs());
+    vmwrite(VMCS_GUEST_GS_SELECTOR, state.gs());
+    vmwrite(VMCS_GUEST_TR_SELECTOR, state.tr());
 
-    vmwrite(VMCS_GUEST_GDTR_BASE, m_gdt_reg.base);
-    vmwrite(VMCS_GUEST_IDTR_BASE, m_idt_reg.base);
+    // unused: VMCS_GUEST_LDTR_SELECTOR
+    // unused: VMCS_GUEST_INTERRUPT_STATUS
+}
 
-    vmwrite(VMCS_GUEST_DR7, m_dr7);
-    vmwrite(VMCS_GUEST_RFLAGS, m_rflags);
+void
+vmcs_intel_x64::write_64bit_guest_state(const vmcs_state_intel_x64 &state)
+{
+    vmwrite(VMCS_VMCS_LINK_POINTER_FULL, 0xFFFFFFFFFFFFFFFF);
+    vmwrite(VMCS_GUEST_IA32_EFER_FULL, state.ia32_efer_msr());
 
-    vmwrite(VMCS_GUEST_IA32_SYSENTER_ESP, m_intrinsics->read_msr32(IA32_SYSENTER_ESP_MSR));
-    vmwrite(VMCS_GUEST_IA32_SYSENTER_EIP, m_intrinsics->read_msr32(IA32_SYSENTER_EIP_MSR));
+    // unused: VMCS_GUEST_IA32_DEBUGCTL_FULL
+    // unused: VMCS_GUEST_IA32_PAT_FULL
+    // unused: VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
+    // unused: VMCS_GUEST_PDPTE0_FULL
+    // unused: VMCS_GUEST_PDPTE1_FULL
+    // unused: VMCS_GUEST_PDPTE2_FULL
+    // unused: VMCS_GUEST_PDPTE3_FULL
+}
 
+void
+vmcs_intel_x64::write_32bit_guest_state(const vmcs_state_intel_x64 &state)
+{
+    auto unusable = m_intrinsics->segment_descriptor_access(0);
+
+    vmwrite(VMCS_GUEST_ES_LIMIT, state.es_limit());
+    vmwrite(VMCS_GUEST_CS_LIMIT, state.cs_limit());
+    vmwrite(VMCS_GUEST_SS_LIMIT, state.ss_limit());
+    vmwrite(VMCS_GUEST_DS_LIMIT, state.ds_limit());
+    vmwrite(VMCS_GUEST_FS_LIMIT, state.fs_limit());
+    vmwrite(VMCS_GUEST_GS_LIMIT, state.gs_limit());
+    vmwrite(VMCS_GUEST_TR_LIMIT, state.tr_limit());
+
+    vmwrite(VMCS_GUEST_GDTR_LIMIT, state.gdt().limit);
+    vmwrite(VMCS_GUEST_IDTR_LIMIT, state.idt().limit);
+
+    vmwrite(VMCS_GUEST_ES_ACCESS_RIGHTS, state.es_access());
+    vmwrite(VMCS_GUEST_CS_ACCESS_RIGHTS, state.cs_access());
+    vmwrite(VMCS_GUEST_SS_ACCESS_RIGHTS, state.ss_access());
+    vmwrite(VMCS_GUEST_DS_ACCESS_RIGHTS, state.ds_access());
+    vmwrite(VMCS_GUEST_FS_ACCESS_RIGHTS, state.fs_access());
+    vmwrite(VMCS_GUEST_GS_ACCESS_RIGHTS, state.gs_access());
+    vmwrite(VMCS_GUEST_LDTR_ACCESS_RIGHTS, unusable);
+    vmwrite(VMCS_GUEST_TR_ACCESS_RIGHTS, state.tr_access());
+
+    vmwrite(VMCS_GUEST_IA32_SYSENTER_CS, state.ia32_sysenter_cs_msr());
+
+    // unused: VMCS_GUEST_LDTR_LIMIT
+    // unused: VMCS_GUEST_INTERRUPTIBILITY_STATE
+    // unused: VMCS_GUEST_ACTIVITY_STATE
+    // unused: VMCS_GUEST_SMBASE
+    // unused: VMCS_VMX_PREEMPTION_TIMER_VALUE
+}
+
+void
+vmcs_intel_x64::write_natural_guest_state(const vmcs_state_intel_x64 &state)
+{
+    vmwrite(VMCS_GUEST_CR0, state.cr0());
+    vmwrite(VMCS_GUEST_CR3, state.cr3());
+    vmwrite(VMCS_GUEST_CR4, state.cr4());
+    vmwrite(VMCS_GUEST_ES_BASE, state.es_base());
+    vmwrite(VMCS_GUEST_CS_BASE, state.cs_base());
+    vmwrite(VMCS_GUEST_SS_BASE, state.ss_base());
+    vmwrite(VMCS_GUEST_DS_BASE, state.ds_base());
+    vmwrite(VMCS_GUEST_FS_BASE, state.ia32_fs_base_msr());
+    vmwrite(VMCS_GUEST_GS_BASE, state.ia32_gs_base_msr());
+    vmwrite(VMCS_GUEST_TR_BASE, state.tr_base());
+
+    vmwrite(VMCS_GUEST_GDTR_BASE, state.gdt().base);
+    vmwrite(VMCS_GUEST_IDTR_BASE, state.idt().base);
+
+    vmwrite(VMCS_GUEST_RFLAGS, state.rflags());
+
+    vmwrite(VMCS_GUEST_IA32_SYSENTER_ESP, state.ia32_sysenter_esp_msr());
+    vmwrite(VMCS_GUEST_IA32_SYSENTER_EIP, state.ia32_sysenter_eip_msr());
+
+    // unused: VMCS_GUEST_LDTR_BASE
+    // unused: VMCS_GUEST_DR7
     // unused: VMCS_GUEST_RSP, see m_intrinsics->vmlaunch()
     // unused: VMCS_GUEST_RIP, see m_intrinsics->vmlaunch()
     // unused: VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
-vmcs_intel_x64::write_natural_width_host_state_fields()
+void
+vmcs_intel_x64::write_16bit_host_state(const vmcs_state_intel_x64 &state)
 {
-    vmwrite(VMCS_HOST_CR0, m_cr0);
-    vmwrite(VMCS_HOST_CR3, m_cr3);
-    vmwrite(VMCS_HOST_CR4, m_cr4);
+    vmwrite(VMCS_HOST_CS_SELECTOR, state.cs());
+    vmwrite(VMCS_HOST_SS_SELECTOR, state.ss());
+    vmwrite(VMCS_HOST_TR_SELECTOR, state.tr());
 
-    vmwrite(VMCS_HOST_TR_BASE, m_tr_base);
+    // unused: VMCS_HOST_ES_SELECTOR
+    // unused: VMCS_HOST_DS_SELECTOR
+    // unused: VMCS_HOST_FS_SELECTOR
+    // unused: VMCS_HOST_GS_SELECTOR
+}
 
-    vmwrite(VMCS_HOST_GDTR_BASE, m_gdt_reg.base);
-    vmwrite(VMCS_HOST_IDTR_BASE, m_idt_reg.base);
+void
+vmcs_intel_x64::write_64bit_host_state(const vmcs_state_intel_x64 &state)
+{
+    (void) state;
+
+    // unused: VMCS_HOST_IA32_PAT_FULL
+    // unused: VMCS_HOST_IA32_EFER_FULL
+    // unused: VMCS_HOST_IA32_PERF_GLOBAL_CTRL_FULL
+}
+
+void
+vmcs_intel_x64::write_32bit_host_state(const vmcs_state_intel_x64 &state)
+{
+    (void) state;
+
+    // unused: VMCS_HOST_IA32_SYSENTER_CS
+}
+
+void
+vmcs_intel_x64::write_natural_host_state(const vmcs_state_intel_x64 &state)
+{
+    vmwrite(VMCS_HOST_CR0, state.cr0());
+    vmwrite(VMCS_HOST_CR3, state.cr3());
+    vmwrite(VMCS_HOST_CR4, state.cr4());
+
+    vmwrite(VMCS_HOST_TR_BASE, state.tr_base());
+
+    vmwrite(VMCS_HOST_GDTR_BASE, state.gdt().base);
+    vmwrite(VMCS_HOST_IDTR_BASE, state.idt().base);
 
     vmwrite(VMCS_HOST_RSP, (uint64_t)exit_handler_stack());
     vmwrite(VMCS_HOST_RIP, (uint64_t)exit_handler_entry);
@@ -685,11 +385,58 @@ vmcs_intel_x64::write_natural_width_host_state_fields()
     // unused: VMCS_HOST_GS_BASE
     // unused: VMCS_HOST_IA32_SYSENTER_ESP
     // unused: VMCS_HOST_IA32_SYSENTER_EIP
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
+vmcs_intel_x64::promote_16bit_guest_state()
+{
+    m_intrinsics->write_es(vmread(VMCS_GUEST_ES_SELECTOR));
+    // m_intrinsics->write_cs(vmread(VMCS_GUEST_CS_SELECTOR));
+    // m_intrinsics->write_ss(vmread(VMCS_GUEST_SS_SELECTOR));
+    m_intrinsics->write_ds(vmread(VMCS_GUEST_DS_SELECTOR));
+    m_intrinsics->write_fs(vmread(VMCS_GUEST_FS_SELECTOR));
+    m_intrinsics->write_gs(vmread(VMCS_GUEST_GS_SELECTOR));
+    // m_intrinsics->write_tr(vmread(VMCS_GUEST_TR_SELECTOR));
+}
+
+void
+vmcs_intel_x64::promote_64bit_guest_state()
+{
+    auto ia32_efer_msr = vmread(VMCS_GUEST_IA32_EFER_FULL);
+    auto ia32_pat_msr = vmread(VMCS_GUEST_IA32_PAT_FULL);
+
+    m_intrinsics->write_msr(IA32_EFER_MSR, ia32_efer_msr);
+    m_intrinsics->write_msr(IA32_PAT_MSR, ia32_pat_msr);
+
+    // unused: VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
+}
+
+void
+vmcs_intel_x64::promote_32bit_guest_state()
+{
+    auto ia32_sysenter_cs_msr = vmread(VMCS_GUEST_IA32_SYSENTER_CS);
+    m_intrinsics->write_msr(IA32_SYSENTER_CS_MSR, ia32_sysenter_cs_msr);
+}
+
+void
+vmcs_intel_x64::promote_natural_guest_state()
+{
+    m_intrinsics->write_cr0(vmread(VMCS_GUEST_CR0));
+    m_intrinsics->write_cr3(vmread(VMCS_GUEST_CR3));
+    m_intrinsics->write_cr4(vmread(VMCS_GUEST_CR4));
+
+    auto ia32_fs_base_msr = vmread(VMCS_GUEST_FS_BASE);
+    auto ia32_gs_base_msr = vmread(VMCS_GUEST_GS_BASE);
+    auto ia32_sysenter_esp_msr = vmread(VMCS_GUEST_IA32_SYSENTER_ESP);
+    auto ia32_sysenter_eip_msr = vmread(VMCS_GUEST_IA32_SYSENTER_EIP);
+
+    m_intrinsics->write_msr(IA32_FS_BASE_MSR, ia32_fs_base_msr);
+    m_intrinsics->write_msr(IA32_GS_BASE_MSR, ia32_gs_base_msr);
+    m_intrinsics->write_msr(IA32_SYSENTER_ESP_MSR, ia32_sysenter_esp_msr);
+    m_intrinsics->write_msr(IA32_SYSENTER_EIP_MSR, ia32_sysenter_eip_msr);
+}
+
+void
 vmcs_intel_x64::default_pin_based_vm_execution_controls()
 {
     auto controls = vmread(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS);
@@ -701,11 +448,9 @@ vmcs_intel_x64::default_pin_based_vm_execution_controls()
     // controls |= VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS;
 
     vmwrite(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS, controls);
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
 vmcs_intel_x64::default_primary_processor_based_vm_execution_controls()
 {
     auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
@@ -725,7 +470,7 @@ vmcs_intel_x64::default_primary_processor_based_vm_execution_controls()
     // controls |= VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING;
     // controls |= VM_EXEC_P_PROC_BASED_MOV_DR_EXITING;
     // controls |= VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING;
-    // controls |= VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS;
+    controls |= VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS;
     // controls |= VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG;
     controls |= VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS;
     // controls |= VM_EXEC_P_PROC_BASED_MONITOR_EXITING;
@@ -733,11 +478,9 @@ vmcs_intel_x64::default_primary_processor_based_vm_execution_controls()
     // controls |= VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS;
 
     vmwrite(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, controls);
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
 vmcs_intel_x64::default_secondary_processor_based_vm_execution_controls()
 {
     auto controls = vmread(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
@@ -762,11 +505,9 @@ vmcs_intel_x64::default_secondary_processor_based_vm_execution_controls()
     // controls |= VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS;
 
     vmwrite(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS, controls);
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
 vmcs_intel_x64::default_vm_exit_controls()
 {
     auto controls = vmread(VMCS_VM_EXIT_CONTROLS);
@@ -782,11 +523,9 @@ vmcs_intel_x64::default_vm_exit_controls()
     // controls |= VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE;
 
     vmwrite(VMCS_VM_EXIT_CONTROLS, controls);
-
-    return vmcs_error::success;
 }
 
-vmcs_error::type
+void
 vmcs_intel_x64::default_vm_entry_controls()
 {
     auto controls = vmread(VMCS_VM_ENTRY_CONTROLS);
@@ -800,23 +539,6 @@ vmcs_intel_x64::default_vm_entry_controls()
     // controls |= VM_ENTRY_CONTROL_LOAD_IA32_EFER;
 
     vmwrite(VMCS_VM_ENTRY_CONTROLS, controls);
-
-    return vmcs_error::success;
-}
-
-void
-vmcs_intel_x64::vmwrite(uint64_t field, uint64_t value)
-{
-    if (m_intrinsics->vmwrite(field, value) == false)
-    {
-        std::cout << std::hex;
-        std::cout << "vmwrite failed: "
-                  << "field = " << field << ", "
-                  << "value = " << value << std::endl;
-        std::cout << std::dec;
-
-        m_valid = false;
-    }
 }
 
 uint64_t
@@ -825,15 +547,14 @@ vmcs_intel_x64::vmread(uint64_t field)
     uint64_t value = 0;
 
     if (m_intrinsics->vmread(field, &value) == false)
-    {
-        std::cout << std::hex;
-        std::cout << "vmread failed: "
-                  << "field = 0x" << field << ", "
-                  << "value = 0x" << value << std::endl;
-        std::cout << std::dec;
-
-        m_valid = false;
-    }
+        throw vmcs_read_failure(field);
 
     return value;
+}
+
+void
+vmcs_intel_x64::vmwrite(uint64_t field, uint64_t value)
+{
+    if (m_intrinsics->vmwrite(field, value) == false)
+        throw vmcs_write_failure(field, value);
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
@@ -19,137 +19,103 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <iomanip>
-#include <iostream>
-
 #include <vmcs/vmcs_intel_x64.h>
 
-void
+std::string
 vmcs_intel_x64::check_vm_instruction_error()
 {
-    auto check_vm_instruction = vmread(VMCS_VM_INSTRUCTION_ERROR);
-
-    if (check_vm_instruction == 0)
-        return;
-
-    // The following error codes are defined in the Intel Software Developers
-    // Manual, Chapter 3, Section 30.4.
-
-    std::cout << "VM Instruction Error:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    switch (check_vm_instruction)
+    switch (vmread(VMCS_VM_INSTRUCTION_ERROR))
     {
         case 1:
-            std::cout << "VMCALL executed in VMX root operation" << std::endl;
-            break;
+            return "VMCALL executed in VMX root operation";
 
         case 2:
-            std::cout << "VMCLEAR with invalid physical address" << std::endl;
-            break;
+            return "VMCLEAR with invalid physical address";
 
         case 3:
-            std::cout << "VMCLEAR with VMXON pointer" << std::endl;
-            break;
+            return "VMCLEAR with VMXON pointer";
 
         case 4:
-            std::cout << "VMLAUNCH with non-clear VMCS" << std::endl;
-            break;
+            return "VMLAUNCH with non-clear VMCS";
 
         case 5:
-            std::cout << "VMRESUME with non-launched VMCS" << std::endl;
-            break;
+            return "VMRESUME with non-launched VMCS";
 
         case 6:
-            std::cout << "VMRESUME after VMXOFF (VMXOFF and VMXON between VMLAUNCH and VMRESUME)" << std::endl;
-            break;
+            return "VMRESUME after VMXOFF (VMXOFF and VMXON between "
+                   "VMLAUNCH and VMRESUME)";
 
         case 7:
-            std::cout << "VM entry with invalid control field(s)" << std::endl;
-            break;
+            return "VM entry with invalid control field(s)";
 
         case 8:
-            std::cout << "VM entry with invalid host-state field(s)" << std::endl;
-            break;
+            return "VM entry with invalid host-state field(s)";
 
         case 9:
-            std::cout << "VMPTRLD with invalid physical address" << std::endl;
-            break;
+            return "VMPTRLD with invalid physical address";
 
         case 10:
-            std::cout << "VMPTRLD with VMXON pointer" << std::endl;
-            break;
+            return "VMPTRLD with VMXON pointer";
 
         case 11:
-            std::cout << "VMPTRLD with incorrect VMCS revision identifier" << std::endl;
-            break;
+            return "VMPTRLD with incorrect VMCS revision identifier";
 
         case 12:
-            std::cout << "VMREAD/VMWRITE from/to unsupported VMCS component" << std::endl;
-            break;
+            return "VMREAD/VMWRITE from/to unsupported VMCS component";
 
         case 13:
-            std::cout << "VMWRITE to read-only VMCS component" << std::endl;
-            break;
+            return "VMWRITE to read-only VMCS component";
 
         case 15:
-            std::cout << "VMXON executed in VMX root operation" << std::endl;
-            break;
+            return "VMXON executed in VMX root operation";
 
         case 16:
-            std::cout << "VM entry with invalid executive-VMCS pointer" << std::endl;
-            break;
+            return "VM entry with invalid executive-VMCS pointer";
 
         case 17:
-            std::cout << "VM entry with non-launched executive VMCS" << std::endl;
-            break;
+            return "VM entry with non-launched executive VMCS";
 
         case 18:
-            std::cout << "VM entry with executive-VMCS pointer not VMXON pointer (when attempting "
-                      << "to deactivate the dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VM entry with executive-VMCS pointer not VMXON "
+                   "pointer (when attempting to deactivate the "
+                   "dual-monitor treatment of SMIs and SMM)";
 
         case 19:
-            std::cout << "VMCALL with non-clear VMCS (when attempting to activate the dual-monitor "
-                      << "treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with non-clear VMCS (when attempting to "
+                   "activate the dual-monitor treatment of SMIs and "
+                   "SMM)";
 
         case 20:
-            std::cout << "VMCALL with invalid VM-exit control fields" << std::endl;
-            break;
+            return "VMCALL with invalid VM-exit control fields";
 
         case 22:
-            std::cout << "VMCALL with incorrect MSEG revision identifier (when attempting to "
-                      << "activate the dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with incorrect MSEG revision identifier "
+                   "(when attempting to activate the dual-monitor "
+                   "treatment of SMIs and SMM)";
 
         case 23:
-            std::cout << "VMXOFF under dual-monitor treatment of SMIs and SMM" << std::endl;
-            break;
+            return "VMXOFF under dual-monitor treatment of SMIs and "
+                   "SMM";
 
         case 24:
-            std::cout << "VMCALL with invalid SMM-monitor features (when attempting to activate the "
-                      << "dual-monitor treatment of SMIs and SMM)" << std::endl;
-            break;
+            return "VMCALL with invalid SMM-monitor features (when "
+                   "attempting to activate the dual-monitor treatment "
+                   "of SMIs and SMM)";
 
         case 25:
-            std::cout << "VM entry with invalid VM-execution control fields in executive VMCS (when "
-                      << "attempting to return from SMM)" << std::endl;
-            break;
+            return "VM entry with invalid VM-execution control fields "
+                   "in executive VMCS (when attempting to return from "
+                   "SMM)";
 
         case 26:
-            std::cout << "VM entry with events blocked by MOV SS." << std::endl;
-            break;
+            return "VM entry with events blocked by MOV SS.";
 
         case 28:
-            std::cout << "Invalid operand to INVEPT/INVVPID." << std::endl;
-            break;
+            return "Invalid operand to INVEPT/INVVPID.";
 
         default:
-            std::cout << "Unknown vm instruction error: " << check_vm_instruction << std::endl;
+            return "Unknown VM instruction error";
     }
-
-    std::cout << std::endl;
 }
 
 bool
@@ -200,4 +166,14 @@ vmcs_intel_x64::check_vmcs_control_state()
     result &= check_control_checks_on_vm_entry_control_fields();
 
     return result;
+}
+
+bool
+vmcs_intel_x64::supports_vpid()
+{
+    auto ia32_vmx_procbased_ctls2_msr =
+        m_intrinsics->read_msr(IA32_VMX_PROCBASED_CTLS2_MSR);
+
+    return ia32_vmx_procbased_ctls2_msr &
+           (VM_EXEC_S_PROC_BASED_ENABLE_VPID << 32);
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
@@ -276,332 +276,332 @@ vmcs_intel_x64::dump_vmcs()
 #define PRINT_STATE(a) \
     std::cout << std::left << std::setw(55) << #a \
               << "0x" << a << std::endl;
-void
-vmcs_intel_x64::dump_state()
-{
-    std::cout << std::hex << std::endl;
-    std::cout << "State Dump:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    std::cout << std::endl;
-    std::cout << "Segment Selectors:" << std::endl;
-    PRINT_STATE(m_es);
-    PRINT_STATE(m_cs);
-    PRINT_STATE(m_ss);
-    PRINT_STATE(m_ds);
-    PRINT_STATE(m_fs);
-    PRINT_STATE(m_gs);
-    PRINT_STATE(m_tr);
-    PRINT_STATE(m_ldtr);
-
-    std::cout << std::endl;
-    std::cout << "Registers:" << std::endl;
-    PRINT_STATE(m_cr0);
-    PRINT_STATE(m_cr3);
-    PRINT_STATE(m_cr4);
-    PRINT_STATE(m_dr7);
-    PRINT_STATE(m_rflags);
-
-    std::cout << std::endl;
-    std::cout << "GDT/IDT:" << std::endl;
-    PRINT_STATE(m_gdt_reg.limit);
-    PRINT_STATE(m_gdt_reg.base);
-    PRINT_STATE(m_idt_reg.limit);
-    PRINT_STATE(m_idt_reg.base);
-
-    std::cout << std::endl;
-    std::cout << "Segment Limit:" << std::endl;
-    PRINT_STATE(m_es_limit);
-    PRINT_STATE(m_cs_limit);
-    PRINT_STATE(m_ss_limit);
-    PRINT_STATE(m_ds_limit);
-    PRINT_STATE(m_fs_limit);
-    PRINT_STATE(m_gs_limit);
-    PRINT_STATE(m_ldtr_limit);
-    PRINT_STATE(m_tr_limit);
-
-    std::cout << std::endl;
-    std::cout << "Segment Access:" << std::endl;
-    PRINT_STATE(m_es_access);
-    PRINT_STATE(m_cs_access);
-    PRINT_STATE(m_ss_access);
-    PRINT_STATE(m_ds_access);
-    PRINT_STATE(m_fs_access);
-    PRINT_STATE(m_gs_access);
-    PRINT_STATE(m_ldtr_access);
-    PRINT_STATE(m_tr_access);
-
-    std::cout << std::endl;
-    std::cout << "Segment Base:" << std::endl;
-    PRINT_STATE(m_es_base);
-    PRINT_STATE(m_cs_base);
-    PRINT_STATE(m_ss_base);
-    PRINT_STATE(m_ds_base);
-    PRINT_STATE(m_fs_base);
-    PRINT_STATE(m_gs_base);
-    PRINT_STATE(m_ldtr_base);
-    PRINT_STATE(m_tr_base);
-
-    std::cout << std::endl;
-    std::cout << "Segment Descriptors:" << std::endl;
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_es));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_cs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ss));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ds));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_fs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_gs));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_ldtr));
-    PRINT_STATE(m_intrinsics->segment_descriptor(m_tr));
-
-    std::cout << std::dec << std::left << std::endl;
-}
-
-void
-vmcs_intel_x64::print_execution_controls()
-{
-    print_pin_based_vm_execution_controls();
-    print_primary_processor_based_vm_execution_controls();
-    print_secondary_processor_based_vm_execution_controls();
-    print_vm_exit_control_fields();
-    print_vm_entry_control_fields();
-}
-
-void
-vmcs_intel_x64::print_pin_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS);
-
-    std::cout << std::hex << std::endl;
-    std::cout << "Pin-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
-
-    if ((controls & VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING" << std::endl;
+// void
+// vmcs_intel_x64::dump_state()
+// {
+//     std::cout << std::hex << std::endl;
+//     std::cout << "State Dump:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Selectors:" << std::endl;
+//     PRINT_STATE(m_es);
+//     PRINT_STATE(m_cs);
+//     PRINT_STATE(m_ss);
+//     PRINT_STATE(m_ds);
+//     PRINT_STATE(m_fs);
+//     PRINT_STATE(m_gs);
+//     PRINT_STATE(m_tr);
+//     PRINT_STATE(m_ldtr);
+
+//     std::cout << std::endl;
+//     std::cout << "Registers:" << std::endl;
+//     PRINT_STATE(m_cr0);
+//     PRINT_STATE(m_cr3);
+//     PRINT_STATE(m_cr4);
+//     PRINT_STATE(m_dr7);
+//     PRINT_STATE(m_rflags);
+
+//     std::cout << std::endl;
+//     std::cout << "GDT/IDT:" << std::endl;
+//     PRINT_STATE(m_gdt_reg.limit);
+//     PRINT_STATE(m_gdt_reg.base);
+//     PRINT_STATE(m_idt_reg.limit);
+//     PRINT_STATE(m_idt_reg.base);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Limit:" << std::endl;
+//     PRINT_STATE(m_es_limit);
+//     PRINT_STATE(m_cs_limit);
+//     PRINT_STATE(m_ss_limit);
+//     PRINT_STATE(m_ds_limit);
+//     PRINT_STATE(m_fs_limit);
+//     PRINT_STATE(m_gs_limit);
+//     PRINT_STATE(m_ldtr_limit);
+//     PRINT_STATE(m_tr_limit);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Access:" << std::endl;
+//     PRINT_STATE(m_es_access);
+//     PRINT_STATE(m_cs_access);
+//     PRINT_STATE(m_ss_access);
+//     PRINT_STATE(m_ds_access);
+//     PRINT_STATE(m_fs_access);
+//     PRINT_STATE(m_gs_access);
+//     PRINT_STATE(m_ldtr_access);
+//     PRINT_STATE(m_tr_access);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Base:" << std::endl;
+//     PRINT_STATE(m_es_base);
+//     PRINT_STATE(m_cs_base);
+//     PRINT_STATE(m_ss_base);
+//     PRINT_STATE(m_ds_base);
+//     PRINT_STATE(m_fs_base);
+//     PRINT_STATE(m_gs_base);
+//     PRINT_STATE(m_ldtr_base);
+//     PRINT_STATE(m_tr_base);
+
+//     std::cout << std::endl;
+//     std::cout << "Segment Descriptors:" << std::endl;
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_es));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_cs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ss));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ds));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_fs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_gs));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_ldtr));
+//     PRINT_STATE(m_intrinsics->segment_descriptor(m_tr));
+
+//     std::cout << std::dec << std::left << std::endl;
+// }
+
+// void
+// vmcs_intel_x64::print_execution_controls()
+// {
+//     print_pin_based_vm_execution_controls();
+//     print_primary_processor_based_vm_execution_controls();
+//     print_secondary_processor_based_vm_execution_controls();
+//     print_vm_exit_control_fields();
+//     print_vm_entry_control_fields();
+// }
+
+// void
+// vmcs_intel_x64::print_pin_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_PIN_BASED_VM_EXECUTION_CONTROLS);
+
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Pin-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
+
+//     if ((controls & VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_EXTERNAL_INTERRUPT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_NMI_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_NMI_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_NMI_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_NMI_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_VIRTUAL_NMIS) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_VIRTUAL_NMIS" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_VIRTUAL_NMIS) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_VIRTUAL_NMIS" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_ACTIVATE_VMX_PREEMPTION_TIMER" << std::endl;
 
-    if ((controls & VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS) != 0)
-        std::cout << "- " << "VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS" << std::endl;
+//     if ((controls & VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS) != 0)
+//         std::cout << "- " << "VM_EXEC_PIN_BASED_PROCESS_POSTED_INTERRUPTS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_primary_processor_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
+// void
+// vmcs_intel_x64::print_primary_processor_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_PRIMARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "Primary Processor-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Primary Processor-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_INTERRUPT_WINDOW_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TSC_OFFSETTING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_HLT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_HLT_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_HLT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_HLT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_INVLPG_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_INVLPG_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_INVLPG_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_INVLPG_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MWAIT_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MWAIT_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MWAIT_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MWAIT_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_RDPMC_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDPMC_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_RDPMC_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDPMC_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_RDTSC_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDTSC_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_RDTSC_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_RDTSC_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_LOAD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR3_STORE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_LOAD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_CR8_STORE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_TPR_SHADOW" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_NMI_WINDOW_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MOV_DR_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MOV_DR_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MOV_DR_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MOV_DR_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_UNCONDITIONAL_IO_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_IO_BITMAPS" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_TRAP_FLAG" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_USE_MSR_BITMAPS" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_MONITOR_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_MONITOR_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_PAUSE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_PAUSE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_PAUSE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_PAUSE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS) != 0)
-        std::cout << "- " << "VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS" << std::endl;
+//     if ((controls & VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS) != 0)
+//         std::cout << "- " << "VM_EXEC_P_PROC_BASED_ACTIVATE_SECONDARY_CONTROLS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_secondary_processor_based_vm_execution_controls()
-{
-    auto controls = vmread(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
+// void
+// vmcs_intel_x64::print_secondary_processor_based_vm_execution_controls()
+// {
+//     auto controls = vmread(VMCS_SECONDARY_PROCESSOR_BASED_VM_EXECUTION_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "Secondary Processor-Based VM-Execution Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "Secondary Processor-Based VM-Execution Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_APIC_ACCESSES" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_EPT) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_EPT" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_EPT) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_EPT" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_DESCRIPTOR_TABLE_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_RDTSCP" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUALIZE_X2APIC_MODE" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VPID) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VPID" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VPID) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VPID" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_WBINVD_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_WBINVD_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_WBINVD_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_WBINVD_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_UNRESTRICTED_GUEST" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_APIC_REGISTER_VIRTUALIZATION" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VIRTUAL_INTERRUPT_DELIVERY" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_PAUSE_LOOP_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_RDRAND_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDRAND_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_RDRAND_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDRAND_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_INVPCID) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_INVPCID" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_INVPCID) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_INVPCID" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_VM_FUNCTIONS" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_VMCS_SHADOWING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_VMCS_SHADOWING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_VMCS_SHADOWING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_VMCS_SHADOWING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_RDSEED_EXITING) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDSEED_EXITING" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_RDSEED_EXITING) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_RDSEED_EXITING" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_EPT_VIOLATION_VE" << std::endl;
 
-    if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS) != 0)
-        std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS" << std::endl;
+//     if ((controls & VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS) != 0)
+//         std::cout << "- " << "VM_EXEC_S_PROC_BASED_ENABLE_XSAVES_XRSTORS" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_vm_exit_control_fields()
-{
-    auto controls = vmread(VMCS_VM_EXIT_CONTROLS);
+// void
+// vmcs_intel_x64::print_vm_exit_control_fields()
+// {
+//     auto controls = vmread(VMCS_VM_EXIT_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "VM-Exit Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "VM-Exit Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_IA32_PAT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_PAT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_PAT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PAT) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PAT" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_PAT" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_IA32_EFER) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_EFER" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_IA32_EFER" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_LOAD_IA32_EFER) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_EFER" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_LOAD_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_LOAD_IA32_EFER" << std::endl;
 
-    if ((controls & VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE) != 0)
-        std::cout << "- " << "VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE" << std::endl;
+//     if ((controls & VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE) != 0)
+//         std::cout << "- " << "VM_EXIT_CONTROL_SAVE_VMX_PREEMPTION_TIMER_VALUE" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }
 
-void
-vmcs_intel_x64::print_vm_entry_control_fields()
-{
-    auto controls = vmread(VMCS_VM_ENTRY_CONTROLS);
+// void
+// vmcs_intel_x64::print_vm_entry_control_fields()
+// {
+//     auto controls = vmread(VMCS_VM_ENTRY_CONTROLS);
 
-    std::cout << std::hex << std::endl;
-    std::cout << "VM-Entry Controls:" << std::endl;
-    std::cout << "----------------------------------------------------------------------" << std::endl;
+//     std::cout << std::hex << std::endl;
+//     std::cout << "VM-Entry Controls:" << std::endl;
+//     std::cout << "----------------------------------------------------------------------" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_IA_32E_MODE_GUEST) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_IA_32E_MODE_GUEST" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_IA_32E_MODE_GUEST) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_IA_32E_MODE_GUEST" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_ENTRY_TO_SMM) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_ENTRY_TO_SMM" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_ENTRY_TO_SMM) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_ENTRY_TO_SMM" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_DEACTIVATE_DUAL_MONITOR_TREATMENT" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PAT) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PAT" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_PAT) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_PAT" << std::endl;
 
-    if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_EFER) != 0)
-        std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_EFER" << std::endl;
+//     if ((controls & VM_ENTRY_CONTROL_LOAD_IA32_EFER) != 0)
+//         std::cout << "- " << "VM_ENTRY_CONTROL_LOAD_IA32_EFER" << std::endl;
 
-    std::cout << std::dec << std::endl;
-}
+//     std::cout << std::dec << std::endl;
+// }

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -22,6 +22,7 @@
 #include <commit_or_rollback.h>
 #include <vmxon/vmxon_intel_x64.h>
 #include <vmxon/vmxon_exceptions_intel_x64.h>
+#include <memory_manager/memory_manager.h>
 
 // =============================================================================
 //  Implementation

--- a/include/constants.h
+++ b/include/constants.h
@@ -167,4 +167,16 @@
 #define ALIGN_MEMORY __attribute__((aligned(MAX_CACHE_LINE_SIZE)))
 #endif
 
+/// Stack Size
+///
+/// Each entry function is guarded with a custom stack to prevent stack
+/// overflows from corrupting the kernel, as well as providing a larger stack
+/// that common in userspace code, but not in the kernel. If stack corruption
+/// is occuring, this function likely needs to be increased. Note one stack
+/// frame is allocated per CPU, so only increase this if needed.
+///
+/// Note: define in 64bits (i.e. an array of uint64_t)
+///
+#define STACK_SIZE 0x2000
+
 #endif

--- a/tools/scripts/bareflank-gcc-wrapper
+++ b/tools/scripts/bareflank-gcc-wrapper
@@ -113,7 +113,8 @@ done
 # only thing the hypervisor code should need from the sysroot is the includes.
 
 if [[ $BAREFLANK_WRAPPER_INCLUDE_LIBC == "true" ]]; then
-    SYSROOT_LIBS="-lc -lbfc -lbfunwind_static"
+    SYSROOT_LIBS+="-lc -lbfc -lbfunwind_static "
+    SYSROOT_LIBS+="-u __cxa_throw_bad_array_new_length"
 fi
 
 SYSROOT_LIB_PATH="-L$HOME/opt/cross/x86_64-elf/lib/"
@@ -123,16 +124,6 @@ SYSROOT_LIB_PATH="-L$HOME/opt/cross/x86_64-elf/lib/"
 # ------------------------------------------------------------------------------
 
 SYSROOT_INC_PATH="-I$HOME/opt/cross/x86_64-elf/include/ -I$HOME/opt/cross/x86_64-elf/include/c++/v1/ "
-
-# REMOVE ME
-#
-# For whatever reason, Libcxx is running a test during it's initial compilation
-# and it needs access to the includes, but doesn't supply them on the
-# command line. This fixes that issue for now.
-
-if [[ $BAREFLANK_WRAPPER_INCLUDE_TMPLIBCXX == "true" ]]; then
-    SYSROOT_INC_PATH+="-I$HOME/tmp-build-dir/libcxx/include/ "
-fi
 
 # ------------------------------------------------------------------------------
 # Libgcc


### PR DESCRIPTION
This patch provides VMCS exception support. During it's
development, it was also identified that the libc++ code can
overwrite the kernel's stack as it's expecting a much larger
stack than the Linux kernel is providing. To overcome this
issue, this patch also includes code to guard the kernel's
by using a different stack while the VMM is execuitng.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>