### PR TITLE
Add Alignment Check

### DIFF
--- a/bfelf_loader/src/bfelf_loader.c
+++ b/bfelf_loader/src/bfelf_loader.c
@@ -628,13 +628,8 @@ private_check_segments(struct bfelf_file_t *ef)
         if (phdr->p_vaddr != phdr->p_paddr)
             return invalid_segment("expect p_vaddr == p_paddr");
 
-        /*
-         * At the moment, libc++.so has an alignment of 20, which is really
-         * strange. Will need to find out why at some point
-         *
-         * if (phdr->p_align != 0x1000 && phdr->p_align != 0x200000)
-         *     return invalid_segment("expect 4k or 2M alignment");
-         */
+        if (phdr->p_align != 0x1000 && phdr->p_align != 0x200000)
+            return invalid_segment("expect 4k or 2M alignment");
 
         if (phdr->p_offset >= ef->fsize)
             return invalid_segment("segment offset out of bounds");


### PR DESCRIPTION
I think this was actually addressed right before we released
version 1.0, but we never fixed this line of code. Bascially,
libc++ was not being compiled correctly, so the alignment
was wrong. Now that we are compiling it correctly, the alignment
is as expected, so we can re-enable this check

Signed-off-by: “Rian <“rianquinn@gmail.com”>