### PR TITLE
Error Code Cleanup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,9 +19,7 @@ Misc:
   flags for BFM and windows for export all.
 
 Version 1.1 TODO:
-- We need to go through all of the error codes, and map out blocks for each
-  module, driver, elf error, etc... This way, when an error bubbles through
-  the system, it's easy to identify
+- Add Windows support
 - Trigger a rebuild if bfcrt changes
 - The vcpuid needs to be figured out. Since we need to be able to move VMCS
   structures from core to core to handle rescheduling a task on a different

--- a/bfdrivers/include/common.h
+++ b/bfdrivers/include/common.h
@@ -24,35 +24,12 @@
 #define COMMON_H
 
 #include <types.h>
+#include <error_codes.h>
 #include <bfelf_loader.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* -------------------------------------------------------------------------- */
-/* Macros                                                                     */
-/* -------------------------------------------------------------------------- */
-
-/*
- * Error Codes
- *
- * Note that these are not the only error codes that could come out of the
- * driver entry. Error codes in supporting software (like the ELF loader)
- * could also show up, so these should be in a range that are easy to
- * identify
- */
-#define BF_SUCCESS 0
-#define BF_ERROR_INVALID_ARG -5001
-#define BF_ERROR_INVALID_INDEX -5002
-#define BF_ERROR_NO_MODULES_ADDED -5010
-#define BF_ERROR_MAX_MODULES_REACHED -5011
-#define BF_ERROR_VMM_INVALID_STATE -5012
-#define BF_ERROR_FAILED_TO_ADD_FILE -5015
-#define BF_ERROR_FAILED_TO_DUMP_DR -5017
-#define BF_ERROR_OUT_OF_MEMORY -5018
-#define BF_ERROR_VMM_CORRUPTED -5100
-#define BF_ERROR_UNKNOWN -5200
 
 /* -------------------------------------------------------------------------- */
 /* Module                                                                     */

--- a/bfdrivers/src/arch/linux/entry.c
+++ b/bfdrivers/src/arch/linux/entry.c
@@ -29,6 +29,7 @@
 #include <linux/notifier.h>
 #include <linux/reboot.h>
 
+#include <types.h>
 #include <debug.h>
 #include <common.h>
 #include <constants.h>
