### PR TITLE
Remove XSAVE

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -19,17 +19,9 @@ Misc:
   flags for BFM and windows for export all.
 
 Version 1.1 TODO:
-- Add Windows support
 - Trigger a rebuild if bfcrt changes
-- The vcpuid needs to be figured out. Since we need to be able to move VMCS
-  structures from core to core to handle rescheduling a task on a different
-  CPU, there is probably no need to make this complicated. Just need to make
-  sure that the vcpuid is a uint64 everywhere.
 - The IOCTLs for Windows are too permissive
 - The IOCTLs for Windows do not share the same #'s as Linux
-- Manually save XMM / YMM registers instead of using XSAVE
-- Do a grep for _tr and make sure all of the LDTR code has been added as 
-  it appears that some is missing
 
 Version 1.2 TODO:
 - Clean up the VMCS checks so that they can be unit tested better, and then

--- a/bfvmm/include/intrinsics/intrinsics_intel_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_intel_x64.h
@@ -85,10 +85,26 @@ struct state_save_intel_x64
     uint64_t vmcs_ptr;              // 0x098
     uint64_t exit_handler_ptr;      // 0x0A0
 
-    uint64_t xsave_size;            // 0x0A8
-    uint64_t xsave_addr;            // 0x0B0
-    uint64_t xsave_xcr0_eax;        // 0x0B8
-    uint64_t xsave_xcr0_edx;        // 0x0C0
+    uint64_t reserved1;             // 0x0A8
+    uint64_t reserved2;             // 0x0B0
+    uint64_t reserved3;             // 0x0B8
+
+    uint64_t ymm00[4];              // 0x0C0
+    uint64_t ymm01[4];              // 0x0E0
+    uint64_t ymm02[4];              // 0x100
+    uint64_t ymm03[4];              // 0x120
+    uint64_t ymm04[4];              // 0x140
+    uint64_t ymm05[4];              // 0x160
+    uint64_t ymm06[4];              // 0x180
+    uint64_t ymm07[4];              // 0x1A0
+    uint64_t ymm08[4];              // 0x1C0
+    uint64_t ymm09[4];              // 0x1E0
+    uint64_t ymm10[4];              // 0x200
+    uint64_t ymm11[4];              // 0x220
+    uint64_t ymm12[4];              // 0x240
+    uint64_t ymm13[4];              // 0x260
+    uint64_t ymm14[4];              // 0x280
+    uint64_t ymm15[4];              // 0x2A0
 };
 
 #pragma pack(pop)

--- a/bfvmm/include/intrinsics/intrinsics_x64.h
+++ b/bfvmm/include/intrinsics/intrinsics_x64.h
@@ -51,6 +51,7 @@ void __cpuid(uint64_t *rax,
              uint64_t *rdx);
 
 uint64_t __read_rflags(void);
+void __write_rflags(uint64_t val);
 
 uint64_t __read_msr(uint32_t msr);
 void __write_msr(uint32_t msr, uint64_t val);
@@ -65,9 +66,6 @@ void __write_cr3(uint64_t val);
 
 uint64_t __read_cr4(void);
 void __write_cr4(uint64_t val);
-
-uint64_t __read_xcr0(void);
-void __write_xcr0(uint64_t val);
 
 uint64_t __read_dr7(void);
 void __write_dr7(uint64_t val);
@@ -165,6 +163,9 @@ public:
     virtual uint64_t read_rflags() const noexcept
     { return __read_rflags(); }
 
+    virtual void write_rflags(uint64_t val) const noexcept
+    { __write_rflags(val); }
+
     virtual uint64_t read_msr(uint32_t msr) const noexcept
     { return __read_msr(msr); }
 
@@ -191,12 +192,6 @@ public:
 
     virtual void write_cr4(uint64_t val) const noexcept
     { __write_cr4(val); }
-
-    virtual uint64_t read_xcr0() const noexcept
-    { return __read_xcr0(); }
-
-    virtual void write_xcr0(uint64_t val) const noexcept
-    { __write_xcr0(val); }
 
     virtual uint64_t read_dr7() const noexcept
     { return __read_dr7(); }

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64_support.asm
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64_support.asm
@@ -68,17 +68,22 @@ exit_handler_entry:
     mov [gs:0x068], r14
     mov [gs:0x070], r15
 
