### PR TITLE
Coverity Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 [![GitHub version](https://badge.fury.io/gh/bareflank%2Fhypervisor.svg)](https://badge.fury.io/gh/bareflank%2Fhypervisor)
 ![](https://travis-ci.org/Bareflank/hypervisor.svg?branch=master)
 [![Coverage Status](https://coveralls.io/repos/github/Bareflank/hypervisor/badge.svg?branch=master)](https://coveralls.io/github/Bareflank/hypervisor?branch=master)
+<a href="https://scan.coverity.com/projects/bareflank-hypervisor">
+  <img alt="Coverity Scan Build Status"
+       src="https://scan.coverity.com/projects/9857/badge.svg"/>
+</a>
 ## Description
 
 The Bareflank Hypervisor is an open source, lightweight hypervisor, lead by
@@ -107,8 +111,8 @@ refer to the instructions provided in the tagged version.
 
 Before you can compile, the build environment must be present. If you are on
 a supported Windows platform, you must first install cygwin, and run a cygwin
-terminal with admin rights. You must also copy the setup-x86_64.exe to 
-"c:\cygwin64\bin". If you are on a supported Linux platform, all you need 
+terminal with admin rights. You must also copy the setup-x86_64.exe to
+"c:\cygwin64\bin". If you are on a supported Linux platform, all you need
 is a terminal. Once your setup, you should be able to run the following:
 
 ```
@@ -120,9 +124,9 @@ git checkout -b v1.0.0
 ./tools/scripts/setup_<platform>.sh
 ```
 
-If you are on Windows, there is one additional step that must be taken 
+If you are on Windows, there is one additional step that must be taken
 to turn on test signing. This step can be skipped if you plan to sign
-the driver with your own signing key. 
+the driver with your own signing key.
 
 ```
 bcdedit.exe /set testsigning ON
@@ -141,7 +145,7 @@ make run_tests
 
 To run the hypervisor, you need to first compile, and load one of the driver
 entry points. Bareflank uses the driver entry point to gain kernel level
-access to the system to load the hypervisor. On Windows and Linux, this 
+access to the system to load the hypervisor. On Windows and Linux, this
 is as simple as:
 
 ```
@@ -171,18 +175,18 @@ For more detailed instructions please read the following (based on which OS you 
 
 ## Extended APIs
 
-Bareflank's main goal is to provide the "bare" minimum hypervisor. 
-Since Bareflank supports C++ 11/14, multiple operating systems, 
-and a full toolstack, it's not as simple as say 
-[SimpleVisor](https://github.com/ionescu007/SimpleVisor), but still 
-adheres to the same basic principles of leaving out the complexity 
-of a full blown hypervisor in favor of an implementation that is simple to 
-read and follow. 
+Bareflank's main goal is to provide the "bare" minimum hypervisor.
+Since Bareflank supports C++ 11/14, multiple operating systems,
+and a full toolstack, it's not as simple as say
+[SimpleVisor](https://github.com/ionescu007/SimpleVisor), but still
+adheres to the same basic principles of leaving out the complexity
+of a full blown hypervisor in favor of an implementation that is simple to
+read and follow.
 
-It is our goal to provide a hypervisor that others can extend to create 
-their own hypervisors. The purpose of the 
-[Extended APIs](https://github.com/Bareflank/extended_apis) repository, 
-is to provide an extended set of APIs to build your hypervisors from 
+It is our goal to provide a hypervisor that others can extend to create
+their own hypervisors. The purpose of the
+[Extended APIs](https://github.com/Bareflank/extended_apis) repository,
+is to provide an extended set of APIs to build your hypervisors from
 that simplify common tasks when working with hypervisors.
 For more information about this project, please see:
 

--- a/bfc/Makefile.bf
+++ b/bfc/Makefile.bf
@@ -35,6 +35,8 @@ Makefile: $(HYPER_REL)/Makefile.bf
 
 .DEFAULT_GOAL := all
 
+ifneq ($(STATIC_ANALYSIS_ENABLED), true)
+
 all: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libbfc.a
 	@echo > /dev/null
 
@@ -46,6 +48,8 @@ $(BUILD_ABS)/sysroot/x86_64-elf/lib/libbfc.a: $(BUILD_ABS)/sysroot/x86_64-elf/li
 
 build_src: all
 build_tests: all
+
+endif
 
 run_tests:
 	@echo > /dev/null

--- a/bfcrt/src/Makefile.bf
+++ b/bfcrt/src/Makefile.bf
@@ -27,7 +27,7 @@ TARGET_NAME:=bfcrt
 TARGET_TYPE:=lib
 
 ifeq ($(shell uname -s), Linux)
-    TARGET_COMPILER:=both
+    TARGET_COMPILER:=both_always
 else
     TARGET_COMPILER:=cross
 endif

--- a/bfcrt/test/test_crt.cpp
+++ b/bfcrt/test/test_crt.cpp
@@ -203,7 +203,7 @@ crt_ut::test_local_init_catch_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(local_init(&info));
+        EXPECT_TRUE(local_init(&info) == CRT_FAILURE);
     });
 }
 
@@ -318,7 +318,7 @@ crt_ut::test_local_fini_catch_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(local_fini(&info));
+        EXPECT_TRUE(local_fini(&info) == CRT_FAILURE);
     });
 }
 

--- a/bfcxx/Makefile.bf
+++ b/bfcxx/Makefile.bf
@@ -35,6 +35,8 @@ Makefile: $(HYPER_REL)/Makefile.bf
 
 .DEFAULT_GOAL := all
 
+ifneq ($(STATIC_ANALYSIS_ENABLED), true)
+
 all: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so
 	@echo > /dev/null
 
@@ -46,6 +48,8 @@ $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so: $(BUILD_ABS)/sysroot/x86_64-elf/l
 
 build_src: all
 build_tests: all
+
+endif
 
 run_tests:
 	@echo > /dev/null

--- a/bfdrivers/src/common.c
+++ b/bfdrivers/src/common.c
@@ -385,6 +385,7 @@ common_load_vmm(void)
 {
     int64_t i = 0;
     int64_t ret = 0;
+    int64_t ignore_ret = 0;
     struct module_t *module = 0;
 
     if (common_vmm_status() == VMM_CORRUPT)
@@ -447,7 +448,9 @@ common_load_vmm(void)
 
 failure:
 
-    common_unload_vmm();
+    ignore_ret = common_unload_vmm();
+    (void) ignore_ret;
+
     return ret;
 }
 
@@ -495,6 +498,7 @@ int64_t
 common_start_vmm(void)
 {
     int64_t ret = 0;
+    int64_t ignore_ret = 0;
     int64_t caller_affinity = 0;
 
     if (common_vmm_status() == VMM_CORRUPT)
@@ -526,7 +530,9 @@ common_start_vmm(void)
 
 failure:
 
-    common_stop_vmm();
+    ignore_ret = common_stop_vmm();
+    (void) ignore_ret;
+
     return ret;
 }
 

--- a/bfdrivers/test/test.cpp
+++ b/bfdrivers/test/test.cpp
@@ -36,7 +36,25 @@ const auto c_dummy_stop_vmm_success_filename = "../cross/libdummy_stop_vmm_succe
 
 extern "C" int verify_no_mem_leaks(void);
 
-driver_entry_ut::driver_entry_ut()
+driver_entry_ut::driver_entry_ut() :
+    m_dummy_add_md_failure(0),
+    m_dummy_add_md_success(0),
+    m_dummy_get_drr_failure(0),
+    m_dummy_get_drr_success(0),
+    m_dummy_misc(0),
+    m_dummy_start_vmm_failure(0),
+    m_dummy_start_vmm_success(0),
+    m_dummy_stop_vmm_failure(0),
+    m_dummy_stop_vmm_success(0),
+    m_dummy_add_md_failure_length(0),
+    m_dummy_add_md_success_length(0),
+    m_dummy_get_drr_failure_length(0),
+    m_dummy_get_drr_success_length(0),
+    m_dummy_misc_length(0),
+    m_dummy_start_vmm_failure_length(0),
+    m_dummy_start_vmm_success_length(0),
+    m_dummy_stop_vmm_failure_length(0),
+    m_dummy_stop_vmm_success_length(0)
 {
 }
 

--- a/bfelf_loader/src/bfelf_loader.c
+++ b/bfelf_loader/src/bfelf_loader.c
@@ -479,10 +479,10 @@ private_check_support(struct bfelf_file_t *ef)
 int64_t
 private_validate_bounds(struct bfelf_file_t *ef)
 {
-    bfelf64_xword phtab_size = ef->ehdr->e_phoff +
-                               (ef->ehdr->e_phentsize * ef->ehdr->e_phnum);
-    bfelf64_xword shtab_size = ef->ehdr->e_shoff +
-                               (ef->ehdr->e_shentsize * ef->ehdr->e_shnum);
+    bfelf64_xword phtab_size = (bfelf64_xword)(ef->ehdr->e_phoff) +
+                               (bfelf64_xword)(ef->ehdr->e_phentsize * ef->ehdr->e_phnum);
+    bfelf64_xword shtab_size = (bfelf64_xword)(ef->ehdr->e_shoff) +
+                               (bfelf64_xword)(ef->ehdr->e_shentsize * ef->ehdr->e_shnum);
 
     if (ef->ehdr->e_ehsize != sizeof(struct bfelf64_ehdr))
         return invalid_file("unexpected header size");

--- a/bfelf_loader/test/test.cpp
+++ b/bfelf_loader/test/test.cpp
@@ -28,7 +28,9 @@
 const auto c_dummy_misc_filename = "../cross/libdummy_misc.so";
 const auto c_dummy_code_filename = "../cross/libdummy_code.so";
 
-bfelf_loader_ut::bfelf_loader_ut()
+bfelf_loader_ut::bfelf_loader_ut() :
+    m_dummy_misc_length(0),
+    m_dummy_code_length(0)
 {
 }
 

--- a/bfelf_loader/test/test_file_get_segment.cpp
+++ b/bfelf_loader/test/test_file_get_segment.cpp
@@ -33,37 +33,43 @@ bfelf_loader_ut::test_bfelf_file_get_segment_invalid_ef()
 void
 bfelf_loader_ut::test_bfelf_file_get_segment_invalid_index()
 {
+    auto ret = 0LL;
     bfelf_file_t ef;
     bfelf_phdr *phdr = 0;
     auto test = get_test();
 
-    bfelf_file_init((char *)&test, sizeof(test), &ef);
+    ret = bfelf_file_init((char *)&test, sizeof(test), &ef);
+    EXPECT_TRUE(ret == BFELF_SUCCESS);
 
-    auto ret = bfelf_file_get_segment(&ef, 10, &phdr);
+    ret = bfelf_file_get_segment(&ef, 10, &phdr);
     EXPECT_TRUE(ret == BFELF_ERROR_INVALID_INDEX);
 }
 
 void
 bfelf_loader_ut::test_bfelf_file_get_segment_invalid_phdr()
 {
+    auto ret = 0LL;
     bfelf_file_t ef;
     auto test = get_test();
 
-    bfelf_file_init((char *)&test, sizeof(test), &ef);
+    ret = bfelf_file_init((char *)&test, sizeof(test), &ef);
+    EXPECT_TRUE(ret == BFELF_SUCCESS);
 
-    auto ret = bfelf_file_get_segment(&ef, 0, 0);
+    ret = bfelf_file_get_segment(&ef, 0, 0);
     EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
 bfelf_loader_ut::test_bfelf_file_get_segment_success()
 {
+    auto ret = 0LL;
     bfelf_file_t ef;
     bfelf_phdr *phdr = 0;
     auto test = get_test();
 
-    bfelf_file_init((char *)&test, sizeof(test), &ef);
+    ret = bfelf_file_init((char *)&test, sizeof(test), &ef);
+    EXPECT_TRUE(ret == BFELF_SUCCESS);
 
-    auto ret = bfelf_file_get_segment(&ef, 0, &phdr);
+    ret = bfelf_file_get_segment(&ef, 0, &phdr);
     EXPECT_TRUE(ret == BFELF_SUCCESS);
 }

--- a/bfelf_loader/test/test_file_num_segments.cpp
+++ b/bfelf_loader/test/test_file_num_segments.cpp
@@ -41,11 +41,13 @@ bfelf_loader_ut::test_bfelf_file_num_segments_uninitalized()
 void
 bfelf_loader_ut::test_bfelf_file_num_segments_success()
 {
+    auto ret = 0LL;
     bfelf_file_t ef;
     auto test = get_test();
 
-    bfelf_file_init((char *)&test, sizeof(test), &ef);
+    ret = bfelf_file_init((char *)&test, sizeof(test), &ef);
+    EXPECT_TRUE(ret == BFELF_SUCCESS);
 
-    auto ret = bfelf_file_num_segments(&ef);
+    ret = bfelf_file_num_segments(&ef);
     EXPECT_TRUE(ret > 0);
 }

--- a/bfelf_loader/test/test_private.cpp
+++ b/bfelf_loader/test/test_private.cpp
@@ -73,11 +73,13 @@ bfelf_loader_ut::test_private_bfelf_error()
 void
 bfelf_loader_ut::test_private_invalid_symbol_index()
 {
-    bfelf_sym *sym;
-    bfelf_file_t ef;
-    e_string_t name;
+    bfelf_sym *sym = nullptr;
+    bfelf_file_t ef = {};
+    e_string_t name = {};
+    bfelf_shdr strtab = {};
 
     ef.symnum = 1;
+    ef.strtab = &strtab;
 
     EXPECT_TRUE(private_check_symbol(&ef, 2, &name, &sym) == BFELF_ERROR_MISMATCH);
 }
@@ -87,21 +89,21 @@ bfelf_loader_ut::test_private_corrupt_symbol_table()
 {
     auto file = "hello";
 
-    bfelf_file_t ef;
-    bfelf_shdr shdr;
-    e_string_t name;
-    bfelf_sym *sym;
+    bfelf_file_t ef = {};
+    bfelf_shdr strtab = {};
+    e_string_t name = {};
+    bfelf_sym *sym = nullptr;
     bfelf_sym symtab[1] = {};
 
     symtab[0].st_name = 0;
 
     ef.file = const_cast<char *>(file);
-    ef.strtab = &shdr;
+    ef.strtab = &strtab;
     ef.symtab = symtab;
     ef.symnum = 1;
 
-    shdr.sh_size = 5;
-    shdr.sh_offset = 0;
+    strtab.sh_size = 5;
+    strtab.sh_offset = 0;
 
     EXPECT_TRUE(private_check_symbol(&ef, 0, &name, &sym) == BFELF_ERROR_MISMATCH);
 }
@@ -112,8 +114,11 @@ bfelf_loader_ut::test_private_relocate_invalid_index()
     bfelf_loader_t loader = {};
     bfelf_file_t ef = {};
     bfelf_rela rela = {};
+    bfelf_shdr strtab = {};
 
     rela.r_info = 0xFFFFFFFF00000000;
+
+    ef.strtab = &strtab;
 
     EXPECT_TRUE(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_INVALID_INDEX);
 }
@@ -124,7 +129,7 @@ bfelf_loader_ut::test_private_relocate_invalid_name()
     bfelf_loader_t loader = {};
     bfelf_file_t ef = {};
     bfelf_rela rela = {};
-    bfelf_shdr shdr = {};
+    bfelf_shdr strtab = {};
     bfelf_sym symtab[1] = {};
 
     auto file = "hello";
@@ -132,12 +137,12 @@ bfelf_loader_ut::test_private_relocate_invalid_name()
     symtab[0].st_name = 0;
 
     ef.file = const_cast<char *>(file);
-    ef.strtab = &shdr;
+    ef.strtab = &strtab;
     ef.symtab = symtab;
     ef.symnum = 1;
 
-    shdr.sh_size = 5;
-    shdr.sh_offset = 0;
+    strtab.sh_size = 5;
+    strtab.sh_offset = 0;
 
     rela.r_info = 0x0;
 
@@ -153,7 +158,7 @@ bfelf_loader_ut::test_private_relocate_invalid_relocation()
     bfelf_loader_t loader = {};
     bfelf_file_t ef = {};
     bfelf_rela rela = {};
-    bfelf_shdr shdr = {};
+    bfelf_shdr strtab = {};
     bfelf_sym symtab[1] = {};
 
     auto file = "hello";
@@ -163,12 +168,12 @@ bfelf_loader_ut::test_private_relocate_invalid_relocation()
 
     ef.exec = exec;
     ef.file = const_cast<char *>(file);
-    ef.strtab = &shdr;
+    ef.strtab = &strtab;
     ef.symtab = symtab;
     ef.symnum = 1;
 
-    shdr.sh_size = 5;
-    shdr.sh_offset = 0;
+    strtab.sh_size = 5;
+    strtab.sh_offset = 0;
 
     rela.r_info = 0xFFFFFFFF;
     rela.r_offset = 0x0;
@@ -178,7 +183,7 @@ bfelf_loader_ut::test_private_relocate_invalid_relocation()
 
     EXPECT_TRUE(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_UNSUPPORTED_RELA);
 
-    delete exec;
+    delete[] exec;
 }
 
 void
@@ -190,10 +195,12 @@ bfelf_loader_ut::test_private_get_section_invalid_name()
     bfelf_shdr *shdr = 0;
     bfelf_shdr shstrtab = {};
     bfelf_shdr shdrtab[1] = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.shdrtab = shdrtab;
     ef.shstrtab = &shstrtab;
+    ef.strtab = &strtab;
 
     ehdr.e_shnum = 1;
 
@@ -213,9 +220,11 @@ bfelf_loader_ut::test_private_symbol_table_sections_invalid_dynsym()
     bfelf_file_t ef = {};
     bfelf64_ehdr ehdr = {};
     bfelf_shdr shdrtab[1] = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.shdrtab = shdrtab;
+    ef.strtab = &strtab;
 
     ehdr.e_shnum = 1;
 
@@ -236,9 +245,11 @@ bfelf_loader_ut::test_private_symbol_table_sections_invalid_hash()
     bfelf_file_t ef = {};
     bfelf64_ehdr ehdr = {};
     bfelf_shdr shdrtab[1] = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.shdrtab = shdrtab;
+    ef.strtab = &strtab;
 
     ehdr.e_shnum = 1;
 
@@ -259,9 +270,11 @@ bfelf_loader_ut::test_private_string_table_sections_invalid()
     bfelf_file_t ef = {};
     bfelf64_ehdr ehdr = {};
     bfelf_shdr dynsym = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.dynsym = &dynsym;
+    ef.strtab = &strtab;
 
     dynsym.sh_link = 0;
     ehdr.e_shstrndx = 0;
@@ -278,9 +291,11 @@ bfelf_loader_ut::test_private_get_relocation_tables_invalid_type()
     bfelf_file_t ef = {};
     bfelf64_ehdr ehdr = {};
     bfelf_shdr shdrtab[1] = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.shdrtab = shdrtab;
+    ef.strtab = &strtab;
 
     ehdr.e_shnum = 1;
 
@@ -298,10 +313,12 @@ bfelf_loader_ut::test_private_get_relocation_tables_invalid_section()
     bfelf_file_t ef = {};
     bfelf64_ehdr ehdr = {};
     bfelf_shdr shdrtab[1] = {};
+    bfelf_shdr strtab = {};
 
     ef.ehdr = &ehdr;
     ef.shdrtab = shdrtab;
     ef.num_rela = 1;
+    ef.strtab = &strtab;
 
     ehdr.e_shnum = 1;
 

--- a/bfm/test/test_file.cpp
+++ b/bfm/test/test_file.cpp
@@ -50,6 +50,5 @@ bfm_ut::test_file_read_with_good_filename()
     tmp.close();
 
     EXPECT_TRUE(g_f.read(filename) == std::string(text));
-
-    std::remove(filename);
+    EXPECT_TRUE(std::remove(filename) == 0);
 }

--- a/bfunwind/include/eh_frame.h
+++ b/bfunwind/include/eh_frame.h
@@ -237,6 +237,22 @@ public:
     ///
     virtual ~common_entry() {}
 
+    /// Default Move Constructor
+    ///
+    common_entry(common_entry &&) = default;
+
+    /// Default Copy Constructor
+    ///
+    common_entry(const common_entry &) = default;
+
+    /// Default Move Assignment Operator
+    ///
+    virtual common_entry &operator=(common_entry &&) = default;
+
+    /// Default Copy Assignment Operator
+    ///
+    virtual common_entry &operator=(const common_entry &) = default;
+
     /// Next CIE/FDE
     ///
     /// Moves to the next CIE/FDE in the list. If the CIE/FDE is invalid, this
@@ -246,41 +262,41 @@ public:
     ///
     /// @return next CIE/FDE
     ///
-    common_entry &operator++();
+    virtual common_entry &operator++();
 
     /// Valid
     ///
     /// @return returns true if the CIE/FDE is valid
     ///
-    operator bool() const
+    virtual operator bool() const
     { return m_entry_start != 0; }
 
     /// Is CIE
     ///
     /// @return returns true if this is a CIE
     ///
-    bool is_cie() const
+    virtual bool is_cie() const
     { return m_is_cie; }
 
     /// Is FDE
     ///
     /// @return returns true is this is an FDE
     ///
-    bool is_fde() const
+    virtual bool is_fde() const
     { return !m_is_cie; }
 
     /// Entry Start
     ///
     /// @return returns the start of the CIE/FDE in memory
     ///
-    char *entry_start() const
+    virtual char *entry_start() const
     { return m_entry_start; }
 
     /// Entry End
     ///
     /// @return returns the end of the CIE/FDE in memory
     ///
-    char *entry_end() const
+    virtual char *entry_end() const
     { return m_entry_end; }
 
     /// Payload Start
@@ -288,7 +304,7 @@ public:
     /// @return returns the start of the CIE/FDE's payload in memory, which
     /// is the portion of the CIE/FDE that does not contain the length field
     ///
-    char *payload_start() const
+    virtual char *payload_start() const
     { return m_payload_start; }
 
     /// Payload End
@@ -297,14 +313,14 @@ public:
     /// is the portion of the CIE/FDE that does not contain the length field.
     /// Note that this should be the same as entry_end
     ///
-    char *payload_end() const
+    virtual char *payload_end() const
     { return m_payload_end; }
 
     /// EH Framework
     ///
     /// @return returns the .eh_frame associated with this CIE/FDE
     ///
-    eh_frame_t eh_frame() const
+    virtual eh_frame_t eh_frame() const
     { return m_eh_frame; }
 
 protected:
@@ -368,6 +384,22 @@ public:
     ///
     virtual ~ci_entry() {}
 
+    /// Default Move Constructor
+    ///
+    ci_entry(ci_entry &&) = default;
+
+    /// Default Copy Constructor
+    ///
+    ci_entry(const ci_entry &) = default;
+
+    /// Default Move Assignment Operator
+    ///
+    virtual ci_entry &operator=(ci_entry &&) = default;
+
+    /// Default Copy Assignment Operator
+    ///
+    virtual ci_entry &operator=(const ci_entry &) = default;
+
     /// Augmentation String
     ///
     /// Each CIE can provide different types of information, and to provide a
@@ -379,7 +411,7 @@ public:
     ///
     /// @return pointer to the augmentation string
     ///
-    char augmentation_string(uint64_t index) const
+    virtual char augmentation_string(uint64_t index) const
     { return m_augmentation_string[index]; }
 
     /// Code Alignment
@@ -387,7 +419,7 @@ public:
     /// @return returns how the code is aligned. On x86_64, this is usually
     /// just 1, which means it's pointless.
     ///
-    uint64_t code_alignment() const
+    virtual uint64_t code_alignment() const
     { return m_code_alignment; }
 
     /// Data Alignment
@@ -396,7 +428,7 @@ public:
     /// -8 bytes, which means that each register is 8 bytes, growing down
     /// from the CFA
     ///
-    int64_t data_alignment() const
+    virtual int64_t data_alignment() const
     { return m_data_alignment; }
 
     /// Return Address Register
@@ -404,7 +436,7 @@ public:
     /// @return returns the instruction pointer register index. The System
     /// V 64bit ABI defines this as 16 (rip)
     ///
-    uint64_t return_address_reg() const
+    virtual uint64_t return_address_reg() const
     { return m_return_address_reg; }
 
     /// Pointer Encoding
@@ -413,21 +445,21 @@ public:
     /// the eh_frame spec (not the DWARF spec) and is usually a PC relative
     /// encoding, as x86_64 code is relocatable.
     ///
-    uint64_t pointer_encoding() const
+    virtual uint64_t pointer_encoding() const
     { return m_pointer_encoding; }
 
     /// LSDA Encoding
     ///
     /// @return returns how the LSDA is encoded
     ///
-    uint64_t lsda_encoding() const
+    virtual uint64_t lsda_encoding() const
     { return m_lsda_encoding; }
 
     /// Personality Encoding
     ///
     /// @return returns how the personality function's pointer is encoded.
     ///
-    uint64_t personality_encoding() const
+    virtual uint64_t personality_encoding() const
     { return m_personality_encoding; }
 
     /// Personality Function
@@ -436,7 +468,7 @@ public:
     /// function tells the unwinder when to stop searching for the catch
     /// blocks
     ///
-    uint64_t personality_function() const
+    virtual uint64_t personality_function() const
     { return m_personality_function; }
 
     /// Initial Instructions
@@ -444,7 +476,7 @@ public:
     /// @return returns a pointer to the initial DWARF instructions that
     /// usually define the function prologs that the compiler creates
     ///
-    char *initial_instructions() const
+    virtual char *initial_instructions() const
     { return m_initial_instructions; }
 
 protected:
@@ -501,6 +533,22 @@ public:
     ///
     virtual ~fd_entry() {}
 
+    /// Default Move Constructor
+    ///
+    fd_entry(fd_entry &&) = default;
+
+    /// Default Copy Constructor
+    ///
+    fd_entry(const fd_entry &) = default;
+
+    /// Default Move Assignment Operator
+    ///
+    virtual fd_entry &operator=(fd_entry &&) = default;
+
+    /// Default Copy Assignment Operator
+    ///
+    virtual fd_entry &operator=(const fd_entry &) = default;
+
     /// Is PC In Range
     ///
     /// Note: the range for the PC is not 0 indexed (fails if you attempt
@@ -513,21 +561,21 @@ public:
     /// @return returns true if this FDE contains the instructions for the
     ///     PC provided.
     ///
-    bool is_in_range(uint64_t pc) const
+    virtual bool is_in_range(uint64_t pc) const
     { return (pc > m_pc_begin) && (pc <= m_pc_begin + m_pc_range); }
 
     /// PC Begin
     ///
     /// @return returns the beginning of the FDE's range
     ///
-    uint64_t pc_begin() const
+    virtual uint64_t pc_begin() const
     { return m_pc_begin; }
 
     /// PC Range
     ///
     /// @return returns the range of the FDE
     ///
-    uint64_t pc_range() const
+    virtual uint64_t pc_range() const
     { return m_pc_range; }
 
     /// LSDA Location
@@ -535,7 +583,7 @@ public:
     /// @return returns the location of the LSDA given the encoding defined
     ///     in the CIE
     ///
-    uint64_t lsda() const
+    virtual uint64_t lsda() const
     { return m_lsda; }
 
     /// Instructions
@@ -543,14 +591,14 @@ public:
     /// @return returns the location of the DWARF instructions that define how
     ///     to unwind the CFA that this FDE defines.
     ///
-    char *instructions() const
+    virtual char *instructions() const
     { return m_instructions; }
 
     /// CIE
     ///
     /// @return returns the CIE associated with this FDE.
     ///
-    const ci_entry &cie() const
+    virtual const ci_entry &cie() const
     { return m_cie; }
 
 protected:

--- a/bfunwind/include/registers.h
+++ b/bfunwind/include/registers.h
@@ -50,7 +50,23 @@ public:
 
     /// Destructor
     ///
-    virtual ~register_state() {}
+    virtual ~register_state() = default;
+
+    /// Default Move Constructor
+    ///
+    register_state(register_state &&) = default;
+
+    /// Default Copy Constructor
+    ///
+    register_state(const register_state &) = default;
+
+    /// Default Move Assignment Operator
+    ///
+    virtual register_state &operator=(register_state &&) = default;
+
+    /// Default Copy Assignment Operator
+    ///
+    virtual register_state &operator=(const register_state &) = default;
 
     /// Get Instruction Pointer
     ///

--- a/bfunwind/include/registers_intel_x64.h
+++ b/bfunwind/include/registers_intel_x64.h
@@ -90,24 +90,30 @@ void __load_registers_intel_x64(registers_intel_x64_t *state);
 class register_state_intel_x64 : public register_state
 {
 public:
-    register_state_intel_x64(registers_intel_x64_t registers)
-    {
-        m_registers = registers;
-        m_tmp_registers = registers;
-    }
+    register_state_intel_x64(const registers_intel_x64_t &registers) :
+        m_registers(registers),
+        m_tmp_registers(registers)
+
+    { }
 
     virtual ~register_state_intel_x64() {}
 
-    uint64_t get_ip() const override
+    register_state_intel_x64(register_state_intel_x64 &&) = default;
+    register_state_intel_x64(const register_state_intel_x64 &) = default;
+
+    virtual register_state_intel_x64 &operator=(register_state_intel_x64 &&) = default;
+    virtual register_state_intel_x64 &operator=(const register_state_intel_x64 &) = default;
+
+    virtual uint64_t get_ip() const override
     { return m_registers.rip; }
 
-    register_state &set_ip(uint64_t value) override
+    virtual register_state &set_ip(uint64_t value) override
     {
         m_tmp_registers.rip = value;
         return *this;
     }
 
-    uint64_t get(uint64_t index) const override
+    virtual uint64_t get(uint64_t index) const override
     {
         if (index >= max_num_registers())
             ABORT("register index out of bounds");
@@ -115,7 +121,7 @@ public:
         return reinterpret_cast<const uint64_t *>(&m_registers)[index];
     }
 
-    register_state &set(uint64_t index, uint64_t value) override
+    virtual register_state &set(uint64_t index, uint64_t value) override
     {
         if (index >= max_num_registers())
             ABORT("register index out of bounds");
@@ -125,22 +131,22 @@ public:
         return *this;
     }
 
-    void commit() override
+    virtual void commit() override
     { m_registers = m_tmp_registers; }
 
-    void commit(uint64_t cfa) override
+    virtual void commit(uint64_t cfa) override
     {
         m_tmp_registers.rsp = cfa;
         commit();
     }
 
-    void resume() override
+    virtual void resume() override
     { __load_registers_intel_x64(&m_registers); }
 
-    uint64_t max_num_registers() const override
+    virtual uint64_t max_num_registers() const override
     { return 17; }
 
-    const char *name(uint64_t index) const override
+    virtual const char *name(uint64_t index) const override
     {
         if (index >= max_num_registers())
             ABORT("register index out of bounds");
@@ -168,7 +174,7 @@ public:
         }
     }
 
-    void dump() const override
+    virtual void dump() const override
     {
         // uint64_t *rsp = (uint64_t *)m_registers.rsp;
 

--- a/bfvmm/include/memory_manager/memory_manager.h
+++ b/bfvmm/include/memory_manager/memory_manager.h
@@ -208,6 +208,7 @@ private:
     virtual void *block_to_virt(int64_t block) noexcept;
     virtual int64_t virt_to_block(void *virt) noexcept;
 
+    virtual bool private_is_power_of_2(uint64_t x) noexcept;
     virtual bool is_block_aligned(int64_t block, int64_t alignment) noexcept;
 
 private:

--- a/bfvmm/src/Makefile.bf
+++ b/bfvmm/src/Makefile.bf
@@ -28,12 +28,15 @@ PARENT_SUBDIRS += entry
 PARENT_SUBDIRS += exit_handler
 PARENT_SUBDIRS += intrinsics
 PARENT_SUBDIRS += memory_manager
-PARENT_SUBDIRS += misc
 PARENT_SUBDIRS += serial
 PARENT_SUBDIRS += vcpu
 PARENT_SUBDIRS += vcpu_factory
 PARENT_SUBDIRS += vmcs
 PARENT_SUBDIRS += vmxon
+
+ifneq ($(STATIC_ANALYSIS_ENABLED), true)
+    PARENT_SUBDIRS += misc
+endif
 
 ################################################################################
 # Common

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -29,7 +29,11 @@
 std::mutex g_unimplemented_handler_mutex;
 
 exit_handler_intel_x64::exit_handler_intel_x64(const std::shared_ptr<intrinsics_intel_x64> &intrinsics) :
-    m_intrinsics(intrinsics)
+    m_intrinsics(intrinsics),
+    m_exit_reason(0),
+    m_exit_qualification(0),
+    m_exit_instruction_length(0),
+    m_exit_instruction_information(0)
 {
     if (!m_intrinsics)
         m_intrinsics = std::make_shared<intrinsics_intel_x64>();

--- a/bfvmm/src/intrinsics/src/idt_x64.cpp
+++ b/bfvmm/src/intrinsics/src/idt_x64.cpp
@@ -22,7 +22,8 @@
 #include <debug.h>
 #include <intrinsics/idt_x64.h>
 
-idt_x64::idt_x64(uint16_t size)
+idt_x64::idt_x64(uint16_t size) :
+    m_size(0)
 {
     if (size == 0)
         return;
@@ -36,7 +37,8 @@ idt_x64::idt_x64(uint16_t size)
     m_idt = std::shared_ptr<uint64_t>(addr);
 }
 
-idt_x64::idt_x64(const std::shared_ptr<intrinsics_x64> &intrinsics)
+idt_x64::idt_x64(const std::shared_ptr<intrinsics_x64> &intrinsics) :
+    m_size(0)
 {
     if (!intrinsics)
         throw std::invalid_argument("gdt_x64: intrinsics == nullptr");

--- a/bfvmm/src/memory_manager/src/memory_manager.cpp
+++ b/bfvmm/src/memory_manager/src/memory_manager.cpp
@@ -278,10 +278,13 @@ memory_manager::phys_to_virt(void *phys)
     return reinterpret_cast<void *>(upper | lower);
 }
 
-static bool
-private_is_power_of_2(uint64_t x)
+bool
+memory_manager::private_is_power_of_2(uint64_t x) noexcept
 {
-    return ((x != 0) && !(x & (x - 1)));
+    if (x <= 0)
+        return false;
+
+    return !(x & (x - 1));
 }
 
 bool
@@ -293,7 +296,7 @@ memory_manager::is_block_aligned(int64_t block, int64_t alignment) noexcept
     if (alignment <= 0)
         return true;
 
-    if (private_is_power_of_2(alignment) == false)
+    if (this->private_is_power_of_2(alignment) == false)
         return false;
 
     return (reinterpret_cast<uint64_t>(block_to_virt(block)) & (alignment - 1)) == 0;

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -74,6 +74,7 @@ memory_manager_ut::list()
     this->test_memory_manager_phys_to_virt_upper_limit();
     this->test_memory_manager_phys_to_virt_lower_limit();
     this->test_memory_manager_phys_to_virt_map();
+    this->test_memory_manager_power_of_two_zero();
 
     this->test_page_table_x64_no_entry();
     this->test_page_table_x64_with_entry();

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -73,6 +73,7 @@ private:
     void test_memory_manager_phys_to_virt_upper_limit();
     void test_memory_manager_phys_to_virt_lower_limit();
     void test_memory_manager_phys_to_virt_map();
+    void test_memory_manager_power_of_two_zero();
 
     void test_page_table_x64_no_entry();
     void test_page_table_x64_with_entry();

--- a/bfvmm/src/memory_manager/test/test_memory_manager.cpp
+++ b/bfvmm/src/memory_manager/test/test_memory_manager.cpp
@@ -417,3 +417,9 @@ memory_manager_ut::test_memory_manager_phys_to_virt_map()
         EXPECT_TRUE(iter.second.type == md.type);
     }
 }
+
+void
+memory_manager_ut::test_memory_manager_power_of_two_zero()
+{
+    EXPECT_TRUE(g_mm->private_is_power_of_2(0) == false);
+}

--- a/bfvmm/src/memory_manager/test/test_page_table_x64.cpp
+++ b/bfvmm/src/memory_manager/test/test_page_table_x64.cpp
@@ -241,6 +241,10 @@ memory_manager_ut::test_page_table_x64_coveralls_cleanup()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(malloc_aligned(4096, 4096) == 0);
+        auto ptr = malloc_aligned(4096, 4096);
+        EXPECT_TRUE(ptr == nullptr);
+
+        if (ptr)
+            free(ptr);
     });
 }

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -768,6 +768,10 @@ vcpu_ut::test_vcpu_intel_x64_coveralls_cleanup()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(malloc_aligned(4096, 4096) == 0);
+        auto ptr = malloc_aligned(4096, 4096);
+        EXPECT_TRUE(ptr == nullptr);
+
+        if (ptr)
+            free(ptr);
     });
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -32,7 +32,8 @@
 #include <exit_handler/exit_handler_intel_x64_support.h>
 
 vmcs_intel_x64::vmcs_intel_x64(const std::shared_ptr<intrinsics_intel_x64> &intrinsics) :