@@ -73,8 +74,8 @@ dev_release(struct inode *inode, struct file *file)
 static long
 ioctl_add_module(char *file)
 {
-    int ret;
     char *buf;
+    int64_t ret;
 
     if (g_num_files >= MAX_NUM_MODULES)
     {
@@ -112,7 +113,8 @@ ioctl_add_module(char *file)
     ret = common_add_module(buf, g_module_length);
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_ADD_MODULE: failed to add module\n");
+        ALERT("IOCTL_ADD_MODULE: common_add_module failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         goto failed;
     }
 
@@ -135,7 +137,7 @@ failed:
 static long
 ioctl_add_module_length(int64_t *len)
 {
-    int ret;
+    int64_t ret;
 
     if (len == 0)
     {
@@ -158,13 +160,14 @@ static long
 ioctl_unload_vmm(void)
 {
     int i;
-    int ret;
+    int64_t ret;
     long status = BF_IOCTL_SUCCESS;
 
     ret = common_unload_vmm();
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_UNLOAD_VMM: failed to unload vmm: %d\n", ret);
+        ALERT("IOCTL_UNLOAD_VMM: common_unload_vmm failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         status = BF_IOCTL_FAILURE;
     }
 
@@ -187,12 +190,13 @@ ioctl_unload_vmm(void)
 static long
 ioctl_load_vmm(void)
 {
-    int ret;
+    int64_t ret;
 
     ret = common_load_vmm();
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_LOAD_VMM: failed to load vmm: %d\n", ret);
+        ALERT("IOCTL_LOAD_VMM: common_load_vmm failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         goto failure;
     }
 
@@ -208,14 +212,15 @@ failure:
 static long
 ioctl_stop_vmm(void)
 {
-    int ret;
+    int64_t ret;
     long status = BF_IOCTL_SUCCESS;
 
     ret = common_stop_vmm();
 
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_STOP_VMM: failed to stop vmm: %d\n", ret);
+        ALERT("IOCTL_STOP_VMM: common_stop_vmm failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         status = BF_IOCTL_FAILURE;
     }
 
@@ -228,12 +233,13 @@ ioctl_stop_vmm(void)
 static long
 ioctl_start_vmm(void)
 {
-    int ret;
+    int64_t ret;
 
     ret = common_start_vmm();
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_START_VMM: failed to start vmm: %d\n", ret);
+        ALERT("IOCTL_START_VMM: common_start_vmm failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         goto failure;
     }
 
@@ -249,13 +255,14 @@ failure:
 static long
 ioctl_dump_vmm(struct debug_ring_resources_t *user_drr)
 {
-    int ret;
+    int64_t ret;
     struct debug_ring_resources_t *drr = 0;
 
     ret = common_dump_vmm(&drr, g_vcpuid);
     if (ret != BF_SUCCESS)
     {
-        ALERT("IOCTL_DUMP_VMM: failed to dump vmm: %d\n", ret);
+        ALERT("IOCTL_DUMP_VMM: common_dump_vmm failed: %p - %s\n", \
+              (void *)ret, ec_to_str(ret));
         return BF_IOCTL_FAILURE;
     }
 
@@ -273,12 +280,12 @@ ioctl_dump_vmm(struct debug_ring_resources_t *user_drr)
 static long
 ioctl_vmm_status(int64_t *status)
 {
-    int ret;
+    int64_t ret;
     int64_t vmm_status = common_vmm_status();
 
     if (status == 0)
     {
-        ALERT("IOCTL_VMM_STATUS: failed with status == NULL\n");
+        ALERT("IOCTL_VMM_STATUS: common_vmm_status failed: NULL\n");
         return BF_IOCTL_FAILURE;
     }
 
@@ -296,7 +303,7 @@ ioctl_vmm_status(int64_t *status)
 static long
 ioctl_set_vcpuid(uint64_t *vcpuid)
 {
-    int ret;
+    int64_t ret;
 
     if (vcpuid == 0)
     {

--- a/bfelf_loader/include/bfelf_loader.h
+++ b/bfelf_loader/include/bfelf_loader.h
@@ -24,6 +24,7 @@
 #define BFELF_LOADER_H
 
 #include <crt.h>
+#include <error_codes.h>
 
 #if defined(KERNEL) && defined(__linux__)
 #include <linux/types.h>
@@ -81,29 +82,6 @@ typedef int64_t bfelf64_sxword;
 /******************************************************************************/
 /* ELF Error Codes                                                            */
 /******************************************************************************/
-
-#define BFELF_ERROR_START ((bfelf64_sword)-11000)
-
-/*
- * ELF error codes
- *
- * The following define the different error codes that this library might
- * provide given bad input.
- */
-#define BFELF_SUCCESS ((bfelf64_sword)0)
-#define BFELF_ERROR_INVALID_ARG (BFELF_ERROR_START - (bfelf64_sword)1)
-#define BFELF_ERROR_INVALID_FILE (BFELF_ERROR_START - (bfelf64_sword)2)
-#define BFELF_ERROR_INVALID_INDEX (BFELF_ERROR_START - (bfelf64_sword)3)
-#define BFELF_ERROR_INVALID_STRING (BFELF_ERROR_START - (bfelf64_sword)4)
-#define BFELF_ERROR_INVALID_SIGNATURE (BFELF_ERROR_START - (bfelf64_sword)5)
-#define BFELF_ERROR_UNSUPPORTED_FILE (BFELF_ERROR_START - (bfelf64_sword)6)
-#define BFELF_ERROR_INVALID_SEGMENT (BFELF_ERROR_START - (bfelf64_sword)7)
-#define BFELF_ERROR_INVALID_SECTION (BFELF_ERROR_START - (bfelf64_sword)8)
-#define BFELF_ERROR_LOADER_FULL (BFELF_ERROR_START - (bfelf64_sword)9)
-#define BFELF_ERROR_NO_SUCH_SYMBOL (BFELF_ERROR_START - (bfelf64_sword)10)
-#define BFELF_ERROR_MISMATCH (BFELF_ERROR_START - (bfelf64_sword)11)
-#define BFELF_ERROR_UNSUPPORTED_RELA (BFELF_ERROR_START - (bfelf64_sword)12)
-#define BFELF_ERROR_OUT_OF_ORDER (BFELF_ERROR_START - (bfelf64_sword)13)
 
 /**
  * Convert ELF error -> const char *
@@ -198,9 +176,9 @@ struct bfelf_file_t
  * @param ef the ELF file structure to initialize.
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_file_init(char *file,
-                              uint64_t fsize,
-                              struct bfelf_file_t *ef);
+int64_t bfelf_file_init(char *file,
+                        uint64_t fsize,
+                        struct bfelf_file_t *ef);
 
 /**
  * Get number of program segments
@@ -213,7 +191,7 @@ bfelf64_sword bfelf_file_init(char *file,
  * @param ef the ELF file
  * @return number of segments on success, negative on error
  */
-bfelf64_sxword bfelf_file_num_segments(struct bfelf_file_t *ef);
+int64_t bfelf_file_num_segments(struct bfelf_file_t *ef);
 
 /**
  * Get program segment
@@ -232,9 +210,9 @@ bfelf64_sxword bfelf_file_num_segments(struct bfelf_file_t *ef);
  * @param phdr where to store the segment's program header
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_file_get_segment(struct bfelf_file_t *ef,
-                                     bfelf64_word index,
-                                     struct bfelf_phdr **phdr);
+int64_t bfelf_file_get_segment(struct bfelf_file_t *ef,
+                               bfelf64_word index,
+                               struct bfelf_phdr **phdr);
 
 /**
  * Resolve Symbol
@@ -253,9 +231,9 @@ bfelf64_sword bfelf_file_get_segment(struct bfelf_file_t *ef,
  * @param addr the resulting address if the symbol is successfully resolved
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_file_resolve_symbol(struct bfelf_file_t *ef,
-                                        struct e_string_t *name,
-                                        void **addr);
+int64_t bfelf_file_resolve_symbol(struct bfelf_file_t *ef,
+                                  struct e_string_t *name,
+                                  void **addr);
 
 /******************************************************************************/
 /* ELF File Header                                                            */
@@ -678,9 +656,9 @@ struct bfelf_loader_t
  *     is run.
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_loader_add(struct bfelf_loader_t *loader,
-                               struct bfelf_file_t *ef,
-                               char *exec);
+int64_t bfelf_loader_add(struct bfelf_loader_t *loader,
+                         struct bfelf_file_t *ef,
+                         char *exec);
 
 /**
  * Relocate ELF Loader
@@ -692,7 +670,7 @@ bfelf64_sword bfelf_loader_add(struct bfelf_loader_t *loader,
  * @param loader the ELF loader
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_loader_relocate(struct bfelf_loader_t *loader);
+int64_t bfelf_loader_relocate(struct bfelf_loader_t *loader);
 
 /**
  * Resolve Symbol
@@ -708,9 +686,9 @@ bfelf64_sword bfelf_loader_relocate(struct bfelf_loader_t *loader);
  * @param addr the resulting address if the symbol is successfully resolved
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_loader_resolve_symbol(struct bfelf_loader_t *loader,
-        struct e_string_t *name,
-        void **addr);
+int64_t bfelf_loader_resolve_symbol(struct bfelf_loader_t *loader,
+                                    struct e_string_t *name,
+                                    void **addr);
 
 /**
  * Get Info
@@ -728,9 +706,9 @@ bfelf64_sword bfelf_loader_resolve_symbol(struct bfelf_loader_t *loader,
  * @param info the info structore to store the results.
  * @return BFELF_SUCCESS on success, negative on error
  */
-bfelf64_sword bfelf_loader_get_info(struct bfelf_loader_t *loader,
-                                    struct bfelf_file_t *ef,
-                                    struct section_info_t *info);
+int64_t bfelf_loader_get_info(struct bfelf_loader_t *loader,
+                              struct bfelf_file_t *ef,
+                              struct section_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/bfelf_loader/test/test_file_resolve_symbol.cpp
+++ b/bfelf_loader/test/test_file_resolve_symbol.cpp
@@ -60,7 +60,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_addr()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_symbol_no_relocation()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t ef;
 
     memset(&ef, 0, sizeof(ef));
@@ -75,7 +75,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_no_relocation()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -110,7 +110,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -145,7 +145,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -180,7 +180,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -215,7 +215,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_symbol_success()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -250,7 +250,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_success()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -288,7 +288,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol_no_hash()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -326,7 +326,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol_no_hash()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -364,7 +364,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length_no_hash()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -402,7 +402,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large_no_hash()
 void
 bfelf_loader_ut::test_bfelf_file_resolve_symbol_success_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 

--- a/bfelf_loader/test/test_loader_add.cpp
+++ b/bfelf_loader/test/test_loader_add.cpp
@@ -24,7 +24,7 @@
 void
 bfelf_loader_ut::test_bfelf_loader_add_invalid_loader()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
 
     ret = bfelf_file_init(m_dummy_misc.get(), m_dummy_misc_length, &dummy_misc_ef);
@@ -47,7 +47,7 @@ bfelf_loader_ut::test_bfelf_loader_add_invalid_elf_file()
 void
 bfelf_loader_ut::test_bfelf_loader_add_too_many_files()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
 
     ret = bfelf_file_init(m_dummy_misc.get(), m_dummy_misc_length, &dummy_misc_ef);

--- a/bfelf_loader/test/test_loader_resolve_symbol.cpp
+++ b/bfelf_loader/test/test_loader_resolve_symbol.cpp
@@ -60,7 +60,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_addr()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_relocation()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_loader_t loader;
 
     memset(&loader, 0, sizeof(loader));
@@ -75,7 +75,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_relocation()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_files_added()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_loader_t loader;
 
     memset(&loader, 0, sizeof(loader));
@@ -93,7 +93,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_files_added()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_uninitialized_files()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t ef1;
     bfelf_file_t ef2;
     bfelf_loader_t loader;
@@ -120,7 +120,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_uninitialized_files()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -155,7 +155,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -190,7 +190,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -225,7 +225,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -260,7 +260,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -295,7 +295,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -333,7 +333,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol_no_hash()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -371,7 +371,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol_no_hash()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -409,7 +409,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length_no_hash()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -447,7 +447,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large_no_hash()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success_no_hash()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 
@@ -485,7 +485,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success_no_hash()
 void
 bfelf_loader_ut::test_bfelf_loader_resolve_symbol_real_test()
 {
-    auto ret = 0;
+    auto ret = 0LL;
     bfelf_file_t dummy_misc_ef;
     bfelf_file_t dummy_code_ef;
 

--- a/include/driver_entry_interface.h
+++ b/include/driver_entry_interface.h
@@ -31,12 +31,6 @@ extern "C" {
 /* Common                                                                     */
 /* -------------------------------------------------------------------------- */
 
-/**
- * Driver Error Codes
- */
-#define BF_IOCTL_SUCCESS 0
-#define BF_IOCTL_FAILURE -10000
-
 /*
  * Driver Entry State Machine
  *

--- a/include/error_codes.h
+++ b/include/error_codes.h
@@ -23,16 +23,36 @@
 #ifndef ERROR_CODES_H
 #define ERROR_CODES_H
 
+#if !defined(KERNEL) && !defined(_WIN32)
+#include <stdint.h>
+#endif
+
+#if defined(KERNEL) && defined(__linux__)
+#include <linux/types.h>
+#define PRId64 "lld"
+#endif
+
+#if defined(_WIN32)
+#include <basetsd.h>
+typedef INT64 int64_t;
+#endif
+
+/* -------------------------------------------------------------------------- */
+/* Helper Macros                                                              */
+/* -------------------------------------------------------------------------- */
+
 #define sign(a) ((int64_t)(a))
 
-/**
- * Success
- */
+/* -------------------------------------------------------------------------- */
+/* Success                                                                    */
+/* -------------------------------------------------------------------------- */
+
 #define SUCCESS 0
 
-/**
- * Entry Error Codes
- */
+/* -------------------------------------------------------------------------- */
+/* Entry Error Codes                                                          */
+/* -------------------------------------------------------------------------- */
+
 #define ENTRY_SUCCESS sign(SUCCESS)
 #define ENTRY_ERROR_STACK_OVERFLOW sign(0x8000000000000010)
 #define ENTRY_ERROR_VMM_INIT_FAILED sign(0x8000000000000020)
@@ -40,22 +60,134 @@
 #define ENTRY_ERROR_VMM_STOP_FAILED sign(0x8000000000000040)
 #define ENTRY_ERROR_UNKNOWN sign(0x8000000000000050)
 
-/**
- * CRT Error Codes
- */
+/* -------------------------------------------------------------------------- */
+/* C Runtime Error Codes                                                      */
+/* -------------------------------------------------------------------------- */
+
 #define CRT_SUCCESS sign(SUCCESS)
 #define CRT_FAILURE sign(0x8000000000000100)
 
-/**
- * Register EH Frame Error Codes
- */
+/* -------------------------------------------------------------------------- */
+/* Unwinder Error Codes                                                       */
+/* -------------------------------------------------------------------------- */
+
 #define REGISTER_EH_FRAME_SUCCESS sign(SUCCESS)
 #define REGISTER_EH_FRAME_FAILURE sign(0x8000000000001000)
 
-/**
- * Debug Ring Error Codes
- */
+/* -------------------------------------------------------------------------- */
+/* Debug Ring Error Codes                                                     */
+/* -------------------------------------------------------------------------- */
+
 #define GET_DRR_SUCCESS sign(SUCCESS)
 #define GET_DRR_FAILURE sign(0x8000000000010000)
+
+/* -------------------------------------------------------------------------- */
+/* ELF Loader Error Codes                                                     */
+/* -------------------------------------------------------------------------- */
+
+#define BFELF_SUCCESS sign(SUCCESS)
+#define BFELF_ERROR_INVALID_ARG sign(0x8000000000100000)
+#define BFELF_ERROR_INVALID_FILE sign(0x8000000000200000)
+#define BFELF_ERROR_INVALID_INDEX sign(0x8000000000300000)
+#define BFELF_ERROR_INVALID_STRING sign(0x8000000000400000)
+#define BFELF_ERROR_INVALID_SIGNATURE sign(0x8000000000500000)
+#define BFELF_ERROR_UNSUPPORTED_FILE sign(0x8000000000600000)
+#define BFELF_ERROR_INVALID_SEGMENT sign(0x8000000000700000)
+#define BFELF_ERROR_INVALID_SECTION sign(0x8000000000800000)
+#define BFELF_ERROR_LOADER_FULL sign(0x8000000000900000)
+#define BFELF_ERROR_NO_SUCH_SYMBOL sign(0x8000000000A00000)
+#define BFELF_ERROR_MISMATCH sign(0x8000000000B00000)
+#define BFELF_ERROR_UNSUPPORTED_RELA sign(0x8000000000C00000)
+#define BFELF_ERROR_OUT_OF_ORDER sign(0x8000000000D00000)
+
+/* -------------------------------------------------------------------------- */
+/* Memory Manager Error Codes                                                 */
+/* -------------------------------------------------------------------------- */
+
+#define MEMORY_MANAGER_SUCCESS sign(SUCCESS)
+#define MEMORY_MANAGER_FAILURE sign(0x8000000001000000)
+
+/* -------------------------------------------------------------------------- */
+/* Common Error Codes                                                         */
+/* -------------------------------------------------------------------------- */
+
+#define BF_SUCCESS sign(SUCCESS)
+#define BF_ERROR_INVALID_ARG sign(0x8000000010000000)
+#define BF_ERROR_INVALID_INDEX sign(0x8000000020000000)
+#define BF_ERROR_NO_MODULES_ADDED sign(0x8000000030000000)
+#define BF_ERROR_MAX_MODULES_REACHED sign(0x8000000040000000)
+#define BF_ERROR_VMM_INVALID_STATE sign(0x8000000050000000)
+#define BF_ERROR_FAILED_TO_ADD_FILE sign(0x8000000060000000)
+#define BF_ERROR_FAILED_TO_DUMP_DR sign(0x8000000070000000)
+#define BF_ERROR_OUT_OF_MEMORY sign(0x8000000080000000)
+#define BF_ERROR_VMM_CORRUPTED sign(0x8000000090000000)
+#define BF_ERROR_UNKNOWN sign(0x80000000A0000000)
+
+/* -------------------------------------------------------------------------- */
+/* IOCTL Error Codes                                                          */
+/* -------------------------------------------------------------------------- */
+
+#define BF_IOCTL_SUCCESS sign(SUCCESS)
+#define BF_IOCTL_FAILURE sign(0x8000000100000000)
+
+/* -------------------------------------------------------------------------- */
+/* Stringify Error Codes                                                      */
+/* -------------------------------------------------------------------------- */
+
+#define EC_CASE(a) \
+    case a: return #a
+
+static inline const char *
+ec_to_str(int64_t value)
+{
+    switch (value)
+    {
+            EC_CASE(SUCCESS);
+
+            EC_CASE(ENTRY_ERROR_STACK_OVERFLOW);
+            EC_CASE(ENTRY_ERROR_VMM_INIT_FAILED);
+            EC_CASE(ENTRY_ERROR_VMM_START_FAILED);
+            EC_CASE(ENTRY_ERROR_VMM_STOP_FAILED);
+            EC_CASE(ENTRY_ERROR_UNKNOWN);
+
+            EC_CASE(CRT_FAILURE);
+
+            EC_CASE(REGISTER_EH_FRAME_FAILURE);
+
+            EC_CASE(GET_DRR_FAILURE);
+
+            EC_CASE(MEMORY_MANAGER_FAILURE);
+
+            EC_CASE(BFELF_ERROR_INVALID_ARG);
+            EC_CASE(BFELF_ERROR_INVALID_FILE);
+            EC_CASE(BFELF_ERROR_INVALID_INDEX);
+            EC_CASE(BFELF_ERROR_INVALID_STRING);
+            EC_CASE(BFELF_ERROR_INVALID_SIGNATURE);
+            EC_CASE(BFELF_ERROR_UNSUPPORTED_FILE);
+            EC_CASE(BFELF_ERROR_INVALID_SEGMENT);
+            EC_CASE(BFELF_ERROR_INVALID_SECTION);
+            EC_CASE(BFELF_ERROR_LOADER_FULL);
+            EC_CASE(BFELF_ERROR_NO_SUCH_SYMBOL);
+            EC_CASE(BFELF_ERROR_MISMATCH);
+            EC_CASE(BFELF_ERROR_UNSUPPORTED_RELA);
+            EC_CASE(BFELF_ERROR_OUT_OF_ORDER);
+
+            EC_CASE(BF_ERROR_INVALID_ARG);
+            EC_CASE(BF_ERROR_INVALID_INDEX);
+            EC_CASE(BF_ERROR_NO_MODULES_ADDED);
+            EC_CASE(BF_ERROR_MAX_MODULES_REACHED);
+            EC_CASE(BF_ERROR_VMM_INVALID_STATE);
+            EC_CASE(BF_ERROR_FAILED_TO_ADD_FILE);
+            EC_CASE(BF_ERROR_FAILED_TO_DUMP_DR);
+            EC_CASE(BF_ERROR_OUT_OF_MEMORY);
+            EC_CASE(BF_ERROR_VMM_CORRUPTED);
+            EC_CASE(BF_ERROR_UNKNOWN);
+
+            EC_CASE(BF_IOCTL_FAILURE);
+
+        default:
+            return "UNDEFINED_ERROR_CODE";
+    }
+}
 
 #endif

--- a/include/memory.h
+++ b/include/memory.h
@@ -29,17 +29,14 @@
 #include <types.h>
 #endif
 
+#include <constants.h>
+#include <error_codes.h>
+
 #pragma pack(push, 1)
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * Memory Manger Error Codes
- */
-#define MEMORY_MANAGER_SUCCESS 0
-#define MEMORY_MANAGER_FAILURE -1LL
 
 /**
  * Memory Types


### PR DESCRIPTION
Originally, the error codes were self contained which made sense
at the time, but as the project has grown, the number of error
codes has increased leading to a lot of redudancy in common.c as
well as overlapping error codes in a couple of cases. This patch
moves all of the error codes toa single file, makes sure the
return types are consistent, and provides a single error code
to string conversion function

Signed-off-by: “Rian <“rianquinn@gmail.com”>