-    sub rsp, [gs:0x0A8]
-    sub rsp, 0x40
-    and rsp, 0xFFFFFFFFFFFFFF80
-    mov [gs:0x0B0], rsp
-
-    mov rax, [gs:0x0B8]
-    mov rdx, [gs:0x0C0]
-    xsave [rsp]
-
-    sub rsp, 0x10
-    and rsp, 0xFFFFFFFFFFFFFFF0
+    vmovdqa [gs:0x0C0], ymm0
+    vmovdqa [gs:0x0E0], ymm1
+    vmovdqa [gs:0x100], ymm2
+    vmovdqa [gs:0x120], ymm3
+    vmovdqa [gs:0x140], ymm4
+    vmovdqa [gs:0x160], ymm5
+    vmovdqa [gs:0x180], ymm6
+    vmovdqa [gs:0x1A0], ymm7
+    vmovdqa [gs:0x1C0], ymm8
+    vmovdqa [gs:0x1E0], ymm9
+    vmovdqa [gs:0x200], ymm10
+    vmovdqa [gs:0x220], ymm11
+    vmovdqa [gs:0x240], ymm12
+    vmovdqa [gs:0x260], ymm13
+    vmovdqa [gs:0x280], ymm14
+    vmovdqa [gs:0x2A0], ymm15
 
     mov rdi, VMCS_GUEST_RIP
     vmread [gs:0x078], rdi
@@ -93,10 +98,22 @@ exit_handler_entry:
     mov rdi, VMCS_GUEST_RIP
     vmwrite rdi, [gs:0x078]
 
-    mov rsi, [gs:0x0B0]
-    mov rax, [gs:0x0B8]
-    mov rdx, [gs:0x0C0]
-    xrstor [rsi]
+    vmovdqa ymm15, [gs:0x2A0]
+    vmovdqa ymm14, [gs:0x280]
+    vmovdqa ymm13, [gs:0x260]
+    vmovdqa ymm12, [gs:0x240]
+    vmovdqa ymm11, [gs:0x220]
+    vmovdqa ymm10, [gs:0x200]
+    vmovdqa ymm9,  [gs:0x1E0]
+    vmovdqa ymm8,  [gs:0x1C0]
+    vmovdqa ymm7,  [gs:0x1A0]
+    vmovdqa ymm6,  [gs:0x180]
+    vmovdqa ymm5,  [gs:0x160]
+    vmovdqa ymm4,  [gs:0x140]
+    vmovdqa ymm3,  [gs:0x120]
+    vmovdqa ymm2,  [gs:0x100]
+    vmovdqa ymm1,  [gs:0x0E0]
+    vmovdqa ymm0,  [gs:0x0C0]
 
     mov r15, [gs:0x070]
     mov r14, [gs:0x068]

--- a/bfvmm/src/intrinsics/src/intrinsics_x64.asm
+++ b/bfvmm/src/intrinsics/src/intrinsics_x64.asm
@@ -19,6 +19,9 @@
 ; License along with this library; if not, write to the Free Software
 ; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+bits 64
+default rel
+
 global __halt:function
 global __stop:function
 global __invd:function
@@ -29,6 +32,7 @@ global __cpuid_ecx:function
 global __cpuid_edx:function
 global __cpuid:function
 global __read_rflags:function
+global __write_rflags:function
 global __read_msr:function
 global __write_msr:function
 global __read_rip:function
@@ -38,8 +42,6 @@ global __read_cr3:function
 global __write_cr3:function
 global __read_cr4:function
 global __write_cr4:function
-global __read_xcr0:function
-global __write_xcr0:function
 global __read_dr7:function
 global __write_dr7:function
 global __read_es:function
@@ -187,6 +189,12 @@ __read_rflags:
     pop rax
     ret
 
+; void __write_rflags(uint64_t val)
+__write_rflags
+    push rdi
+    popf
+    ret
+
 ; uint64_t __read_msr(uint32_t msr)
 __read_msr:
     mov rcx, rdi
@@ -239,23 +247,6 @@ __read_cr4:
 ; void __write_cr4(uint64_t val)
 __write_cr4:
     mov cr4, rdi
-    ret
-
-; uint64_t __read_xcr0(void)
-__read_xcr0:
-    mov rcx, 0
-    xgetbv
-    shl rdx, 32
-    or rax, rdx
-    ret
-
-; void __write_xcr0(uint64_t val)
-__write_xcr0:
-    mov rax, rdi
-    mov rdx, rdi
-    shr rdx, 32
-    mov rcx, 0
-    xsetbv
     ret
 
 ; uint64_t __read_dr7(void)

