### PR TITLE
Fix Windows 32bit App Crashing Issue

### DIFF
--- a/bfvmm/include/vmcs/vmcs_intel_x64_host_vm_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_host_vm_state.h
@@ -49,6 +49,7 @@ public:
     uint16_t ds() const override { return m_ds; }
     uint16_t fs() const override { return m_fs; }
     uint16_t gs() const override { return m_gs; }
+    uint16_t ldtr() const override { return m_ldtr; }
     uint16_t tr() const override { return m_tr; }
 
     uint64_t cr0() const override { return m_cr0; }
@@ -70,6 +71,7 @@ public:
     uint32_t ds_limit() const override { return m_gdt.limit(m_ds_index); }
     uint32_t fs_limit() const override { return m_gdt.limit(m_fs_index); }
     uint32_t gs_limit() const override { return m_gdt.limit(m_gs_index); }
+    uint32_t ldtr_limit() const override { return m_gdt.limit(m_ldtr_index); }
     uint32_t tr_limit() const override { return m_gdt.limit(m_tr_index); }
 
     uint32_t es_access_rights() const override { return m_gdt.access_rights(m_es_index); }
@@ -78,6 +80,7 @@ public:
     uint32_t ds_access_rights() const override { return m_gdt.access_rights(m_ds_index); }
     uint32_t fs_access_rights() const override { return m_gdt.access_rights(m_fs_index); }
     uint32_t gs_access_rights() const override { return m_gdt.access_rights(m_gs_index); }
+    uint32_t ldtr_access_rights() const override { return m_gdt.access_rights(m_ldtr_index); }
     uint32_t tr_access_rights() const override { return m_gdt.access_rights(m_tr_index); }
 
     uint64_t es_base() const override { return m_gdt.base(m_es_index); }
@@ -86,6 +89,7 @@ public:
     uint64_t ds_base() const override { return m_gdt.base(m_ds_index); }
     uint64_t fs_base() const override { return m_gdt.base(m_fs_index); }
     uint64_t gs_base() const override { return m_gdt.base(m_gs_index); }
+    uint64_t ldtr_base() const override { return m_gdt.base(m_ldtr_index); }
     uint64_t tr_base() const override { return m_gdt.base(m_tr_index); }
 
     uint64_t ia32_debugctl_msr() const override { return m_ia32_debugctl_msr; }
@@ -112,6 +116,7 @@ public:
         PRINT_STATE(m_ds);
         PRINT_STATE(m_fs);
         PRINT_STATE(m_gs);
+        PRINT_STATE(m_ldtr);
         PRINT_STATE(m_tr);
 
         bfdebug << bfendl;
@@ -122,6 +127,7 @@ public:
         PRINT_STATE(ds_base());
         PRINT_STATE(fs_base());
         PRINT_STATE(gs_base());
+        PRINT_STATE(ldtr_base());
         PRINT_STATE(tr_base());
 
         bfdebug << bfendl;
@@ -132,6 +138,7 @@ public:
         PRINT_STATE(ds_limit());
         PRINT_STATE(fs_limit());
         PRINT_STATE(gs_limit());
+        PRINT_STATE(ldtr_limit());
         PRINT_STATE(tr_limit());
 
         bfdebug << bfendl;
@@ -142,6 +149,7 @@ public:
         PRINT_STATE(ds_access_rights());
         PRINT_STATE(fs_access_rights());
         PRINT_STATE(gs_access_rights());
+        PRINT_STATE(ldtr_access_rights());
         PRINT_STATE(tr_access_rights());
 
         bfdebug << bfendl;
@@ -185,6 +193,7 @@ private:
     uint16_t m_ds;
     uint16_t m_fs;
     uint16_t m_gs;
+    uint16_t m_ldtr;
     uint16_t m_tr;
 
     uint16_t m_es_index;
@@ -193,6 +202,7 @@ private:
     uint16_t m_ds_index;
     uint16_t m_fs_index;
     uint16_t m_gs_index;
+    uint16_t m_ldtr_index;
     uint16_t m_tr_index;
 
     uint64_t m_cr0;

--- a/bfvmm/include/vmcs/vmcs_intel_x64_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_state.h
@@ -62,6 +62,7 @@ public:
     virtual uint16_t ds() const { return 0; }
     virtual uint16_t fs() const { return 0; }
     virtual uint16_t gs() const { return 0; }
+    virtual uint16_t ldtr() const { return 0; }
     virtual uint16_t tr() const { return 0; }
 
     virtual uint64_t cr0() const { return 0; }
