### PR TITLE
Add Missing DWARF4 CFA Opcodes

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -5,7 +5,3 @@
   disable this check from executing or don't use a kernrel with this enabled.
   This is seen on Fedora as installing the kernel source enables a debug kernel
   by default with this enabled.
-- At the moment, GCC 6.1 appears to be broken with respect to exceptions. We
-  have a hack in the unwinder to deal with this issue, but this hack should be
-  removed in the future. Please see:
-  https://gcc.gnu.org/bugzilla/show_bug.cgi?id=71978

--- a/bfunwind/include/registers_intel_x64.h
+++ b/bfunwind/include/registers_intel_x64.h
@@ -170,7 +170,7 @@ public:
 
     void dump() const override
     {
-        uint64_t *rsp = (uint64_t *)m_registers.rsp;
+        // uint64_t *rsp = (uint64_t *)m_registers.rsp;
 
         debug("Register State:\n")
         debug("  rax: 0x%08lx\n", m_registers.rax);
@@ -192,25 +192,25 @@ public:
         debug("  rip: 0x%08lx\n", m_registers.rip);
         debug("\n")
 
-        debug("Stack State:\n")
-        debug("  rsp[-8]: %p\n", (void *)rsp[-8]);
-        debug("  rsp[-7]: %p\n", (void *)rsp[-7]);
-        debug("  rsp[-6]: %p\n", (void *)rsp[-6]);
-        debug("  rsp[-5]: %p\n", (void *)rsp[-5]);
-        debug("  rsp[-4]: %p\n", (void *)rsp[-4]);
-        debug("  rsp[-3]: %p\n", (void *)rsp[-3]);
-        debug("  rsp[-2]: %p\n", (void *)rsp[-2]);
-        debug("  rsp[-1]: %p\n", (void *)rsp[-1]);
-        debug("  rsp[0] : %p\n", (void *)rsp[0]);
-        debug("  rsp[1] : %p\n", (void *)rsp[1]);
-        debug("  rsp[2] : %p\n", (void *)rsp[2]);
-        debug("  rsp[3] : %p\n", (void *)rsp[3]);
-        debug("  rsp[4] : %p\n", (void *)rsp[4]);
-        debug("  rsp[5] : %p\n", (void *)rsp[5]);
-        debug("  rsp[6] : %p\n", (void *)rsp[6]);
-        debug("  rsp[7] : %p\n", (void *)rsp[7]);
-        debug("  rsp[8] : %p\n", (void *)rsp[8]);
-        debug("\n")
+        // debug("Stack State:\n")
+        // debug("  rsp[-8]: %p\n", (void *)rsp[-8]);
+        // debug("  rsp[-7]: %p\n", (void *)rsp[-7]);
+        // debug("  rsp[-6]: %p\n", (void *)rsp[-6]);
+        // debug("  rsp[-5]: %p\n", (void *)rsp[-5]);
+        // debug("  rsp[-4]: %p\n", (void *)rsp[-4]);
+        // debug("  rsp[-3]: %p\n", (void *)rsp[-3]);
+        // debug("  rsp[-2]: %p\n", (void *)rsp[-2]);
+        // debug("  rsp[-1]: %p\n", (void *)rsp[-1]);
+        // debug("  rsp[0] : %p\n", (void *)rsp[0]);
+        // debug("  rsp[1] : %p\n", (void *)rsp[1]);
+        // debug("  rsp[2] : %p\n", (void *)rsp[2]);
+        // debug("  rsp[3] : %p\n", (void *)rsp[3]);
+        // debug("  rsp[4] : %p\n", (void *)rsp[4]);
+        // debug("  rsp[5] : %p\n", (void *)rsp[5]);
+        // debug("  rsp[6] : %p\n", (void *)rsp[6]);
+        // debug("  rsp[7] : %p\n", (void *)rsp[7]);
+        // debug("  rsp[8] : %p\n", (void *)rsp[8]);
+        // debug("\n")
     }
 
 private:

--- a/bfunwind/src/dwarf4.cpp
+++ b/bfunwind/src/dwarf4.cpp
@@ -46,6 +46,7 @@ template<typename T> T static get(char **p)
         continue; \
     }
 
+#define REMEMBER_STACK_SIZE 10
 #define EXPRESSION_STACK_SIZE 100
 
 // -----------------------------------------------------------------------------
@@ -220,7 +221,7 @@ private_parse_expression(char *p,
 
     char *end = p + dwarf4::decode_uleb128(&p);
 
-    while (p < end)
+    while (p <= end)
     {
         uint8_t opcode = *(uint8_t *)(p);
         p++;
@@ -979,7 +980,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 0, state->name(0), (void *)reg,
             offset);
         })
 