--- a/bfvmm/src/misc/src/execute_entry.asm
+++ b/bfvmm/src/misc/src/execute_entry.asm
@@ -27,16 +27,6 @@ global execute_entry:function
 section .text
 
 ; int64_t execute_entry(void *stack, void *func, uint64_t arg1, uint64_t arg2);
-;
-; r08 -> xsave enabled bits
-; r09 -> xsave enabled bits
-; r10 -> size of xsave area
-; r11 -> func return value
-; r12 ->
-; r13 -> func pointer
-; r14 -> arg1
-; r15 -> arg2
-;
 execute_entry:
 
     push rbx
@@ -68,35 +58,40 @@ execute_entry:
     mov r15, rcx
 %endif
 
-    mov rcx, 0x00
-    xgetbv
-    mov r8, rax
-    mov r9, rdx
+    and rsp, 0xFFFFFFFFFFFFFFE0
 
-    mov rax, 0x0D
-    mov rbx, 0x00
-    mov rcx, 0x00
-    mov rdx, 0x00
-    cpuid
-    mov r10, rcx
-
-    sub rsp, r10
-    sub rsp, 0x40
-    and rsp, 0xFFFFFFFFFFFFFF80
-
-    mov rcx, r10
-    mov rax, 0x00
-    mov rdi, rsp
-    rep
-    stosb
-
-    mov rax, r8
-    mov rdx, r9
-    xsave [rsp]
-
-    push r8
-    push r9
-    push r10
+    sub rsp, 0x20
+    vmovdqa [rsp], xmm0
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm1
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm2
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm3
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm4
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm5
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm6
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm7
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm8
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm9
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm10
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm11
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm12
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm13
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm14
+    sub rsp, 0x20
+    vmovdqa [rsp], ymm15
 
     mov rax, 0xABCDEF1234567890
     push rax
@@ -111,13 +106,38 @@ execute_entry:
     cmp rax, rbx
     jne stack_overflow
 
-    pop r10
-    pop r9
-    pop r8
-
-    mov rax, r8
-    mov rdx, r9
-    xrstor [rsp]
+    vmovdqa [rsp], ymm15
+    add rsp, 0x20
+    vmovdqa [rsp], ymm14
+    add rsp, 0x20
+    vmovdqa [rsp], ymm13
+    add rsp, 0x20
+    vmovdqa [rsp], ymm12
+    add rsp, 0x20
+    vmovdqa [rsp], ymm11
+    add rsp, 0x20
+    vmovdqa [rsp], ymm10
+    add rsp, 0x20
+    vmovdqa [rsp], ymm9
+    add rsp, 0x20
+    vmovdqa [rsp], ymm8
+    add rsp, 0x20
+    vmovdqa [rsp], ymm7
+    add rsp, 0x20
+    vmovdqa [rsp], ymm6
+    add rsp, 0x20
+    vmovdqa [rsp], ymm5
+    add rsp, 0x20
+    vmovdqa [rsp], ymm4
+    add rsp, 0x20
+    vmovdqa [rsp], ymm3
+    add rsp, 0x20
+    vmovdqa [rsp], ymm2
+    add rsp, 0x20
+    vmovdqa [rsp], ymm1
+    add rsp, 0x20
+    vmovdqa [rsp], ymm0
+    add rsp, 0x20
 
     mov rax, r11
     leave

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -25,88 +25,6 @@
 #include <debug_ring/debug_ring.h>
 #include <memory_manager/memory_manager.h>
 
