### PR TITLE
README.md: Git clone typo error.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ is a terminal. Once your setup, you should be able to run the following:
 
 ```
 cd ~/
-git https://github.com/bareflank/hypervisor.git
+git clone https://github.com/bareflank/hypervisor.git
 cd ~/hypervisor
 git checkout -b v1.0.0
 


### PR DESCRIPTION

There is a typo error, like below:
original:
	git https://github.com/bareflank/hypervisor.git
it should be:
        git clone https://github.com/bareflank/hypervisor.git

Signed-off-by: Xuguo Wang <huddy1985@gmail.com>