@@ -990,7 +991,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 1, state->name(1), (void *)reg,
             offset);
         })
 
@@ -1001,7 +1002,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 2, state->name(2), (void *)reg,
             offset);
         })
 
@@ -1012,7 +1013,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 3, state->name(3), (void *)reg,
             offset);
         })
 
@@ -1023,7 +1024,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 4, state->name(4), (void *)reg,
             offset);
         })
 
@@ -1034,7 +1035,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 5, state->name(5), (void *)reg,
             offset);
         })
 
@@ -1043,18 +1044,7 @@ private_parse_expression(char *p,
             auto reg = state->get(6);
             auto offset = dwarf4::decode_sleb128(&p);
 
-            // REMOVE ME:
-            //
-            // The following is a dirty hack to address a potential bug with
-            // the GCC 6.1 compiler. Once this issue has been resolved, this
-            // code should be removed as it is not to spec, and will likely
-            // break other code.
-            //
-
-            if (initialStackValue == 0xBABEBABEBABEBABE)
-                stack[++i] = reg - offset;
-            else
-                stack[++i] = reg + offset;
+            stack[++i] = reg + offset;
 
             log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
             offset);
@@ -1067,7 +1057,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 7, state->name(7), (void *)reg,
             offset);
         })
 
@@ -1078,7 +1068,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 8, state->name(8), (void *)reg,
             offset);
         })
 
@@ -1089,7 +1079,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 9, state->name(9), (void *)reg,
             offset);
         })
 
@@ -1100,7 +1090,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 10, state->name(10), (void *)reg,
             offset);
         })
 
@@ -1111,7 +1101,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 11, state->name(11), (void *)reg,
             offset);
         })
 
@@ -1122,7 +1112,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 12, state->name(12), (void *)reg,
             offset);
         })
 
@@ -1133,7 +1123,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 13, state->name(13), (void *)reg,
             offset);
         })
 
@@ -1144,7 +1134,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 14, state->name(14), (void *)reg,
             offset);
         })
 
@@ -1155,7 +1145,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 15, state->name(15), (void *)reg,
             offset);
         })
 
@@ -1166,7 +1156,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 16, state->name(16), (void *)reg,
             offset);
         })
 
@@ -1177,7 +1167,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 17, state->name(17), (void *)reg,
             offset);
         })
 
@@ -1188,7 +1178,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 18, state->name(18), (void *)reg,
             offset);
         })
 
@@ -1199,7 +1189,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 19, state->name(19), (void *)reg,
             offset);
         })
 
@@ -1210,7 +1200,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 20, state->name(20), (void *)reg,
             offset);
         })
 
@@ -1221,7 +1211,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 21, state->name(21), (void *)reg,
             offset);
         })
 
@@ -1232,7 +1222,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 22, state->name(22), (void *)reg,
             offset);
         })
 
@@ -1243,7 +1233,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 23, state->name(23), (void *)reg,
             offset);
         })
 
@@ -1254,7 +1244,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 24, state->name(24), (void *)reg,
             offset);
         })
 
@@ -1265,7 +1255,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 25, state->name(25), (void *)reg,
             offset);
         })
 
@@ -1276,7 +1266,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 26, state->name(26), (void *)reg,
             offset);
         })
 
@@ -1287,7 +1277,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 27, state->name(27), (void *)reg,
             offset);
         })
 
@@ -1298,7 +1288,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 28, state->name(28), (void *)reg,
             offset);
         })
 
@@ -1309,7 +1299,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 29, state->name(29), (void *)reg,
             offset);
         })
 
@@ -1320,7 +1310,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 30, state->name(30), (void *)reg,
             offset);
         })
 
@@ -1331,7 +1321,7 @@ private_parse_expression(char *p,
 
             stack[++i] = reg + offset;
 
-            log("r%d (%s) %p, offset: %ld\n", 6, state->name(6), (void *)reg,
+            log("r%d (%s) %p, offset: %ld\n", 31, state->name(31), (void *)reg,
             offset);
         })
 
@@ -1472,7 +1462,7 @@ private_decode_cfa(const cfi_table_row &row, register_state *state)
 
         case cfi_cfa::cfa_expression:
             log("cfa_expression\n");
-            value = private_parse_expression((char *)cfa.value(), 0xBABEBABEBABEBABE, state);
+            value = private_parse_expression((char *)cfa.value(), 0, state);
             break;
     }
 
@@ -1532,6 +1522,8 @@ private_decode_reg(const cfi_register &reg, uint64_t cfa, register_state *state)
     return value;
 }
 