-void
-vcpu_ut::test_vcpu_intel_x64_id_too_large()
-{
-    MockRepository mocks;
-    auto dr = bfn::mock_shared<debug_ring>(mocks);
-    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
-    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
-    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
-    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
-
-    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
-    {
-        EXPECT_EXCEPTION(std::make_shared<vcpu_intel_x64>(RESERVED_VCPUIDS + 1), std::invalid_argument);
-        EXPECT_EXCEPTION(std::make_shared<vcpu_intel_x64>(RESERVED_VCPUIDS + 1, dr, on, cs, eh, in), std::invalid_argument);
-    });
-}
-
-void
-vcpu_ut::test_vcpu_intel_x64_invalid_objects()
-{
-    MockRepository mocks;
-    auto dr = std::shared_ptr<debug_ring>();
-    auto on = std::shared_ptr<vmxon_intel_x64>();
-    auto cs = std::shared_ptr<vmcs_intel_x64>();
-    auto eh = std::shared_ptr<exit_handler_intel_x64>();
-    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
-
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::write_xcr0);
-
-    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
-    {
-        EXPECT_NO_EXCEPTION(std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in));
-    });
-}
-
-void
-vcpu_ut::test_vcpu_intel_x64_valid()
-{
-    MockRepository mocks;
-    auto dr = bfn::mock_shared<debug_ring>(mocks);
-    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
-    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
-    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
-    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
-
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::write_xcr0);
-
-    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
-    {
-        EXPECT_NO_EXCEPTION(std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in));
-    });
-}
-
-void
-vcpu_ut::test_vcpu_intel_x64_run_vmxon_start_failed()
-{
-    MockRepository mocks;
-    auto dr = bfn::mock_shared<debug_ring>(mocks);
-    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
-    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
-    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
-    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
-
-    auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in);
-
-    mocks.OnCall(on.get(), vmxon_intel_x64::start).Throw(bfn::general_exception());
-    mocks.OnCall(on.get(), vmxon_intel_x64::stop);
-
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
-    mocks.OnCall(in.get(), intrinsics_intel_x64::write_xcr0);
-
-    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
-    {
-        EXPECT_EXCEPTION(vc->run(), bfn::general_exception);
-    });
-}
-
 void *
 malloc_aligned(size_t size, uint64_t alignment)
 {
@@ -129,6 +47,102 @@ const std::map<uintptr_t, memory_descriptor> &virt_to_phys_map() noexcept
     return m_virt_to_phys_map;
 }
 
+void
+vcpu_ut::test_vcpu_intel_x64_id_too_large()
+{
+    MockRepository mocks;
+    auto dr = bfn::mock_shared<debug_ring>(mocks);
+    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
+    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
+    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
+    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_EXCEPTION(std::make_shared<vcpu_intel_x64>(RESERVED_VCPUIDS + 1), std::invalid_argument);
+        EXPECT_EXCEPTION(std::make_shared<vcpu_intel_x64>(RESERVED_VCPUIDS + 1, dr, on, cs, eh, in), std::invalid_argument);
+    });
+}
+
+void
+vcpu_ut::test_vcpu_intel_x64_invalid_objects()
+{
+    MockRepository mocks;
+    auto mm = mocks.Mock<memory_manager>();
+    auto dr = std::shared_ptr<debug_ring>();
+    auto on = std::shared_ptr<vmxon_intel_x64>();
+    auto cs = std::shared_ptr<vmcs_intel_x64>();
+    auto eh = std::shared_ptr<exit_handler_intel_x64>();
+    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
+
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
+
+    mocks.OnCallFunc(memory_manager::instance).Return(mm);
+    mocks.OnCall(mm, memory_manager::malloc_aligned).Do(malloc_aligned);
+    mocks.OnCall(mm, memory_manager::virt_to_phys).Do(virt_to_phys);
+    mocks.OnCall(mm, memory_manager::virt_to_phys_map).Do(virt_to_phys_map);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_NO_EXCEPTION(std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in));
+    });
+}
+
+void
+vcpu_ut::test_vcpu_intel_x64_valid()
+{
+    MockRepository mocks;
+    auto mm = mocks.Mock<memory_manager>();
+    auto dr = bfn::mock_shared<debug_ring>(mocks);
+    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
+    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
+    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
+    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
+
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
+
+    mocks.OnCallFunc(memory_manager::instance).Return(mm);
+    mocks.OnCall(mm, memory_manager::malloc_aligned).Do(malloc_aligned);
+    mocks.OnCall(mm, memory_manager::virt_to_phys).Do(virt_to_phys);
+    mocks.OnCall(mm, memory_manager::virt_to_phys_map).Do(virt_to_phys_map);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_NO_EXCEPTION(std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in));
+    });
+}
+
+void
+vcpu_ut::test_vcpu_intel_x64_run_vmxon_start_failed()
+{
+    MockRepository mocks;
+    auto mm = mocks.Mock<memory_manager>();
+    auto dr = bfn::mock_shared<debug_ring>(mocks);
+    auto on = bfn::mock_shared<vmxon_intel_x64>(mocks);
+    auto cs = bfn::mock_shared<vmcs_intel_x64>(mocks);
+    auto eh = bfn::mock_shared<exit_handler_intel_x64>(mocks);
+    auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
+
+    auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, in);
+
+    mocks.OnCall(on.get(), vmxon_intel_x64::start).Throw(bfn::general_exception());
+    mocks.OnCall(on.get(), vmxon_intel_x64::stop);
+
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
+    mocks.OnCall(in.get(), intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
+
+    mocks.OnCallFunc(memory_manager::instance).Return(mm);
+    mocks.OnCall(mm, memory_manager::malloc_aligned).Do(malloc_aligned);
+    mocks.OnCall(mm, memory_manager::virt_to_phys).Do(virt_to_phys);
+    mocks.OnCall(mm, memory_manager::virt_to_phys_map).Do(virt_to_phys_map);
+
+    RUN_UNITTEST_WITH_MOCKS(mocks, [&]
+    {
+        EXPECT_EXCEPTION(vc->run(), bfn::general_exception);
+    });
+}
 
 static void
 setup_intrinsics(MockRepository &mocks, intrinsics_intel_x64 *in)
