### PR TITLE
Fix endl

### DIFF
--- a/bfm/main/main.cpp
+++ b/bfm/main/main.cpp
@@ -35,29 +35,29 @@
 void
 terminate()
 {
-    std::cerr << "FATAL ERROR: terminate called" << std::endl;
+    std::cerr << "FATAL ERROR: terminate called" << '\n';
     abort();
 }
 
 void
 new_handler()
 {
-    std::cerr << "FATAL ERROR: out of memory" << std::endl;
+    std::cerr << "FATAL ERROR: out of memory" << '\n';
     std::terminate();
 }
 
 void
 help()
 {
-    std::cout << "Usage: bfm [OPTION]... load... list_of_modules..." << std::endl;
-    std::cout << "  or:  bfm [OPTION]... unload..." << std::endl;
-    std::cout << "  or:  bfm [OPTION]... start..." << std::endl;
-    std::cout << "  or:  bfm [OPTION]... stop..." << std::endl;
-    std::cout << "  or:  bfm [OPTION]... dump..." << std::endl;
-    std::cout << "  or:  bfm [OPTION]... status..." << std::endl;
-    std::cout << "Controls or queries the bareflank hypervisor" << std::endl;
-    std::cout << std::endl;
-    std::cout << "       -h, --help      show this help menu" << std::endl;
+    std::cout << "Usage: bfm [OPTION]... load... list_of_modules..." << '\n';
+    std::cout << "  or:  bfm [OPTION]... unload..." << '\n';
+    std::cout << "  or:  bfm [OPTION]... start..." << '\n';
+    std::cout << "  or:  bfm [OPTION]... stop..." << '\n';
+    std::cout << "  or:  bfm [OPTION]... dump..." << '\n';
+    std::cout << "  or:  bfm [OPTION]... status..." << '\n';
+    std::cout << "Controls or queries the bareflank hypervisor" << '\n';
+    std::cout << '\n';
+    std::cout << "       -h, --help      show this help menu" << '\n';
 }
 
 int
@@ -74,8 +74,8 @@ protected_main(const std::vector<std::string> &args)
     }
     catch (bfn::general_exception &ge)
     {
-        std::cerr << "bfm: " << ge << std::endl;
-        std::cerr << "Try `bfm --help' for more information." << std::endl;
+        std::cerr << "bfm: " << ge << '\n';
+        std::cerr << "Try `bfm --help' for more information." << '\n';
 
         return EXIT_FAILURE;
     }
@@ -97,7 +97,7 @@ protected_main(const std::vector<std::string> &args)
     }
     catch (bfn::general_exception &ge)
     {
-        std::cerr << "bfm: " << ge << std::endl;
+        std::cerr << "bfm: " << ge << '\n';
 
         return EXIT_FAILURE;
     }
@@ -114,7 +114,7 @@ protected_main(const std::vector<std::string> &args)
     }
     catch (bfn::general_exception &ge)
     {
-        std::cerr << "bfm: " << ge << std::endl;
+        std::cerr << "bfm: " << ge << '\n';
 
         return EXIT_FAILURE;
     }
@@ -140,12 +140,12 @@ main(int argc, const char *argv[])
     }
     catch (std::exception &e)
     {
-        std::cerr << "Caught unhandled exception:" << std::endl;
-        std::cerr << "    - what(): " << e.what() << std::endl;
+        std::cerr << "Caught unhandled exception:" << '\n';
+        std::cerr << "    - what(): " << e.what() << '\n';
     }
     catch (...)
     {
-        std::cerr << "Caught unknown exception" << std::endl;
+        std::cerr << "Caught unknown exception" << '\n';
     }
 
     return EXIT_FAILURE;

--- a/bfunwind/test/test_try_catch.cpp
+++ b/bfunwind/test/test_try_catch.cpp
@@ -316,7 +316,7 @@ bfunwind_ut::test_catch_throw_from_stream()
     try
     {
         auto raii1 = raii();
-        std::cout << raii1 << std::endl;
+        std::cout << raii1 << '\n';
     }
     catch (std::exception &e)
     {

--- a/include/debug.h
+++ b/include/debug.h
@@ -53,7 +53,7 @@ void output_to_vcpu(uint64_t vcpuid, T func)
     func();
 }
 
-/// This macro is a shortcut for std::endl
+/// Newline macro
 ///
 #ifndef bfendl
 #define bfendl '\n'

--- a/include/debug.h
+++ b/include/debug.h
@@ -56,7 +56,7 @@ void output_to_vcpu(uint64_t vcpuid, T func)
 /// This macro is a shortcut for std::endl
 ///
 #ifndef bfendl
-#define bfendl std::endl
+#define bfendl '\n'
 #endif
 
 /// This macro is a shortcut for std::cout that adds some text and color.