-    m_intrinsics(intrinsics)
+    m_intrinsics(intrinsics),
+    m_vmcs_region_phys(0)
 {
     if (!m_intrinsics)
         m_intrinsics = std::make_shared<intrinsics_intel_x64>();

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -27,7 +27,8 @@
 
 vmxon_intel_x64::vmxon_intel_x64(const std::shared_ptr<intrinsics_intel_x64> &intrinsics) :
     m_intrinsics(intrinsics),
-    m_vmxon_enabled(false)
+    m_vmxon_enabled(false),
+    m_vmxon_region_phys(0)
 {
     if (!m_intrinsics)
         m_intrinsics = std::make_shared<intrinsics_intel_x64>();

--- a/bfvmm/src/vmxon/test/test_vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/test/test_vmxon_intel_x64.cpp
@@ -489,6 +489,10 @@ vmxon_ut::test_coveralls_cleanup()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(malloc_aligned(4096, 4096) == 0);
+        auto ptr = malloc_aligned(4096, 4096);
+        EXPECT_TRUE(ptr == nullptr);
+
+        if (ptr)
+            free(ptr);
     });
 }

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -36,6 +36,16 @@ ifeq ($(TARGET_COMPILER), cross)
 endif
 
 ifeq ($(TARGET_COMPILER), both)
+	ifeq ($(STATIC_ANALYSIS_ENABLED), true)
+		TARGET_CROSS_COMPILED:=
+		TARGET_NATIVE_COMPILED:=true
+	else
+		TARGET_CROSS_COMPILED:=true
+		TARGET_NATIVE_COMPILED:=true
+	endif
+endif
+
+ifeq ($(TARGET_COMPILER), both_always)
 	TARGET_CROSS_COMPILED:=true
 	TARGET_NATIVE_COMPILED:=true
 endif

--- a/include/unittest.h
+++ b/include/unittest.h
@@ -563,7 +563,11 @@ private:
 
 public:
 
-    unittest() {}
+    unittest() :
+        m_pass(0),
+        m_fail(0)
+    { }
+
     virtual ~unittest() {}
 
     decltype(auto)


### PR DESCRIPTION
This patch set add support for static analysis. Specifically,
we have enabled Coverity, fixed the bugs that it found, and
have added the badge. This patch set addresses all of the issues
that were seen by Coverity.

There are other issues that are pending as clang-tidy has
identified a lot of issues the Coverity has not, so a future
PR will address clang-tidy specific issues.

Signed-off-by: “Rian <“rianquinn@gmail.com”>