### PR TITLE
Store and restore guest PAT MSR values

### DIFF
--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -301,9 +301,9 @@ vmcs_intel_x64::write_64bit_guest_state(const vmcs_state_intel_x64 &state)
 {
     vmwrite(VMCS_VMCS_LINK_POINTER_FULL, 0xFFFFFFFFFFFFFFFF);
     vmwrite(VMCS_GUEST_IA32_EFER_FULL, state.ia32_efer_msr());
+    vmwrite(VMCS_GUEST_IA32_PAT_FULL, state.ia32_pat_msr());
 
     // unused: VMCS_GUEST_IA32_DEBUGCTL_FULL
-    // unused: VMCS_GUEST_IA32_PAT_FULL
     // unused: VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
     // unused: VMCS_GUEST_PDPTE0_FULL
     // unused: VMCS_GUEST_PDPTE1_FULL


### PR DESCRIPTION
If you don't store and restore guest PAT MSR values, system performance after turning off the hypervisor is pretty awful, as it seems to default to all no caching.