### PR TITLE
Update to Libc++ 3.9

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ clone_depth: 1
 #
 install:
     - ps: 'Start-FileDownload "https://cygwin.com/setup-x86_64.exe" -FileName "setup-x86_64.exe"'
-    - 'setup-x86_64.exe --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages gcc-core,gcc-g++'
+    - 'setup-x86_64.exe --quiet-mode --no-shortcuts --only-site --root "%CYG_ROOT%" --site "%CYG_MIRROR%" --local-package-dir "%CYG_CACHE%" --packages git'
     - 'copy setup-x86_64.exe %CYG_ROOT%\bin\'
     - '%CYG_BASH% -lc "cygcheck -dc cygwin"'
 
@@ -33,7 +33,7 @@ install:
 #
 build_script:
     - 'echo Building...'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./tools/scripts/setup_cygwin.sh -l" > NUL 2>&1'
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./tools/scripts/setup_cygwin.sh -l"'
     - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"'
 
 #

--- a/configure
+++ b/configure
@@ -20,7 +20,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-version=2
+version=3
 
 # ------------------------------------------------------------------------------
 # Colors
@@ -106,7 +106,7 @@ check_env() {
         echo -e "creating script:$CB env.sh$CE"
         echo "export BUILD_ABS=\"$BUILD_ABS\"" >> $BUILD_ABS/env.sh
         echo "export HYPER_ABS=\"$HYPER_ABS\"" >> $BUILD_ABS/env.sh
-        echo "export LLVM_RELEASE=\"release_38\"" >> $BUILD_ABS/env.sh
+        echo "export LLVM_RELEASE=\"release_39\"" >> $BUILD_ABS/env.sh
         echo "export module_file=\"$module_file\"" >> $BUILD_ABS/env.sh
         echo "export compiler=\"$compiler\"" >> $BUILD_ABS/env.sh
         echo "export CFLAGS=\"$CROSS_CCFLAGS\"" >> $BUILD_ABS/env.sh

--- a/tools/patches/libcxx.patch
+++ b/tools/patches/libcxx.patch
@@ -1,0 +1,40 @@
+diff -Naur source_libcxx_original/CMakeLists.txt source_libcxx/CMakeLists.txt
+--- source_libcxx_original/CMakeLists.txt	2016-09-06 11:50:25.003974957 -0600
++++ source_libcxx/CMakeLists.txt	2016-09-06 12:23:30.835600782 -0600
+@@ -310,9 +310,8 @@
+ add_definitions(-D_LIBCPP_HAS_NO_PRAGMA_SYSTEM_HEADER)
+ add_compile_flags_if_supported(
+     -Wall -W -Wwrite-strings
+-    -Wno-unused-parameter -Wno-long-long -Wno-user-defined-literals
+-    -Wno-covered-switch-default
+-    -Werror=return-type)
++    -Wno-unused-parameter -Wno-long-long -Wno-strict-aliasing -Wno-attributes
++    -Werror=return-type -Wno-c++14-compat)
+ if (LIBCXX_ENABLE_WERROR)
+   add_compile_flags_if_supported(-Werror)
+   add_compile_flags_if_supported(-WX)
+diff -Naur source_libcxx_original/include/atomic source_libcxx/include/atomic
+--- source_libcxx_original/include/atomic	2016-09-06 11:50:25.003974957 -0600
++++ source_libcxx/include/atomic	2016-09-06 12:23:30.727606751 -0600
+@@ -589,6 +589,9 @@
+     : __a_value(value) {}
+   _Tp __a_value;
+ };
++#ifdef _Atomic
++#undef _Atomic
++#endif
+ #define _Atomic(x) __gcc_atomic::__gcc_atomic_t<x>
+ 
+ template <typename _Tp> _Tp __create();
+diff -Naur source_libcxx_original/src/strstream.cpp source_libcxx/src/strstream.cpp
+--- source_libcxx_original/src/strstream.cpp	2016-09-06 11:50:25.007974684 -0600
++++ source_libcxx/src/strstream.cpp	2016-09-06 12:23:30.727606751 -0600
+@@ -253,7 +253,7 @@
+         legal = false;
+     if (legal)
+     {
+-        off_type newoff;
++        off_type newoff = 0;
+         char* seekhigh = epptr() ? epptr() : egptr();
+         switch (__way)
+         {

--- a/tools/patches/libcxxabi.patch
+++ b/tools/patches/libcxxabi.patch
@@ -1,0 +1,50 @@
+diff -Naur source_libcxxabi_original/CMakeLists.txt source_libcxxabi/CMakeLists.txt
+--- source_libcxxabi_original/CMakeLists.txt	2016-09-06 08:38:50.645647621 -0600
++++ source_libcxxabi/CMakeLists.txt	2016-09-06 10:18:05.257087827 -0600
+@@ -262,8 +262,8 @@
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSHORTEN_64_TO_32_FLAG -Wshorten-64-to-32)
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSIGN_COMPARE_FLAG -Wsign-compare)
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSIGN_CONVERSION_FLAG -Wsign-conversion)
+-append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSTRICT_ALIASING_FLAG -Wstrict-aliasing=2)
+-append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSTRICT_OVERFLOW_FLAG -Wstrict-overflow=4)
++#append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSTRICT_ALIASING_FLAG -Wstrict-aliasing=2)
++#append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WSTRICT_OVERFLOW_FLAG -Wstrict-overflow=4)
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WUNUSED_PARAMETER_FLAG -Wunused-parameter)
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WUNUSED_VARIABLE_FLAG -Wunused-variable)
+ append_if(LIBCXXABI_COMPILE_FLAGS LIBCXXABI_HAS_WWRITE_STRINGS_FLAG -Wwrite-strings)
+diff -Naur source_libcxxabi_original/src/cxa_handlers.cpp source_libcxxabi/src/cxa_handlers.cpp
+--- source_libcxxabi_original/src/cxa_handlers.cpp	2016-09-06 08:38:50.645647621 -0600
++++ source_libcxxabi/src/cxa_handlers.cpp	2016-09-06 10:18:05.253088009 -0600
+@@ -104,7 +104,7 @@
+ 
+ // In the future this will become:
+ // std::atomic<std::new_handler>  __cxa_new_handler(0);
+-extern "C" _LIBCXXABI_DATA_VIS new_handler __cxa_new_handler = 0;
++extern "C" { _LIBCXXABI_DATA_VIS new_handler __cxa_new_handler = 0; }
+ 
+ new_handler
+ set_new_handler(new_handler handler) _NOEXCEPT
+diff -Naur source_libcxxabi_original/src/private_typeinfo.cpp source_libcxxabi/src/private_typeinfo.cpp
+--- source_libcxxabi_original/src/private_typeinfo.cpp	2016-09-06 08:38:50.645647621 -0600
++++ source_libcxxabi/src/private_typeinfo.cpp	2016-09-06 10:18:05.253088009 -0600
+@@ -37,6 +37,10 @@
+ 
+ #include <string.h>
+ 
++#ifdef __GNUC__
++#pragma GCC diagnostic push
++#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
++#endif
+ 
+ #ifdef _LIBCXX_DYNAMIC_FALLBACK
+ #include "abort_message.h"
+@@ -1277,3 +1281,9 @@
+ #pragma GCC visibility pop
+ 
+ }  // __cxxabiv1
++
++
++#ifdef __GNUC__
++#pragma GCC diagnostic pop
++#endif
++

