### PR TITLE
Fix CTORS/DTORS

### DIFF
--- a/bfdrivers/include/platform.h
+++ b/bfdrivers/include/platform.h
@@ -37,8 +37,7 @@ extern "C" {
  * @param len the size of virtual memory to be allocated in bytes.
  * @return a virtual address pointing to the newly allocated memory
  */
-void *
-platform_alloc(int64_t len);
+void *platform_alloc(int64_t len);
 
 /**
  * Allocate Executable Memory
@@ -48,8 +47,7 @@ platform_alloc(int64_t len);
  * @param len the size of virtual memory to be allocated in bytes.
  * @return a virtual address pointing to the newly allocated memory
  */
-void *
-platform_alloc_exec(int64_t len);
+void *platform_alloc_exec(int64_t len);
 
 /**
  * Convert Virtual Address to Physical Address
@@ -62,8 +60,7 @@ platform_alloc_exec(int64_t len);
  * @param virt thevirtual address to convert
  * @return the physical address assocaited with the provided virtual address
  */
-void *
-platform_virt_to_phys(void *virt);
+void *platform_virt_to_phys(void *virt);
 
 /**
  * Free Memory
@@ -73,8 +70,7 @@ platform_virt_to_phys(void *virt);
  *
  * @param addr the virtual address returned from platform_alloc
  */
-void
-platform_free(void *addr);
+void platform_free(void *addr);
 
 /**
  * Free Executable Memory
@@ -85,8 +81,7 @@ platform_free(void *addr);
  * @param addr the virtual address returned from platform_alloc_exec
  * @param len the size of the memory allocated
  */
-void
-platform_free_exec(void *addr, int64_t len);
+void platform_free_exec(void *addr, int64_t len);
 
 /**
  * Memset
@@ -95,8 +90,7 @@ platform_free_exec(void *addr, int64_t len);
  * @param value the value to set each byte to
  * @param num the number of bytes to set
  */
-void
-platform_memset(void *ptr, char value, int64_t num);
+void platform_memset(void *ptr, char value, int64_t num);
 
 /**
  * Memcpy
@@ -105,8 +99,21 @@ platform_memset(void *ptr, char value, int64_t num);
  * @param src a pointer to the memory to copy from
  * @param num the number of bytes to copy
  */
-void
-platform_memcpy(void *dst, const void *src, int64_t num);
+void platform_memcpy(void *dst, const void *src, int64_t num);
+
+/**
+ * Start
+ *
+ * Run after the start function has been executed.
+ */
+void platform_start(void);
+
+/**
+ * Stop
+ *
+ * Run after the stop function has been executed.
+ */
+void platform_stop(void);
 
 #ifdef __cplusplus
 }

--- a/bfdrivers/src/arch/linux/entry.c
+++ b/bfdrivers/src/arch/linux/entry.c
@@ -7,9 +7,6 @@
 #include <linux/kallsyms.h>
 #include <linux/cpumask.h>
 #include <linux/sched.h>
-#include <linux/version.h>
-
-#include <asm/tlbflush.h>
 
 #include <debug.h>
 #include <common.h>
@@ -30,18 +27,6 @@ typedef long (*set_affinity_fn)(pid_t, const struct cpumask *);
 set_affinity_fn set_cpu_affinity;
 
 struct mm_struct *g_mmu_context = NULL;
-
-/* ========================================================================== */
-/* Helpers                                                                    */
-/* ========================================================================== */
-
-static void
-private_cr4_init_shadow(void)
-{
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
-    cr4_init_shadow();
-#endif
-}
 
 /* ========================================================================== */
 /* Misc Device                                                                */
@@ -208,8 +193,6 @@ ioctl_stop_vmm(void)
 
     g_mmu_context = NULL;
 
-    private_cr4_init_shadow();
-
     if (status == BF_IOCTL_SUCCESS)
         DEBUG("IOCTL_STOP_VMM: succeeded\n");
 
@@ -234,8 +217,6 @@ ioctl_start_vmm(void)
         ALERT("IOCTL_START_VMM: failed to start vmm: %d\n", ret);
         goto failure;
     }