@@ -83,6 +84,7 @@ public:
     virtual uint32_t ds_limit() const { return 0; }
     virtual uint32_t fs_limit() const { return 0; }
     virtual uint32_t gs_limit() const { return 0; }
+    virtual uint32_t ldtr_limit() const { return 0; }
     virtual uint32_t tr_limit() const { return 0; }
 
     virtual uint32_t es_access_rights() const { return 0x10000; }
@@ -91,6 +93,7 @@ public:
     virtual uint32_t ds_access_rights() const { return 0x10000; }
     virtual uint32_t fs_access_rights() const { return 0x10000; }
     virtual uint32_t gs_access_rights() const { return 0x10000; }
+    virtual uint32_t ldtr_access_rights() const { return 0x10000; }
     virtual uint32_t tr_access_rights() const { return 0x10000; }
 
     virtual uint64_t es_base() const { return 0; }
@@ -99,6 +102,7 @@ public:
     virtual uint64_t ds_base() const { return 0; }
     virtual uint64_t fs_base() const { return 0; }
     virtual uint64_t gs_base() const { return 0; }
+    virtual uint64_t ldtr_base() const { return 0; }
     virtual uint64_t tr_base() const { return 0; }
 
     virtual uint64_t ia32_debugctl_msr() const { return 0; }

--- a/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
@@ -312,7 +312,7 @@ intrinsics_ut::test_set_limit_descriptor_success()
         gdt_x64 gdt(intrinsics);
 
         EXPECT_NO_EXCEPTION(gdt.set_limit(1, 0xBBBBBBBB12345678));
-        EXPECT_TRUE(g_gdt[1] == 0xFFF4FFFFFFFF5678);
+        EXPECT_TRUE(g_gdt[1] == 0xFFF1FFFFFFFF2345);
     });
 }
 
@@ -361,7 +361,7 @@ intrinsics_ut::test_limit_descriptor_success()
         gdt_x64 gdt(intrinsics);
 
         g_gdt[1] = 0xFFF4FFFFFFFF5678;
-        EXPECT_TRUE(gdt.limit(1) == 0x0000000000045678);
+        EXPECT_TRUE(gdt.limit(1) == 0x0000000045678FFF);
     });
 }
 

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -322,9 +322,9 @@ vmcs_intel_x64::write_16bit_guest_state(const std::shared_ptr<vmcs_intel_x64_sta
     vmwrite(VMCS_GUEST_DS_SELECTOR, state->ds());
     vmwrite(VMCS_GUEST_FS_SELECTOR, state->fs());
     vmwrite(VMCS_GUEST_GS_SELECTOR, state->gs());
+    vmwrite(VMCS_GUEST_LDTR_SELECTOR, state->ldtr());
     vmwrite(VMCS_GUEST_TR_SELECTOR, state->tr());
 
-    // unused: VMCS_GUEST_LDTR_SELECTOR
     // unused: VMCS_GUEST_INTERRUPT_STATUS
 }
 
