### PR TITLE
Destructor / Constructor Bug

### DIFF
--- a/bfvmm/include/debug_ring/debug_ring.h
+++ b/bfvmm/include/debug_ring/debug_ring.h
@@ -60,7 +60,7 @@ public:
     ///     constructed is invalid (likely due to an invalid vcpuid)
     /// @throws range_error thown if the string that is provided is too large
     ///
-    virtual void write(const std::string &str);
+    virtual void write(const std::string &str) noexcept;
 
 private:
 

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -118,8 +118,7 @@ public:
     ///
     /// @param str the string to write to the log
     ///
-    virtual void write(const std::string &str)
-    { m_debug_ring->write(str); }
+    virtual void write(const std::string &str) noexcept;
 
 private:
 

--- a/bfvmm/include/vcpu/vcpu_manager.h
+++ b/bfvmm/include/vcpu/vcpu_manager.h
@@ -91,7 +91,7 @@ public:
     /// @param vcpuid the vcpu's log to write to
     /// @param str the string to write to the log
     ///
-    virtual void write(uint64_t vcpuid, const std::string &str);
+    virtual void write(uint64_t vcpuid, const std::string &str) noexcept;
 
 public:
 

--- a/bfvmm/src/debug_ring/src/debug_ring.cpp
+++ b/bfvmm/src/debug_ring/src/debug_ring.cpp
@@ -58,7 +58,7 @@ debug_ring::debug_ring(uint64_t vcpuid)
 }
 
 void
-debug_ring::write(const std::string &str)
+debug_ring::write(const std::string &str) noexcept
 {
     // TODO: A more interesting implementation would use an optimized
     //       memcpy to implement this code. Doing so would increase it's

--- a/bfvmm/src/vcpu/src/vcpu.cpp
+++ b/bfvmm/src/vcpu/src/vcpu.cpp
@@ -51,3 +51,10 @@ vcpu::~vcpu()
     if (m_is_running)
         this->hlt();
 }
+
+void
+vcpu::write(const std::string &str) noexcept
+{
+    if (m_debug_ring)
+        m_debug_ring->write(str);
+}


### PR DESCRIPTION
The VCPU manager had an issue were the mutex lock could
deadlock if you printed from a constructor destructor. This
patch removes this issue.

The debug path was also not guarded from exceptions, which
would recursively hit the BS core. Added noexcept to
redirect exceptions to std::terminate if this should occur.

[ISUE]: https://github.com/Bareflank/hypervisor/issues/153

Signed-off-by: “Rian <“rianquinn@gmail.com”>