--- a/tools/scripts/build_libcxx.sh
+++ b/tools/scripts/build_libcxx.sh
@@ -56,7 +56,9 @@ cmake $BUILD_ABS/source_libcxx/ \
     -DLIBCXX_SYSROOT=$BUILD_ABS/sysroot/x86_64-elf/ \
     -DCMAKE_C_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-gcc \
     -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++ \
-    -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DLIBCXX_HAS_PTHREAD_API=ON \
+    -DLIBCXX_ENABLE_EXPERIMENTAL_LIBRARY=OFF
 
 make -j2
 make -j2 install

--- a/tools/scripts/build_libcxxabi.sh
+++ b/tools/scripts/build_libcxxabi.sh
@@ -60,10 +60,10 @@ cmake $BUILD_ABS/source_libcxxabi/ \
     -DCMAKE_C_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-gcc \
     -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++ \
     -DLIBCXXABI_ENABLE_SHARED=OFF \
-    -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+    -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+    -DLIBCXXABI_HAS_PTHREAD_API=ON
 
 make -j2
 make -j2 install
 
 popd
-

--- a/tools/scripts/fetch_libcxx.sh
+++ b/tools/scripts/fetch_libcxx.sh
@@ -32,4 +32,7 @@ do
     sleep 15
 done
 
+cd source_libcxx
+patch -p1 < $HYPER_ABS/tools/patches/libcxx.patch
+
 popd

--- a/tools/scripts/fetch_libcxxabi.sh
+++ b/tools/scripts/fetch_libcxxabi.sh
@@ -32,4 +32,7 @@ do
     sleep 15
 done
 
+cd source_libcxxabi
+patch -p1 < $HYPER_ABS/tools/patches/libcxxabi.patch
+
 popd

--- a/tools/scripts/setup_cygwin.sh
+++ b/tools/scripts/setup_cygwin.sh
@@ -58,7 +58,19 @@ option_help() {
 # ------------------------------------------------------------------------------
 
 install_common_packages() {
-    setup-x86_64.exe -q --wait -P wget,make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,cmake,unzip,bash-completion
+    setup-x86_64.exe -q --wait -P wget,make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel
+}
+
+install_cmake() {
+    rm -Rf cmake-*
+    wget https://cmake.org/files/v3.6/cmake-3.6.1.tar.gz
+    tar xf cmake-*
+    pushd cmake-*
+    ./configure
+    make
+    make install
+    popd
+    rm -Rf cmake-*
 }
 
 setup_ewdk() {
@@ -111,8 +123,15 @@ done
 # ------------------------------------------------------------------------------
 
 case $(uname -r) in
+2.6.*)
+    install_common_packages
+    install_cmake
+    setup_ewdk
+    ;;
+
 2.5.*)
     install_common_packages
+    install_cmake
     setup_ewdk
     ;;
 


### PR DESCRIPTION
This patch provides updates to support libc++ 3.9. It also
adds a patch queue for libc++. This will be used in the
future fix issues with libc++ that prevent certain features
from being used in the VMM (for example, unordered_map).
In addition, future PRs will provide a set of unit tests for
libc++ to verify that supported STL functionality works
as expected.

Signed-off-by: “Rian <“rianquinn@gmail.com”>