@@ -139,6 +153,7 @@ setup_intrinsics(MockRepository &mocks, intrinsics_intel_x64 *in)
     mocks.OnCall(in, intrinsics_intel_x64::read_ds).Return(0);
     mocks.OnCall(in, intrinsics_intel_x64::read_fs).Return(0);
     mocks.OnCall(in, intrinsics_intel_x64::read_gs).Return(0);
+    mocks.OnCall(in, intrinsics_intel_x64::read_ldtr).Return(0);
     mocks.OnCall(in, intrinsics_intel_x64::read_tr).Return(0);
 
     mocks.OnCall(in, intrinsics_intel_x64::read_cr0).Return(0);
@@ -152,10 +167,6 @@ setup_intrinsics(MockRepository &mocks, intrinsics_intel_x64 *in)
     mocks.OnCall(in, intrinsics_intel_x64::read_idt);
 
     mocks.OnCall(in, intrinsics_intel_x64::read_msr).Return(0);
-
-    mocks.OnCall(in, intrinsics_intel_x64::cpuid_eax).With(0x0D).Return(0);
-    mocks.OnCall(in, intrinsics_intel_x64::cpuid_ecx).With(0x0D).Return(0x10);
-    mocks.OnCall(in, intrinsics_intel_x64::write_xcr0);
 }
 
 void

--- a/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
@@ -156,8 +156,8 @@ vcpu_ut::test_vcpu_manager_write_uninitialized_vcpuid_with_valid_vcpu()
     MockRepository mocks;
     g_vcpu = bfn::mock_shared<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.ExpectCall(g_vcpu.get(), vcpu::write);
+    mocks.OnCall(g_vcpu.get(), vcpu::stop);
+    mocks.NeverCall(g_vcpu.get(), vcpu::write);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_promote.asm
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_promote.asm
@@ -22,7 +22,64 @@
 bits 64
 default rel
 
+%define VMCS_GUEST_IA32_DEBUGCTL_FULL                             0x00002802
+%define VMCS_GUEST_IA32_PAT_FULL                                  0x00002804
+%define VMCS_GUEST_IA32_EFER_FULL                                 0x00002806
+%define VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL                     0x00002808
+%define VMCS_GUEST_IA32_SYSENTER_CS                               0x0000482A
+%define VMCS_GUEST_IA32_SYSENTER_ESP                              0x00006824
+%define VMCS_GUEST_IA32_SYSENTER_EIP                              0x00006826
+%define VMCS_GUEST_FS_BASE                                        0x0000680E
+%define VMCS_GUEST_GS_BASE                                        0x00006810
+
+%define IA32_DEBUGCTL_MSR                                         0x000001D9
+%define IA32_PAT_MSR                                              0x00000277
+%define IA32_EFER_MSR                                             0xC0000080
+%define IA32_PERF_GLOBAL_CTRL_MSR                                 0x0000038F
+%define IA32_SYSENTER_CS_MSR                                      0x00000174
+%define IA32_SYSENTER_ESP_MSR                                     0x00000175
+%define IA32_SYSENTER_EIP_MSR                                     0x00000176
+%define IA32_FS_BASE_MSR                                          0xC0000100
+%define IA32_GS_BASE_MSR                                          0xC0000101
+
+%define VMCS_GUEST_ES_SELECTOR                                    0x00000800
+%define VMCS_GUEST_CS_SELECTOR                                    0x00000802
+%define VMCS_GUEST_SS_SELECTOR                                    0x00000804
+%define VMCS_GUEST_DS_SELECTOR                                    0x00000806
+%define VMCS_GUEST_FS_SELECTOR                                    0x00000808
+%define VMCS_GUEST_GS_SELECTOR                                    0x0000080A
+%define VMCS_GUEST_LDTR_SELECTOR                                  0x0000080C
+%define VMCS_GUEST_TR_SELECTOR                                    0x0000080E
+
+%define VMCS_GUEST_GDTR_BASE                                      0x00006816
+%define VMCS_GUEST_GDTR_LIMIT                                     0x00004810
+
+%define VMCS_GUEST_IDTR_BASE                                      0x00006818
+%define VMCS_GUEST_IDTR_LIMIT                                     0x00004812
+
+%define VMCS_GUEST_CR0                                            0x00006800
+%define VMCS_GUEST_CR3                                            0x00006802
+%define VMCS_GUEST_CR4                                            0x00006804
+%define VMCS_GUEST_DR7                                            0x0000681A
+
 global promote_vmcs_to_root:function