--- a/include/unittest.h
+++ b/include/unittest.h
@@ -100,7 +100,7 @@
                 expecting_str = typeid(b).name(); \
             } \
             else \
-                std::cout << "caught: " << ge << std::endl; \
+                std::cout << "caught: " << ge << '\n'; \
         } \
         catch(std::exception &e) \
         { \
@@ -112,13 +112,13 @@
                 expecting_str = typeid(b).name(); \
             } \
             else \
-                std::cout << "caught: " << e << std::endl; \
+                std::cout << "caught: " << e << '\n'; \
         } \
         catch(...) \
         { \
             caught = true; \
             wrong_exception = true; \
-            std::cerr << "unknown exception caught" << std::endl; \
+            std::cerr << "unknown exception caught" << '\n'; \
         } \
         if(!caught) \
         { \
@@ -129,8 +129,8 @@
             if (wrong_exception) \
             { \
                 this->expect_failed("wrong exception caught", static_cast<const char *>(__PRETTY_FUNCTION__), __LINE__); \
-                std::cerr << "    - caught: " << caught_str << std::endl; \
-                std::cerr << "    - expecting: " << expecting_str << std::endl; \
+                std::cerr << "    - caught: " << caught_str << '\n'; \
+                std::cerr << "    - expecting: " << expecting_str << '\n'; \
             } \
             else \
                 this->inc_pass(); \
@@ -225,7 +225,7 @@
                 expecting_str = typeid(b).name(); \
             } \
             else \
-                std::cout << "caught: " << ge << std::endl; \
+                std::cout << "caught: " << ge << '\n'; \
         } \
         catch(std::exception &e) \
         { \
@@ -237,13 +237,13 @@
                 expecting_str = typeid(b).name(); \
             } \
             else \
-                std::cout << "caught: " << e << std::endl; \
+                std::cout << "caught: " << e << '\n'; \
         } \
         catch(...) \
         { \
             caught = true; \
             wrong_exception = true; \
-            std::cerr << "unknown exception caught" << std::endl; \
+            std::cerr << "unknown exception caught" << '\n'; \
         } \
         if(!caught) \
         { \
@@ -254,8 +254,8 @@
             if (wrong_exception) \
             { \
                 this->assert_failed("wrong exception caught", static_cast<const char *>(__PRETTY_FUNCTION__), __LINE__); \
-                std::cerr << "    - caught: " << caught_str << std::endl; \
-                std::cerr << "    - expecting: " << expecting_str << std::endl; \
+                std::cerr << "    - caught: " << caught_str << '\n'; \
+                std::cerr << "    - expecting: " << expecting_str << '\n'; \
             } \
             else \
                 this->inc_pass(); \
@@ -547,13 +547,13 @@ private:
     {
         if (m_fail > 0)
         {
-            std::cout << std::endl;
+            std::cout << '\n';
             std::cout << "totals: ";
             std::cout << m_pass << " passed, ";
             std::cout << "\033[1;31m";
             std::cout << m_fail << " failed";
             std::cout << "\033[0m";
-            std::cout << std::endl;
+            std::cout << '\n';
 
             return false;
         }
@@ -564,7 +564,7 @@ private:
             std::cout << m_pass << " passed, ";
             std::cout << "\033[0m";
             std::cout << m_fail << " failed";
-            std::cout << std::endl;
+            std::cout << '\n';
 
             return true;
         }
@@ -587,7 +587,7 @@ public:
 
         if (this->init() == false)
         {
-            std::cout << "\033[1;31mFAILED\033[0m: init" << std::endl;
+            std::cout << "\033[1;31mFAILED\033[0m: init" << '\n';
             return EXIT_FAILURE;
         }
 
@@ -595,7 +595,7 @@ public:
         {
             if (this->list() == false)
             {
-                std::cout << "\033[1;31mFAILED\033[0m: list" << std::endl;
+                std::cout << "\033[1;31mFAILED\033[0m: list" << '\n';
                 return EXIT_FAILURE;
             }
         }
@@ -605,7 +605,7 @@ public:
 
         if (this->fini() == false)
         {
-            std::cout << "\033[1;31mFAILED\033[0m: fini" << std::endl;
+            std::cout << "\033[1;31mFAILED\033[0m: fini" << '\n';
             return EXIT_FAILURE;
         }
 
@@ -618,8 +618,8 @@ public:
     void
     expect_failed(const char *condition, const char *func, int line)
     {
-        std::cout << "\033[1;31mFAILED\033[0m: [" << line << "]: " << func << std::endl;
-        std::cout << "    - condition: " << condition << std::endl;
+        std::cout << "\033[1;31mFAILED\033[0m: [" << line << "]: " << func << '\n';
+        std::cout << "    - condition: " << condition << '\n';
         this->inc_fail();
     }
 


### PR DESCRIPTION
Removes the use of std::endl in favor of '\n'