### PR TITLE
Changed French spelling of the word symboles to English in API Doc

### DIFF
--- a/bfdrivers/include/common.h
+++ b/bfdrivers/include/common.h
@@ -137,7 +137,7 @@ common_load_vmm(void);
 /**
  * Unload VMM
  *
- * This function unloads the vmm. Once the VMM is unloaded, all of the symboles
+ * This function unloads the vmm. Once the VMM is unloaded, all of the symbols
  * for the VMM are removed from memory, and are no longer accessible. The VMM
  * cannot be unloaded unless the VMM is already loaded, but is not running.
  *


### PR DESCRIPTION
# Change
* Spelling of the word `symboles` -> `symbols`

Signed-off-by: “Rico <“ricoantoniofelix@yahoo.com”>