+
+extern __write_es
+extern __write_cs
+extern __write_ss
+extern __write_ds
+extern __write_gs
+extern __write_fs
+extern __write_ldtr
+extern __write_tr
+extern __write_msr
+extern __write_msr
+extern __write_gdt
+extern __write_idt
+extern __write_cr0;
+extern __write_cr3;
+extern __write_cr4;
+extern __write_dr7;
 
 section .text
 
@@ -38,31 +95,200 @@ section .text
 ;
 promote_vmcs_to_root:
 
-    mov rsi, [rdi + 0x0B0]
-    mov rax, [rdi + 0x0B8]
-    mov rdx, [rdi + 0x0C0]
-    xrstor [rsi]
+    mov r15, rdi
 
-    mov rsp, [rdi + 0x080]
-    mov rax, [rdi + 0x078]
+    ;
+    ; Restore Control Registers
+    ;
+
+    mov rsi, VMCS_GUEST_CR0
+    vmread rdi, rsi
+    call __write_cr0 wrt ..plt
+
+    mov rsi, VMCS_GUEST_CR3
+    vmread rdi, rsi
+    call __write_cr3 wrt ..plt
+
+    mov rsi, VMCS_GUEST_CR4
+    vmread rdi, rsi
+    call __write_cr4 wrt ..plt
+
+    mov rsi, VMCS_GUEST_DR7
+    vmread rdi, rsi
+    call __write_dr7 wrt ..plt
+
+    ;
+    ; Restore GDT
+    ;
+
+    mov rsi, VMCS_GUEST_GDTR_BASE
+    vmread rdi, rsi
+    push rdi
+
+    mov rsi, VMCS_GUEST_GDTR_LIMIT
+    vmread rdi, rsi
+    push di
+
+    mov rdi, rsp
+    call __write_gdt wrt ..plt
+
+    ;
+    ; Restore IDT
+    ;
+
+    mov rsi, VMCS_GUEST_IDTR_BASE
+    vmread rdi, rsi
+    push rdi
+
+    mov rsi, VMCS_GUEST_IDTR_LIMIT
+    vmread rdi, rsi
+    push di
+
+    mov rdi, rsp
+    call __write_idt wrt ..plt
+
+    ;
+    ; Clear TSS Busy
+    ;
+
+    mov rsi, VMCS_GUEST_GDTR_BASE
+    vmread rdi, rsi
+    mov rsi, VMCS_GUEST_TR_SELECTOR
+    vmread rsi, rsi
+
+    add rdi, rsi
+
+    mov rax, 0xFFFFFDFFFFFFFFFF
+    and [rdi], rax
+
+    ;
+    ; Restore Selectors
+    ;
+
+    mov rsi, VMCS_GUEST_ES_SELECTOR
+    vmread rdi, rsi
+    call __write_es wrt ..plt
+
+    mov rsi, VMCS_GUEST_CS_SELECTOR
+    vmread rdi, rsi
+    call __write_cs wrt ..plt
+
+    mov rsi, VMCS_GUEST_SS_SELECTOR
+    vmread rdi, rsi
+    call __write_ss wrt ..plt
+
+    mov rsi, VMCS_GUEST_DS_SELECTOR
+    vmread rdi, rsi
+    call __write_ds wrt ..plt
+
+    mov rsi, VMCS_GUEST_FS_SELECTOR
+    vmread rdi, rsi
+    call __write_fs wrt ..plt
+
+    mov rsi, VMCS_GUEST_GS_SELECTOR
+    vmread rdi, rsi
+    call __write_gs wrt ..plt
+
+    mov rsi, VMCS_GUEST_LDTR_SELECTOR
+    vmread rdi, rsi
+    call __write_ldtr wrt ..plt
+
+    mov rsi, VMCS_GUEST_TR_SELECTOR
+    vmread rdi, rsi
+    call __write_tr wrt ..plt
+
+    ;
+    ; Restore MSRs
+    ;
+
+    mov rdi, IA32_DEBUGCTL_MSR
+    mov rsi, VMCS_GUEST_IA32_DEBUGCTL_FULL
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_PAT_MSR
+    mov rsi, VMCS_GUEST_IA32_PAT_FULL
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_EFER_MSR
+    mov rsi, VMCS_GUEST_IA32_EFER_FULL
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_PERF_GLOBAL_CTRL_MSR
+    mov rsi, VMCS_GUEST_IA32_PERF_GLOBAL_CTRL_FULL
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_SYSENTER_CS_MSR
+    mov rsi, VMCS_GUEST_IA32_SYSENTER_CS
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_SYSENTER_ESP_MSR
+    mov rsi, VMCS_GUEST_IA32_SYSENTER_ESP
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_SYSENTER_EIP_MSR
+    mov rsi, VMCS_GUEST_IA32_SYSENTER_EIP
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_FS_BASE_MSR
+    mov rsi, VMCS_GUEST_FS_BASE
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    mov rdi, IA32_GS_BASE_MSR
+    mov rsi, VMCS_GUEST_GS_BASE
+    vmread rsi, rsi
+    call __write_msr wrt ..plt
+
+    ;
+    ; Restore Registers
+    ;
+
+    mov rdi, r15
+
+    vmovdqa ymm15, [rdi + 0x2A0]
+    vmovdqa ymm14, [rdi + 0x280]
+    vmovdqa ymm13, [rdi + 0x260]
+    vmovdqa ymm12, [rdi + 0x240]
+    vmovdqa ymm11, [rdi + 0x220]
+    vmovdqa ymm10, [rdi + 0x200]
+    vmovdqa ymm9,  [rdi + 0x1E0]
+    vmovdqa ymm8,  [rdi + 0x1C0]
+    vmovdqa ymm7,  [rdi + 0x1A0]
+    vmovdqa ymm6,  [rdi + 0x180]
+    vmovdqa ymm5,  [rdi + 0x160]
+    vmovdqa ymm4,  [rdi + 0x140]
+    vmovdqa ymm3,  [rdi + 0x120]
+    vmovdqa ymm2,  [rdi + 0x100]
+    vmovdqa ymm1,  [rdi + 0x0E0]
+    vmovdqa ymm0,  [rdi + 0x0C0]
+
+    mov rsp,       [rdi + 0x080]
+    mov rax,       [rdi + 0x078]
     push rax
 