+
+
 void
 private_parse_instruction(cfi_table_row *row,
                           const ci_entry &cie,
@@ -1539,7 +1531,10 @@ private_parse_instruction(cfi_table_row *row,
                           uint64_t *l1,
                           uint64_t *l2,
                           uint64_t pc_begin,
-                          register_state *state)
+                          register_state *state,
+                          uint64_t &rememberIndex,
+                          cfi_table_row *rememberStack,
+                          cfi_table_row *initialRow)
 {
     (void) pc_begin;
     (void) state;
@@ -1572,7 +1567,8 @@ private_parse_instruction(cfi_table_row *row,
 
     if_cfa(DW_CFA_restore,
     {
-        ABORT("register restoration currently not supported");
+        row->set_reg(initialRow->reg(operand));
+        log("r%d (%s)\n", operand, state->name(operand));
     })
 
     if_cfa(DW_CFA_nop,
@@ -1634,7 +1630,9 @@ private_parse_instruction(cfi_table_row *row,
 
     if_cfa(DW_CFA_restore_extended,
     {
-        ABORT("register restoration currently not supported");
+        auto reg = dwarf4::decode_uleb128(p);
+        row->set_reg(initialRow->reg(reg));
+        log("r%d (%s)\n", reg, state->name(reg));
     })
 
     if_cfa(DW_CFA_undefined,
@@ -1662,12 +1660,20 @@ private_parse_instruction(cfi_table_row *row,
 
     if_cfa(DW_CFA_remember_state,
     {
-        ABORT("unsupported in .eh_frame. this should not happen");
+        if (rememberIndex >= REMEMBER_STACK_SIZE)
+            ABORT("remember stack is full. unable to continue unwind");
+
+        rememberStack[rememberIndex++] = *row;
+        log("index %ld\n", rememberIndex);
     })
 
     if_cfa(DW_CFA_restore_state,
     {
-        ABORT("unsupported in .eh_frame. this should not happen");
+        if (rememberIndex == 0)
+            ABORT("remember stack is empty. unable to continue unwind");
+
+        *row = rememberStack[--rememberIndex];
+        log("index %ld\n", rememberIndex);
     })
 
     if_cfa(DW_CFA_def_cfa,
@@ -1800,8 +1806,14 @@ private_parse_instructions(cfi_table_row *row,
     char *p = is_cie ? cie.initial_instructions() : fde.instructions();
     char *end = is_cie ? cie.entry_end() : fde.entry_end();
 
+    uint64_t rememberIndex = 0;
+    cfi_table_row rememberStack[REMEMBER_STACK_SIZE] = {};
+
+    auto initialRow = *row;
+
     while (p < end && l1 >= l2)
-        private_parse_instruction(row, cie, &p, &l1, &l2, pc_begin, state);
+        private_parse_instruction(row, cie, &p, &l1, &l2, pc_begin, state,
+                                  rememberIndex, rememberStack, &initialRow);
 }
 
 cfi_table_row

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -26,7 +26,7 @@
 #include <memory>
 #include <debug_ring/debug_ring.h>
 
-#define RESERVED_VCPUIDS 0xC000000000000000
+#define RESERVED_VCPUIDS 0x8000000000000000
 
 /// Virtual CPU
 ///


### PR DESCRIPTION
We never implemented the opcodes in this patch, and they are
showing up during testing. The main reason we didn't implement
these was because it was assumed that GCC would not implement
stack operations in the EH Frame FDEs because they use a
malloc/free, which doesn't make sense if the throw came
from std::bad_alloc.

To overcome this limitation of malloc/free, we implemented the
stack frame "remember/restore" calls using a temp stack without
malloc/free. The down side to this is if the temp stack is not
large enough, the unwinder will fail, but the possibility of
this is extremely small, and even if it does occur, I added a
macro that can be increased if needed.

One thing that is interesting is it appears GCC is spitting
out bad DRAWF instructions for the case that was seen.
GCC is calling DW_CFA_restore on registers that do not have
initial instructions in the CIE, which results in 0.
The test cases still work because GCC is wrapping the bad
calls to DW_CFA_restore in a DW_CFA_remember_state /
DW_CFA_restore_state so in the end, the DW_CFA_restore are
simply ignored. Either way, this patch completes the missing
DWARF CFA instructons so we now implement them all.

Finally, we addressed an earlier issue with the expression
support that we thought was an issue with GCC but turned
out to be an issue with the unwinder. We were using
"<" instead of "<=" so we missed the last opcode which was
needed.

Signed-off-by: “Rian <“rianquinn@gmail.com”>