-
-    private_cr4_init_shadow();
 
     DEBUG("IOCTL_START_VMM: succeeded\n");
     return BF_IOCTL_SUCCESS;

--- a/bfdrivers/src/arch/linux/platform.c
+++ b/bfdrivers/src/arch/linux/platform.c
@@ -28,6 +28,9 @@
 #include <linux/string.h>
 #include <linux/module.h>
 #include <linux/vmalloc.h>
+#include <linux/version.h>
+
+#include <asm/tlbflush.h>
 
 void *
 platform_alloc(int64_t len)
@@ -116,4 +119,20 @@ platform_memcpy(void *dst, const void *src, int64_t num)
         return;
 
     memcpy(dst, src, num);
+}
+
+void
+platform_start(void)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+    cr4_init_shadow();
+#endif
+}
+
+void
+platform_stop(void)
+{
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4,0,0)
+    cr4_init_shadow();
+#endif
 }

--- a/bfdrivers/src/arch/test/platform.c
+++ b/bfdrivers/src/arch/test/platform.c
@@ -110,3 +110,13 @@ platform_memcpy(void *dst, const void *src, int64_t num)
 
     memcpy(dst, src, num);
 }
+
+void
+platform_start(void)
+{
+}
+
+void
+platform_stop(void)
+{
+}