-    mov r15, [rdi + 0x070]
-    mov r14, [rdi + 0x068]
-    mov r13, [rdi + 0x060]
-    mov r12, [rdi + 0x058]
-    mov r11, [rdi + 0x050]
-    mov r10, [rdi + 0x048]
-    mov r9,  [rdi + 0x040]
-    mov r8,  [rdi + 0x038]
-    mov rsi, [rdi + 0x028]
-    mov rbp, [rdi + 0x020]
-    mov rdx, [rdi + 0x018]
-    mov rcx, [rdi + 0x010]
-    mov rbx, [rdi + 0x008]
-    mov rax, [rdi + 0x000]
+    mov r15,       [rdi + 0x070]
+    mov r14,       [rdi + 0x068]
+    mov r13,       [rdi + 0x060]
+    mov r12,       [rdi + 0x058]
+    mov r11,       [rdi + 0x050]
+    mov r10,       [rdi + 0x048]
+    mov r9,        [rdi + 0x040]
+    mov r8,        [rdi + 0x038]
+    mov rsi,       [rdi + 0x028]
+    mov rbp,       [rdi + 0x020]
+    mov rdx,       [rdi + 0x018]
+    mov rcx,       [rdi + 0x010]
+    mov rbx,       [rdi + 0x008]
+    mov rax,       [rdi + 0x000]
 