@@ -352,6 +352,7 @@ vmcs_intel_x64::write_32bit_guest_state(const std::shared_ptr<vmcs_intel_x64_sta
     vmwrite(VMCS_GUEST_DS_LIMIT, state->ds_limit());
     vmwrite(VMCS_GUEST_FS_LIMIT, state->fs_limit());
     vmwrite(VMCS_GUEST_GS_LIMIT, state->gs_limit());
+    vmwrite(VMCS_GUEST_LDTR_LIMIT, state->ldtr_limit());
     vmwrite(VMCS_GUEST_TR_LIMIT, state->tr_limit());
 
     vmwrite(VMCS_GUEST_GDTR_LIMIT, state->gdt_limit());
@@ -363,12 +364,11 @@ vmcs_intel_x64::write_32bit_guest_state(const std::shared_ptr<vmcs_intel_x64_sta
     vmwrite(VMCS_GUEST_DS_ACCESS_RIGHTS, state->ds_access_rights());
     vmwrite(VMCS_GUEST_FS_ACCESS_RIGHTS, state->fs_access_rights());
     vmwrite(VMCS_GUEST_GS_ACCESS_RIGHTS, state->gs_access_rights());
-    vmwrite(VMCS_GUEST_LDTR_ACCESS_RIGHTS, 0x10000);
+    vmwrite(VMCS_GUEST_LDTR_ACCESS_RIGHTS, state->ldtr_access_rights());
     vmwrite(VMCS_GUEST_TR_ACCESS_RIGHTS, state->tr_access_rights());
 
     vmwrite(VMCS_GUEST_IA32_SYSENTER_CS, state->ia32_sysenter_cs_msr());
 
-    // unused: VMCS_GUEST_LDTR_LIMIT
     // unused: VMCS_GUEST_INTERRUPTIBILITY_STATE
     // unused: VMCS_GUEST_ACTIVITY_STATE
     // unused: VMCS_GUEST_SMBASE
@@ -388,6 +388,7 @@ vmcs_intel_x64::write_natural_guest_state(const std::shared_ptr<vmcs_intel_x64_s
     vmwrite(VMCS_GUEST_DS_BASE, state->ds_base());
     vmwrite(VMCS_GUEST_FS_BASE, state->ia32_fs_base_msr());
     vmwrite(VMCS_GUEST_GS_BASE, state->ia32_gs_base_msr());
+    vmwrite(VMCS_GUEST_LDTR_BASE, state->ldtr_base());
     vmwrite(VMCS_GUEST_TR_BASE, state->tr_base());
 
     vmwrite(VMCS_GUEST_GDTR_BASE, state->gdt_base());
@@ -399,7 +400,6 @@ vmcs_intel_x64::write_natural_guest_state(const std::shared_ptr<vmcs_intel_x64_s
     vmwrite(VMCS_GUEST_IA32_SYSENTER_ESP, state->ia32_sysenter_esp_msr());
     vmwrite(VMCS_GUEST_IA32_SYSENTER_EIP, state->ia32_sysenter_eip_msr());
 
-    // unused: VMCS_GUEST_LDTR_BASE
     // unused: VMCS_GUEST_RSP, see m_intrinsics->vmlaunch()
     // unused: VMCS_GUEST_RIP, see m_intrinsics->vmlaunch()
     // unused: VMCS_GUEST_PENDING_DEBUG_EXCEPTIONS
@@ -543,7 +543,7 @@ vmcs_intel_x64::vm_exit_controls()
     controls |= VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS;
     controls |= VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE;
     controls |= VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL;
-    // controls |= VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT;
+    controls |= VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT;
     controls |= VM_EXIT_CONTROL_SAVE_IA32_PAT;
     controls |= VM_EXIT_CONTROL_LOAD_IA32_PAT;
     controls |= VM_EXIT_CONTROL_SAVE_IA32_EFER;

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
@@ -34,6 +34,7 @@ vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state(const std::shared_ptr
     m_ds = intrinsics->read_ds();
     m_fs = intrinsics->read_fs();
     m_gs = intrinsics->read_gs();
+    m_ldtr = intrinsics->read_ldtr();
     m_tr = intrinsics->read_tr();
 
     m_es_index = m_es >> 3;
@@ -42,6 +43,7 @@ vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state(const std::shared_ptr
     m_ds_index = m_ds >> 3;
     m_fs_index = m_fs >> 3;
     m_gs_index = m_gs >> 3;
+    m_ldtr_index = m_ldtr >> 3;
     m_tr_index = m_tr >> 3;
 
     m_cr0 = intrinsics->read_cr0();

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
@@ -70,9 +70,9 @@ vmcs_intel_x64_vmm_state::vmcs_intel_x64_vmm_state(const std::shared_ptr<state_s
     m_gdt.set_base(4, (uint64_t)&m_tss);
 
     m_gdt.set_limit(0, 0);
-    m_gdt.set_limit(1, 0xFFFFF);
-    m_gdt.set_limit(2, 0xFFFFF);
-    m_gdt.set_limit(3, 0xFFFFF);
+    m_gdt.set_limit(1, 0xFFFFFFFF);
+    m_gdt.set_limit(2, 0xFFFFFFFF);
+    m_gdt.set_limit(3, 0xFFFFFFFF);
     m_gdt.set_limit(4, sizeof(m_tss));
 
     m_cs_index = 1;


### PR DESCRIPTION
Windows 32bit applications were crashing because we were not
properly handling segment limits which are used by 32bit.
Specifically, when the granulatiry bit is set, the limit must
be converted to "bytes" for Intel VMX.

This patch also adds support for the LDTR which could be used
in the future. Just in case, the LDTR is now being set, but
usually is 0, even on Windows.

[ISSUE}: https://github.com/Bareflank/hypervisor/issues/140

Signed-off-by: “Rian <“rianquinn@gmail.com”>