--- a/bfdrivers/test/test_helpers.cpp
+++ b/bfdrivers/test/test_helpers.cpp
@@ -34,7 +34,7 @@ extern "C"
 {
     struct module_t *get_module(uint64_t index);
     int64_t symbol_length(const char *sym);
-    int64_t resolve_symbol(const char *name, void **sym);
+    int64_t resolve_symbol(const char *name, void **sym, struct module_t *module);
     int64_t execute_symbol(const char *sym, int64_t arg);
     int64_t add_mdl_to_memory_manager(char *exec, uint64_t size);
 
@@ -108,13 +108,13 @@ driver_entry_ut::test_helper_resolve_symbol_invalid_name()
 {
     void *sym;
 
-    EXPECT_TRUE(resolve_symbol(0, &sym) == BF_ERROR_INVALID_ARG);
+    EXPECT_TRUE(resolve_symbol(0, &sym, 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_helper_resolve_symbol_invalid_sym()
 {
-    EXPECT_TRUE(resolve_symbol("sym", 0) == BF_ERROR_INVALID_ARG);
+    EXPECT_TRUE(resolve_symbol("sym", 0, 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
@@ -128,7 +128,7 @@ driver_entry_ut::test_helper_resolve_symbol_missing_symbol()
     EXPECT_TRUE(common_add_module(m_dummy_add_mdl_success, m_dummy_add_mdl_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(resolve_symbol("invalid_symbol", &sym) == BFELF_ERROR_NO_SUCH_SYMBOL);
+    EXPECT_TRUE(resolve_symbol("invalid_symbol", &sym, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
 
@@ -188,7 +188,7 @@ driver_entry_ut::test_helper_constructors_success()
     EXPECT_TRUE(common_add_module(m_dummy_add_mdl_success, m_dummy_add_mdl_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    ASSERT_TRUE(resolve_symbol("get_misc", (void **)&get_misc) == BF_SUCCESS);
+    ASSERT_TRUE(resolve_symbol("get_misc", (void **)&get_misc, 0) == BF_SUCCESS);
     EXPECT_TRUE(get_misc() == 10);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -213,7 +213,7 @@ driver_entry_ut::test_helper_add_mdl_1_page()
     EXPECT_TRUE(common_add_module(m_dummy_add_mdl_success, m_dummy_add_mdl_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num) == BF_SUCCESS);
+    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num, 0) == BF_SUCCESS);
 
     EXPECT_TRUE(add_mdl_to_memory_manager(exec_1_page, exec_1_page_length) == BF_SUCCESS);
     EXPECT_TRUE(get_mdl_num() == 1);
@@ -229,7 +229,7 @@ driver_entry_ut::test_helper_add_mdl_3_pages()
     EXPECT_TRUE(common_add_module(m_dummy_add_mdl_success, m_dummy_add_mdl_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num) == BF_SUCCESS);
+    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num, 0) == BF_SUCCESS);
 
     EXPECT_TRUE(add_mdl_to_memory_manager(exec_3_pages, exec_3_pages_length) == BF_SUCCESS);
     EXPECT_TRUE(get_mdl_num() == 3);
@@ -245,7 +245,7 @@ driver_entry_ut::test_helper_add_mdl_3_pages_plus()
     EXPECT_TRUE(common_add_module(m_dummy_add_mdl_success, m_dummy_add_mdl_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num) == BF_SUCCESS);
+    ASSERT_TRUE(resolve_symbol("get_mdl_num", (void **)&get_mdl_num, 0) == BF_SUCCESS);
 
     EXPECT_TRUE(add_mdl_to_memory_manager(exec_3_pages_plus, exec_3_pages_plus_length) == BF_SUCCESS);
     EXPECT_TRUE(get_mdl_num() == 4);

--- a/bfelf_loader/include/bfelf_loader.h
+++ b/bfelf_loader/include/bfelf_loader.h
@@ -175,6 +175,8 @@ struct bfelf_file_t
 
     bfelf64_word num_rela;
     struct relatab_t relatab[BFELF_MAX_RELATAB];
+
+    bfelf64_word relocated;
 };
 
 /**
@@ -227,6 +229,27 @@ bfelf64_sxword bfelf_file_num_segments(struct bfelf_file_t *ef);
 bfelf64_sword bfelf_file_get_segment(struct bfelf_file_t *ef,
                                      bfelf64_word index,
                                      struct bfelf_phdr **phdr);
+
+/**
+ * Resolve Symbol
+ *
+ * Once an ELF loader has had all of it's ELF files initalized and added,
+ * use the relocate ELF loader to setup the ELF files such that they can
+ * be executed. If the ELF file is relocated into memory that is accessable
+ * via the ELF loader, the resolve symbol function can be used to get the
+ * address of a specific symbol so that it can be executed.
+ *
+ * Note that this version takes a single ELF module instead of the
+ * loader. The loader version will do a global lookup if it has to.
+ *
+ * @param ef the ELF file to get the symbol from
+ * @param name the name of the symbol to resolve
+ * @param addr the resulting address if the symbol is successfully resolved
+ * @return BFELF_SUCCESS on success, negative on error
+ */
+bfelf64_sword bfelf_file_resolve_symbol(struct bfelf_file_t *ef,
+                                        struct e_string_t *name,
+                                        void **addr);
 
 /******************************************************************************/
 /* ELF File Header                                                            */
@@ -630,7 +653,6 @@ struct bfelf_loader_t
 {
     bfelf64_word num;
     bfelf64_word relocated;
-    bfelf64_word ignore_crt;
     struct bfelf_file_t *efs[BFELF_MAX_MODULES];
 };
 

--- a/bfelf_loader/test/Makefile
+++ b/bfelf_loader/test/Makefile
@@ -53,6 +53,7 @@ SOURCES+=test.cpp
 SOURCES+=test_file_get_segment.cpp
 SOURCES+=test_file_init.cpp
 SOURCES+=test_file_num_segments.cpp
+SOURCES+=test_file_resolve_symbol.cpp
 SOURCES+=test_loader_add.cpp
 SOURCES+=test_loader_get_info.cpp
 SOURCES+=test_loader_relocate.cpp

--- a/bfelf_loader/test/test.cpp
+++ b/bfelf_loader/test/test.cpp
@@ -166,6 +166,21 @@ bool bfelf_loader_ut::list()
     this->test_bfelf_file_get_segment_invalid_phdr();
     this->test_bfelf_file_get_segment_success();
 
+    this->test_bfelf_file_resolve_symbol_invalid_loader();
+    this->test_bfelf_file_resolve_symbol_invalid_name();
+    this->test_bfelf_file_resolve_symbol_invalid_addr();
+    this->test_bfelf_file_resolve_symbol_no_relocation();
+    this->test_bfelf_file_resolve_no_such_symbol();
+    this->test_bfelf_file_resolve_zero_length_symbol();
+    this->test_bfelf_file_resolve_invalid_symbol_length();
+    this->test_bfelf_file_resolve_symbol_length_too_large();
+    this->test_bfelf_file_resolve_symbol_success();
+    this->test_bfelf_file_resolve_no_such_symbol_no_hash();
+    this->test_bfelf_file_resolve_zero_length_symbol_no_hash();
+    this->test_bfelf_file_resolve_invalid_symbol_length_no_hash();
+    this->test_bfelf_file_resolve_symbol_length_too_large_no_hash();
+    this->test_bfelf_file_resolve_symbol_success_no_hash();
+
     this->test_bfelf_loader_add_invalid_loader();
     this->test_bfelf_loader_add_invalid_elf_file();
     this->test_bfelf_loader_add_too_many_files();

--- a/bfelf_loader/test/test.h
+++ b/bfelf_loader/test/test.h
@@ -101,6 +101,21 @@ private:
     void test_bfelf_file_get_segment_invalid_phdr();
     void test_bfelf_file_get_segment_success();
 
+    void test_bfelf_file_resolve_symbol_invalid_loader();
+    void test_bfelf_file_resolve_symbol_invalid_name();
+    void test_bfelf_file_resolve_symbol_invalid_addr();
+    void test_bfelf_file_resolve_symbol_no_relocation();
+    void test_bfelf_file_resolve_no_such_symbol();
+    void test_bfelf_file_resolve_zero_length_symbol();
+    void test_bfelf_file_resolve_invalid_symbol_length();
+    void test_bfelf_file_resolve_symbol_length_too_large();
+    void test_bfelf_file_resolve_symbol_success();
+    void test_bfelf_file_resolve_no_such_symbol_no_hash();
+    void test_bfelf_file_resolve_zero_length_symbol_no_hash();
+    void test_bfelf_file_resolve_invalid_symbol_length_no_hash();
+    void test_bfelf_file_resolve_symbol_length_too_large_no_hash();
+    void test_bfelf_file_resolve_symbol_success_no_hash();
+
     void test_bfelf_loader_add_invalid_loader();
     void test_bfelf_loader_add_invalid_elf_file();
     void test_bfelf_loader_add_too_many_files();

--- a/bfelf_loader/test/test_file_resolve_symbol.cpp
+++ b/bfelf_loader/test/test_file_resolve_symbol.cpp
@@ -24,101 +24,56 @@
 typedef int (*func_t)(int);
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_loader()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_loader()
 {
     func_t func;
     e_string_t name = {"foo", 3};
 
-    auto ret = bfelf_loader_resolve_symbol(0, &name, (void **)&func);
+    auto ret = bfelf_file_resolve_symbol(0, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_name()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_name()
 {
     func_t func;
-    bfelf_loader_t loader;
+    bfelf_file_t ef;
 
-    memset(&loader, 0, sizeof(loader));
+    memset(&ef, 0, sizeof(ef));
 
-    auto ret = bfelf_loader_resolve_symbol(&loader, 0, (void **)&func);
+    auto ret = bfelf_file_resolve_symbol(&ef, 0, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_addr()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_addr()
 {
-    bfelf_loader_t loader;
+    bfelf_file_t ef;
     e_string_t name = {"foo", 3};
 
-    memset(&loader, 0, sizeof(loader));
+    memset(&ef, 0, sizeof(ef));
 
-    auto ret = bfelf_loader_resolve_symbol(&loader, &name, 0);
+    auto ret = bfelf_file_resolve_symbol(&ef, &name, 0);
     EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_relocation()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_no_relocation()
 {
     auto ret = 0;
-    bfelf_loader_t loader;
+    bfelf_file_t ef;
 
-    memset(&loader, 0, sizeof(loader));
+    memset(&ef, 0, sizeof(ef));
 
     func_t func;
     e_string_t name = {"foo", 3};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_OUT_OF_ORDER);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_files_added()
-{
-    auto ret = 0;
-    bfelf_loader_t loader;
-
-    memset(&loader, 0, sizeof(loader));
-
-    ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
-
-    func_t func;
-    e_string_t name = {"foo", 3};
-
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
-}
-
-void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_uninitialized_files()
-{
-    auto ret = 0;
-    bfelf_file_t ef1;
-    bfelf_file_t ef2;
-    bfelf_loader_t loader;
-
-    memset(&ef1, 0, sizeof(ef1));
-    memset(&ef2, 0, sizeof(ef2));
-    memset(&loader, 0, sizeof(loader));
-
-    ret = bfelf_loader_add(&loader, &ef1, 0);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
-    ret = bfelf_loader_add(&loader, &ef2, 0);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
-
-    ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
-
-    func_t func;
-    e_string_t name = {"foo", 3};
-
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
-}
-
-void
-bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol()
+bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -148,12 +103,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol()
     func_t func;
     e_string_t name = {"fighters", 8};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol()
+bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -183,12 +138,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol()
     func_t func;
     e_string_t name = {"foo", 0};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length()
+bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -218,12 +173,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length()
     func_t func;
     e_string_t name = {"foo", 2};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -253,12 +208,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large()
     func_t func;
     e_string_t name = {"foo", 1000};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_success()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -288,12 +243,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success()
     func_t func;
     e_string_t name = {"foo", 3};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_SUCCESS);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol_no_hash()
+bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol_no_hash()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -326,12 +281,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol_no_hash()
     func_t func;
     e_string_t name = {"fighters", 8};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol_no_hash()
+bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol_no_hash()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -364,12 +319,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol_no_hash()
     func_t func;
     e_string_t name = {"foo", 0};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length_no_hash()
+bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length_no_hash()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -402,12 +357,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length_no_hash()
     func_t func;
     e_string_t name = {"foo", 2};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large_no_hash()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large_no_hash()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -440,12 +395,12 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large_no_hash()
     func_t func;
     e_string_t name = {"foo", 1000};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success_no_hash()
+bfelf_loader_ut::test_bfelf_file_resolve_symbol_success_no_hash()
 {
     auto ret = 0;
     bfelf_file_t dummy_misc_ef;
@@ -478,89 +433,6 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success_no_hash()
     func_t func;
     e_string_t name = {"foo", 3};
 
-    ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
+    ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&func);
     EXPECT_TRUE(ret == BFELF_SUCCESS);
-}
-
-void
-bfelf_loader_ut::test_bfelf_loader_resolve_symbol_real_test()
-{
-    auto ret = 0;
-    bfelf_file_t dummy_misc_ef;
-    bfelf_file_t dummy_code_ef;
-
-    ret = bfelf_file_init(m_dummy_misc.get(), m_dummy_misc_length, &dummy_misc_ef);
-    ASSERT_TRUE(ret == BFELF_SUCCESS);
-    ret = bfelf_file_init(m_dummy_code.get(), m_dummy_code_length, &dummy_code_ef);
-    ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-    m_dummy_misc_exec = load_elf_file(&dummy_misc_ef);
-    ASSERT_TRUE(m_dummy_misc_exec.get() != 0);
-    m_dummy_code_exec = load_elf_file(&dummy_code_ef);
-    ASSERT_TRUE(m_dummy_code_exec.get() != 0);
-
-    bfelf_loader_t loader;
-    memset(&loader, 0, sizeof(loader));
-
-    ret = bfelf_loader_add(&loader, &dummy_misc_ef, m_dummy_misc_exec.get());
-    ASSERT_TRUE(ret == BFELF_SUCCESS);
-    ret = bfelf_loader_add(&loader, &dummy_code_ef, m_dummy_code_exec.get());
-    ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-    ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
-
-    {
-        section_info_t info;
-        local_init_t local_init;
-        e_string_t name = {"local_init", 10};
-
-        ret = bfelf_loader_get_info(&loader, &dummy_misc_ef, &info);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&local_init);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        local_init(&info);
-
-        ret = bfelf_loader_get_info(&loader, &dummy_code_ef, &info);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&local_init);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        local_init(&info);
-    }
-
-    {
-        func_t func;
-        e_string_t name = {"foo", 3};
-
-        ret = bfelf_loader_resolve_symbol(&loader, &name, (void **)&func);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        EXPECT_TRUE(func(5) == 1005);
-    }
-
-    {
-        section_info_t info;
-        local_fini_t local_fini;
-        e_string_t name = {"local_fini", 10};
-
-        ret = bfelf_loader_get_info(&loader, &dummy_misc_ef, &info);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&local_fini);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        local_fini(&info);
-
-        ret = bfelf_loader_get_info(&loader, &dummy_code_ef, &info);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, (void **)&local_fini);
-        ASSERT_TRUE(ret == BFELF_SUCCESS);
-
-        local_fini(&info);
-    }
 }

--- a/bfelf_loader/test/test_loader_get_info.cpp
+++ b/bfelf_loader/test/test_loader_get_info.cpp
@@ -109,9 +109,6 @@ bfelf_loader_ut::test_bfelf_loader_get_info_expected_misc_resources()
 
     EXPECT_TRUE(info.eh_frame_addr != 0);
     EXPECT_TRUE(info.eh_frame_size != 0);
-
-    EXPECT_TRUE(info.local_init != 0);
-    EXPECT_TRUE(info.local_fini != 0);
 }
 
 void
@@ -156,7 +153,4 @@ bfelf_loader_ut::test_bfelf_loader_get_info_expected_code_resources()
 
     EXPECT_TRUE(info.eh_frame_addr != 0);
     EXPECT_TRUE(info.eh_frame_size != 0);
-
-    EXPECT_TRUE(info.local_init != 0);
-    EXPECT_TRUE(info.local_fini != 0);
 }

--- a/bfm/bin/native/vmm.modules
+++ b/bfm/bin/native/vmm.modules
@@ -2,8 +2,9 @@
 # Default Modules                                                              #
 ################################################################################
 
-../../../bfvmm/bin/cross/libmemory_manager.so
+../../../bfvmm/bin/cross/libc++.so
 ../../../bfvmm/bin/cross/libentry.so
+../../../bfvmm/bin/cross/libmemory_manager.so
 ../../../bfvmm/bin/cross/libserial.so
 ../../../bfvmm/bin/cross/libdebug_ring.so
 ../../../bfvmm/bin/cross/libintrinsics.so
@@ -13,4 +14,3 @@
 ../../../bfvmm/bin/cross/libvcpu_factory.so
 ../../../bfvmm/bin/cross/libexit_handler.so
 ../../../bfvmm/bin/cross/libmisc.so
-../../../bfvmm/bin/cross/libc++.so

--- a/bfunwind/test/test.cpp
+++ b/bfunwind/test/test.cpp
@@ -116,7 +116,6 @@ bool bfunwind_ut::init()
     memset(&loader, 0, sizeof(loader));
 
     loader.relocated = 1;
-    loader.ignore_crt = 1;
 
     ret = bfelf_loader_get_info(&loader, &self_ef, &g_info);
     ASSERT_TRUE(ret == BFELF_SUCCESS);

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -69,6 +69,8 @@ vmxon_intel_x64::start()
     cor3.commit();
 }
 
+#include <debug.h>
+
 void
 vmxon_intel_x64::stop()
 {

--- a/include/crt.h
+++ b/include/crt.h
@@ -105,9 +105,6 @@ struct section_info_t
 
     void *eh_frame_addr;
     uint64_t eh_frame_size;
-
-    local_init_t local_init;
-    local_fini_t local_fini;
 };
 
 #ifdef __cplusplus


### PR DESCRIPTION
The local_init and local_fini functions were being executed out of
the info struct which (besides from being an ugly approach) was
causing issues with no-execute stacks. There was also a bug where
destructors were not being executed which was also fixed.

Signed-off-by: Rian Quinn <quinnr@ainfosec.com>