-    mov rdi, [rdi + 0x030]
+    mov rdi,       [rdi + 0x030]
 
     sti
     ret

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
@@ -112,6 +112,7 @@ vmcs_intel_x64_vmm_state::vmcs_intel_x64_vmm_state(const std::shared_ptr<state_s
 
     m_cr0 = 0;
     m_cr0 |= CRO_PE_PROTECTION_ENABLE;
+    m_cr0 |= CR0_MP_MONITOR_COPROCESSOR;
     m_cr0 |= CR0_NE_NUMERIC_ERROR;
     m_cr0 |= CR0_PG_PAGING;
 

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -124,10 +124,10 @@ CROSS_CCFLAGS+=-march=sandybridge
 CROSS_CCFLAGS+=-malign-data=abi
 CROSS_CCFLAGS+=-mstackrealign
 
-#ifeq ($(PRODUCTION),yes)
-#	NATIVE_CCFLAGS+=-O3
-#	CROSS_CCFLAGS+=-O3
-#endif
+ifeq ($(PRODUCTION),yes)
+	NATIVE_CCFLAGS+=-O3
+	CROSS_CCFLAGS+=-O3
+endif
 
 ################################################################################
 # Default CXX Flags
@@ -165,10 +165,10 @@ CROSS_CXXFLAGS+=-march=sandybridge
 CROSS_CXXFLAGS+=-malign-data=abi
 CROSS_CXXFLAGS+=-mstackrealign
 
-#ifeq ($(PRODUCTION),yes)
-#	NATIVE_CXXFLAGS+=-O3
-#	CROSS_CXXFLAGS+=-O3
-#endif
+ifeq ($(PRODUCTION),yes)
+	NATIVE_CXXFLAGS+=-O3
+	CROSS_CXXFLAGS+=-O3
+endif
 
 ################################################################################
 # Default ASM Flags

--- a/tools/scripts/build_libcxx.sh
+++ b/tools/scripts/build_libcxx.sh
@@ -45,6 +45,12 @@ export CXXFLAGS="-fno-use-cxa-atexit -fno-threadsafe-statics $CFLAGS"
 
 export BAREFLANK_WRAPPER_IS_LIBCXX="true"
 
+if [[ $PRODUCTION == "yes" ]]; then
+    BUILD_TYPE=Release
+else
+    BUILD_TYPE=Debug
+fi
+
 cmake $BUILD_ABS/source_libcxx/ \
     -DCMAKE_SYSTEM_NAME=Linux \
     -DLLVM_PATH=$BUILD_ABS/source_llvm \
@@ -53,7 +59,8 @@ cmake $BUILD_ABS/source_libcxx/ \
     -DCMAKE_INSTALL_PREFIX=$BUILD_ABS/sysroot/x86_64-elf/ \
     -DLIBCXX_SYSROOT=$BUILD_ABS/sysroot/x86_64-elf/ \
     -DCMAKE_C_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-gcc \
-    -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++
+    -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++ \
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
 make -j2
 make -j2 install

--- a/tools/scripts/build_libcxxabi.sh
+++ b/tools/scripts/build_libcxxabi.sh
@@ -49,6 +49,12 @@ if [[ ! -f "$BUILD_ABS/sysroot/x86_64-elf/include/unwind.h" ]]; then
     ln -s $HYPER_ABS/bfunwind/include/ia64_cxx_abi.h $BUILD_ABS/sysroot/x86_64-elf/include/unwind.h
 fi
 
+if [[ $PRODUCTION == "yes" ]]; then
+    BUILD_TYPE=Release
+else
+    BUILD_TYPE=Debug
+fi
+
 cmake $BUILD_ABS/source_libcxxabi/ \
     -DCMAKE_SYSTEM_NAME=Linux \
     -DLLVM_PATH=$BUILD_ABS/source_llvm \
@@ -57,7 +63,8 @@ cmake $BUILD_ABS/source_libcxxabi/ \
     -DLIBCXXABI_SYSROOT=$BUILD_ABS/sysroot/x86_64-elf/ \
     -DCMAKE_C_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-gcc \
     -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++ \
-    -DLIBCXXABI_ENABLE_SHARED=OFF
+    -DLIBCXXABI_ENABLE_SHARED=OFF \
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
 make -j2
 make -j2 install


### PR DESCRIPTION
In order to support -O3, we need to save the YMM registers as
the hypervisor will use these are part of the optimizations.
The problem is, XSAVE has some issues with the hypervisor that
are not simple to solve.

For example, before you can run XSAVE, you need to set xcr0 with
the bits you plan to support. Since Barefalnk is both a bare
metal, and late launch hypervisor, the host OS is responsible
for setting up xcr0, which might not set the same bits that
Bareflank needs to use. This means Bareflank must enable the
bits it plans to use. If the host OS ever changes these
Bareflank would stop working. To solve that problem requires
a bit of emulation.

XSAVE is also saving a bunch of stuff that we don't need,
increasing the time it takes to Exit / Enter.

To solve these problems (and more), the simple solution is
to save off the contents of the YMM registers manually.
This patch provides the changes to do this.

Signed-off-by: “Rian <“rianquinn@gmail.com”>