### PR TITLE
Remove delete[] from bfdrivers unit tests

### DIFF
--- a/bfdrivers/test/test.cpp
+++ b/bfdrivers/test/test.cpp
@@ -81,15 +81,15 @@ driver_entry_ut::init()
     m_dummy_stop_vmm_failure_length = static_cast<uint64_t>(dummy_stop_vmm_failure_ifs.tellg());
     m_dummy_stop_vmm_success_length = static_cast<uint64_t>(dummy_stop_vmm_success_ifs.tellg());
 
-    m_dummy_add_md_failure = new char[m_dummy_add_md_failure_length];
-    m_dummy_add_md_success = new char[m_dummy_add_md_success_length];
-    m_dummy_get_drr_failure = new char[m_dummy_get_drr_failure_length];
-    m_dummy_get_drr_success = new char[m_dummy_get_drr_success_length];
-    m_dummy_misc = new char[m_dummy_misc_length];
-    m_dummy_start_vmm_failure = new char[m_dummy_start_vmm_failure_length];
-    m_dummy_start_vmm_success = new char[m_dummy_start_vmm_success_length];
-    m_dummy_stop_vmm_failure = new char[m_dummy_stop_vmm_failure_length];
-    m_dummy_stop_vmm_success = new char[m_dummy_stop_vmm_success_length];
+    m_dummy_add_md_failure = std::make_unique<char[]>(m_dummy_add_md_failure_length);
+    m_dummy_add_md_success = std::make_unique<char[]>(m_dummy_add_md_success_length);
+    m_dummy_get_drr_failure = std::make_unique<char[]>(m_dummy_get_drr_failure_length);
+    m_dummy_get_drr_success = std::make_unique<char[]>(m_dummy_get_drr_success_length);
+    m_dummy_misc = std::make_unique<char[]>(m_dummy_misc_length);
+    m_dummy_start_vmm_failure = std::make_unique<char[]>(m_dummy_start_vmm_failure_length);
+    m_dummy_start_vmm_success = std::make_unique<char[]>(m_dummy_start_vmm_success_length);
+    m_dummy_stop_vmm_failure = std::make_unique<char[]>(m_dummy_stop_vmm_failure_length);
+    m_dummy_stop_vmm_success = std::make_unique<char[]>(m_dummy_stop_vmm_success_length);
 
     dummy_add_md_failure_ifs.seekg(0);
     dummy_add_md_success_ifs.seekg(0);
@@ -101,15 +101,15 @@ driver_entry_ut::init()
     dummy_stop_vmm_failure_ifs.seekg(0);
     dummy_stop_vmm_success_ifs.seekg(0);
 
-    dummy_add_md_failure_ifs.read(m_dummy_add_md_failure, static_cast<int64_t>(m_dummy_add_md_failure_length));
-    dummy_add_md_success_ifs.read(m_dummy_add_md_success, static_cast<int64_t>(m_dummy_add_md_success_length));
-    dummy_get_drr_failure_ifs.read(m_dummy_get_drr_failure, static_cast<int64_t>(m_dummy_get_drr_failure_length));
-    dummy_get_drr_success_ifs.read(m_dummy_get_drr_success, static_cast<int64_t>(m_dummy_get_drr_success_length));
-    dummy_misc_ifs.read(m_dummy_misc, static_cast<int64_t>(m_dummy_misc_length));
-    dummy_start_vmm_failure_ifs.read(m_dummy_start_vmm_failure, static_cast<int64_t>(m_dummy_start_vmm_failure_length));
-    dummy_start_vmm_success_ifs.read(m_dummy_start_vmm_success, static_cast<int64_t>(m_dummy_start_vmm_success_length));
-    dummy_stop_vmm_failure_ifs.read(m_dummy_stop_vmm_failure, static_cast<int64_t>(m_dummy_stop_vmm_failure_length));
-    dummy_stop_vmm_success_ifs.read(m_dummy_stop_vmm_success, static_cast<int64_t>(m_dummy_stop_vmm_success_length));
+    dummy_add_md_failure_ifs.read(m_dummy_add_md_failure.get(), static_cast<int64_t>(m_dummy_add_md_failure_length));
+    dummy_add_md_success_ifs.read(m_dummy_add_md_success.get(), static_cast<int64_t>(m_dummy_add_md_success_length));
+    dummy_get_drr_failure_ifs.read(m_dummy_get_drr_failure.get(), static_cast<int64_t>(m_dummy_get_drr_failure_length));
+    dummy_get_drr_success_ifs.read(m_dummy_get_drr_success.get(), static_cast<int64_t>(m_dummy_get_drr_success_length));
+    dummy_misc_ifs.read(m_dummy_misc.get(), static_cast<int64_t>(m_dummy_misc_length));
+    dummy_start_vmm_failure_ifs.read(m_dummy_start_vmm_failure.get(), static_cast<int64_t>(m_dummy_start_vmm_failure_length));
+    dummy_start_vmm_success_ifs.read(m_dummy_start_vmm_success.get(), static_cast<int64_t>(m_dummy_start_vmm_success_length));
+    dummy_stop_vmm_failure_ifs.read(m_dummy_stop_vmm_failure.get(), static_cast<int64_t>(m_dummy_stop_vmm_failure_length));
+    dummy_stop_vmm_success_ifs.read(m_dummy_stop_vmm_success.get(), static_cast<int64_t>(m_dummy_stop_vmm_success_length));
 
     return true;
 }
@@ -117,33 +117,6 @@ driver_entry_ut::init()
 bool
 driver_entry_ut::fini()
 {
-    if (m_dummy_add_md_failure != nullptr)
-        delete[] m_dummy_add_md_failure;
-
-    if (m_dummy_add_md_success != nullptr)
-        delete[] m_dummy_add_md_success;
-
-    if (m_dummy_get_drr_failure != nullptr)
-        delete[] m_dummy_get_drr_failure;
-
-    if (m_dummy_get_drr_success != nullptr)
-        delete[] m_dummy_get_drr_success;
-
-    if (m_dummy_misc != nullptr)
-        delete[] m_dummy_misc;
-
-    if (m_dummy_start_vmm_failure != nullptr)
-        delete[] m_dummy_start_vmm_failure;
-
-    if (m_dummy_start_vmm_success != nullptr)
-        delete[] m_dummy_start_vmm_success;
-
-    if (m_dummy_stop_vmm_failure != nullptr)
-        delete[] m_dummy_stop_vmm_failure;
-
-    if (m_dummy_stop_vmm_success != nullptr)
-        delete[] m_dummy_stop_vmm_success;
-
     return true;
 }
 

--- a/bfdrivers/test/test.h
+++ b/bfdrivers/test/test.h
@@ -129,15 +129,15 @@ private:
 
 private:
 
-    char *m_dummy_add_md_failure;
-    char *m_dummy_add_md_success;
-    char *m_dummy_get_drr_failure;
-    char *m_dummy_get_drr_success;
-    char *m_dummy_misc;
-    char *m_dummy_start_vmm_failure;
-    char *m_dummy_start_vmm_success;
-    char *m_dummy_stop_vmm_failure;
-    char *m_dummy_stop_vmm_success;
+    std::unique_ptr<char[]> m_dummy_add_md_failure;
+    std::unique_ptr<char[]> m_dummy_add_md_success;
+    std::unique_ptr<char[]> m_dummy_get_drr_failure;
+    std::unique_ptr<char[]> m_dummy_get_drr_success;
+    std::unique_ptr<char[]> m_dummy_misc;
+    std::unique_ptr<char[]> m_dummy_start_vmm_failure;
+    std::unique_ptr<char[]> m_dummy_start_vmm_success;
+    std::unique_ptr<char[]> m_dummy_stop_vmm_failure;
+    std::unique_ptr<char[]> m_dummy_stop_vmm_success;
 
     uint64_t m_dummy_add_md_failure_length;
     uint64_t m_dummy_add_md_success_length;

--- a/bfdrivers/test/test_common_add_module.cpp
+++ b/bfdrivers/test/test_common_add_module.cpp
@@ -49,7 +49,7 @@ driver_entry_ut::test_common_add_module_invalid_file()
 void
 driver_entry_ut::test_common_add_module_invalid_file_size()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_misc, 0) == BF_ERROR_INVALID_ARG);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
@@ -63,40 +63,40 @@ driver_entry_ut::test_common_add_module_garbage_module()
 void
 driver_entry_ut::test_common_add_module_add_when_already_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_add_module_add_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_RUNNING);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_add_module_add_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
     EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_ERROR_VMM_CORRUPTED);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -105,9 +105,9 @@ void
 driver_entry_ut::test_common_add_module_add_too_many()
 {
     for (auto i = 0U; i < MAX_NUM_MODULES; i++)
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
+        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_ERROR_MAX_MODULES_REACHED);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_MAX_MODULES_REACHED);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
 
@@ -119,7 +119,7 @@ driver_entry_ut::test_common_add_module_get_elf_file_size_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_ERROR_FAILED_TO_ADD_FILE);
+        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_FAILED_TO_ADD_FILE);
     });
 }
 
@@ -131,7 +131,7 @@ driver_entry_ut::test_common_add_module_platform_alloc_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_ERROR_OUT_OF_MEMORY);
+        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_OUT_OF_MEMORY);
     });
 }
 
@@ -143,6 +143,6 @@ driver_entry_ut::test_common_add_module_load_elf_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == -1);
+        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == -1);
     });
 }

--- a/bfdrivers/test/test_common_dump.cpp
+++ b/bfdrivers/test/test_common_dump.cpp
@@ -37,11 +37,11 @@ driver_entry_ut::test_common_dump_invalid_drr()
 void
 driver_entry_ut::test_common_dump_invalid_vcpuid()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_dump_vmm(&g_drr, 100000) == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -50,11 +50,11 @@ driver_entry_ut::test_common_dump_invalid_vcpuid()
 void
 driver_entry_ut::test_common_dump_dump_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BF_ERROR_VMM_INVALID_STATE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -62,11 +62,11 @@ driver_entry_ut::test_common_dump_dump_when_unloaded()
 void
 driver_entry_ut::test_common_dump_dump_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
@@ -79,11 +79,11 @@ driver_entry_ut::test_common_dump_dump_when_corrupt()
 void
 driver_entry_ut::test_common_dump_dump_when_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success, m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -92,10 +92,10 @@ driver_entry_ut::test_common_dump_dump_when_loaded()
 void
 driver_entry_ut::test_common_dump_get_drr_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -104,11 +104,11 @@ driver_entry_ut::test_common_dump_get_drr_missing()
 void
 driver_entry_ut::test_common_dump_get_drr_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_failure, m_dummy_get_drr_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_get_drr_failure.get(), m_dummy_get_drr_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == GET_DRR_FAILURE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);

--- a/bfdrivers/test/test_common_fini.cpp
+++ b/bfdrivers/test/test_common_fini.cpp
@@ -37,10 +37,10 @@ driver_entry_ut::test_common_fini_unloaded()
 void
 driver_entry_ut::test_common_fini_successful_start()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -50,10 +50,10 @@ driver_entry_ut::test_common_fini_successful_start()
 void
 driver_entry_ut::test_common_fini_successful_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
@@ -62,10 +62,10 @@ driver_entry_ut::test_common_fini_successful_load()
 void
 driver_entry_ut::test_common_fini_successful_add_module()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
 }
@@ -73,10 +73,10 @@ driver_entry_ut::test_common_fini_successful_add_module()
 void
 driver_entry_ut::test_common_fini_corrupted()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
@@ -88,8 +88,8 @@ driver_entry_ut::test_common_fini_corrupted()
 void
 driver_entry_ut::test_common_fini_failed_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
@@ -98,10 +98,10 @@ driver_entry_ut::test_common_fini_failed_load()
 void
 driver_entry_ut::test_common_fini_failed_start()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure, m_dummy_start_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -111,10 +111,10 @@ driver_entry_ut::test_common_fini_failed_start()
 void
 driver_entry_ut::test_common_fini_unload_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
 
     {
@@ -134,10 +134,10 @@ driver_entry_ut::test_common_fini_unload_failed()
 void
 driver_entry_ut::test_common_fini_stop_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
 
@@ -158,10 +158,10 @@ driver_entry_ut::test_common_fini_stop_failed()
 void
 driver_entry_ut::test_common_fini_reset_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
 

--- a/bfdrivers/test/test_common_load.cpp
+++ b/bfdrivers/test/test_common_load.cpp
@@ -43,10 +43,10 @@ extern "C"
 void
 driver_entry_ut::test_common_load_successful_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -56,10 +56,10 @@ driver_entry_ut::test_common_load_successful_load()
 void
 driver_entry_ut::test_common_load_load_when_already_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
@@ -70,10 +70,10 @@ driver_entry_ut::test_common_load_load_when_already_loaded()
 void
 driver_entry_ut::test_common_load_load_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_ERROR_VMM_INVALID_STATE);
@@ -85,10 +85,10 @@ driver_entry_ut::test_common_load_load_when_already_running()
 void
 driver_entry_ut::test_common_load_load_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
@@ -101,8 +101,8 @@ driver_entry_ut::test_common_load_load_when_corrupt()
 void
 driver_entry_ut::test_common_load_fail_due_to_relocation_error()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -121,10 +121,10 @@ driver_entry_ut::test_common_load_fail_due_to_no_modules_added()
 void
 driver_entry_ut::test_common_load_add_md_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_failure, m_dummy_add_md_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_failure.get(), m_dummy_add_md_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == MEMORY_MANAGER_FAILURE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -132,10 +132,10 @@ driver_entry_ut::test_common_load_add_md_failed()
 void
 driver_entry_ut::test_common_load_platform_alloc_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -153,10 +153,10 @@ driver_entry_ut::test_common_load_platform_alloc_failed()
 void
 driver_entry_ut::test_common_load_loader_add_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -174,10 +174,10 @@ driver_entry_ut::test_common_load_loader_add_failed()
 void
 driver_entry_ut::test_common_load_resolve_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -195,10 +195,10 @@ driver_entry_ut::test_common_load_resolve_symbol_failed()
 void
 driver_entry_ut::test_common_load_loader_get_info_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -216,10 +216,10 @@ driver_entry_ut::test_common_load_loader_get_info_failed()
 void
 driver_entry_ut::test_common_load_execute_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;

--- a/bfdrivers/test/test_common_start.cpp
+++ b/bfdrivers/test/test_common_start.cpp
@@ -29,10 +29,10 @@
 void
 driver_entry_ut::test_common_start_start_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_ERROR_VMM_INVALID_STATE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -40,10 +40,10 @@ driver_entry_ut::test_common_start_start_when_unloaded()
 void
 driver_entry_ut::test_common_start_start_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
@@ -53,10 +53,10 @@ driver_entry_ut::test_common_start_start_when_already_running()
 void
 driver_entry_ut::test_common_start_start_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
@@ -69,9 +69,9 @@ driver_entry_ut::test_common_start_start_when_corrupt()
 void
 driver_entry_ut::test_common_start_start_when_start_vmm_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -80,10 +80,10 @@ driver_entry_ut::test_common_start_start_when_start_vmm_missing()
 void
 driver_entry_ut::test_common_start_start_vmm_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure, m_dummy_start_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -92,10 +92,10 @@ driver_entry_ut::test_common_start_start_vmm_failure()
 void
 driver_entry_ut::test_common_start_set_affinity_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
 
     {

--- a/bfdrivers/test/test_common_stop.cpp
+++ b/bfdrivers/test/test_common_stop.cpp
@@ -28,10 +28,10 @@
 void
 driver_entry_ut::test_common_stop_stop_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == BF_ERROR_VMM_INVALID_STATE);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -39,10 +39,10 @@ driver_entry_ut::test_common_stop_stop_when_unloaded()
 void
 driver_entry_ut::test_common_stop_stop_when_not_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -51,10 +51,10 @@ driver_entry_ut::test_common_stop_stop_when_not_running()
 void
 driver_entry_ut::test_common_stop_stop_when_alread_stopped()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
@@ -65,10 +65,10 @@ driver_entry_ut::test_common_stop_stop_when_alread_stopped()
 void
 driver_entry_ut::test_common_stop_stop_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
@@ -81,9 +81,9 @@ driver_entry_ut::test_common_stop_stop_when_corrupt()
 void
 driver_entry_ut::test_common_stop_stop_vmm_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
@@ -95,10 +95,10 @@ driver_entry_ut::test_common_stop_stop_vmm_missing()
 void
 driver_entry_ut::test_common_stop_stop_vmm_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
@@ -110,10 +110,10 @@ driver_entry_ut::test_common_stop_stop_vmm_failure()
 void
 driver_entry_ut::test_common_stop_set_affinity_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
 

--- a/bfdrivers/test/test_common_unload.cpp
+++ b/bfdrivers/test/test_common_unload.cpp
@@ -47,10 +47,10 @@ driver_entry_ut::test_common_unload_unload_when_already_unloaded()
 void
 driver_entry_ut::test_common_unload_unload_when_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_unload_vmm() == BF_ERROR_VMM_INVALID_STATE);
@@ -60,10 +60,10 @@ driver_entry_ut::test_common_unload_unload_when_running()
 void
 driver_entry_ut::test_common_unload_unload_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
@@ -76,10 +76,10 @@ driver_entry_ut::test_common_unload_unload_when_corrupt()
 void
 driver_entry_ut::test_common_unload_loader_get_info_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
 
     {
@@ -98,10 +98,10 @@ driver_entry_ut::test_common_unload_loader_get_info_failed()
 void
 driver_entry_ut::test_common_unload_execute_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure, m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
 
     {

--- a/bfdrivers/test/test_helpers.cpp
+++ b/bfdrivers/test/test_helpers.cpp
@@ -51,10 +51,10 @@ void
 driver_entry_ut::test_helper_common_vmm_status()
 {
     EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
     EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
@@ -74,7 +74,7 @@ driver_entry_ut::test_helper_get_file_invalid_index()
 void
 driver_entry_ut::test_helper_get_file_success()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
     EXPECT_TRUE(get_module(0) != nullptr);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
@@ -118,10 +118,10 @@ driver_entry_ut::test_helper_resolve_symbol_missing_symbol()
 {
     void *sym;
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(resolve_symbol("invalid_symbol", &sym, nullptr) == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -132,10 +132,10 @@ driver_entry_ut::test_helper_resolve_symbol_missing_symbol_from_module()
 {
     void *sym;
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
 
     auto module = get_module(0);
@@ -153,10 +153,10 @@ driver_entry_ut::test_helper_execute_symbol_invalid_arg()
 void
 driver_entry_ut::test_helper_execute_symbol_missing_symbol()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(execute_symbol("invalid_symbol", 0, 0, nullptr) == BFELF_ERROR_NO_SUCH_SYMBOL);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -165,10 +165,10 @@ driver_entry_ut::test_helper_execute_symbol_missing_symbol()
 void
 driver_entry_ut::test_helper_execute_symbol_sym_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(execute_symbol("sym_that_returns_failure", 0, 0, nullptr) == -1);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -177,10 +177,10 @@ driver_entry_ut::test_helper_execute_symbol_sym_failed()
 void
 driver_entry_ut::test_helper_execute_symbol_sym_success()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(execute_symbol("sym_that_returns_success", 0, 0, nullptr) == 0);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
@@ -191,10 +191,10 @@ driver_entry_ut::test_helper_constructors_success()
 {
     get_misc_t get_misc;
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success, m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success, m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc, m_dummy_misc_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     ASSERT_TRUE(resolve_symbol("get_misc", reinterpret_cast<void **>(&get_misc), nullptr) == BF_SUCCESS);
     EXPECT_TRUE(get_misc() == 10);
@@ -216,7 +216,7 @@ driver_entry_ut::test_helper_get_elf_file_size_null_module()
 void
 driver_entry_ut::test_helper_get_elf_file_size_get_segment_fails()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -241,7 +241,7 @@ driver_entry_ut::test_helper_load_elf_file_null_module()
 void
 driver_entry_ut::test_helper_load_elf_file_get_segment_fails()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success, m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;

--- a/bfelf_loader/test/test.cpp
+++ b/bfelf_loader/test/test.cpp
@@ -40,8 +40,8 @@ bool bfelf_loader_ut::init()
     m_dummy_misc_length = static_cast<uint64_t>(dummy_misc_ifs.tellg());
     m_dummy_code_length = static_cast<uint64_t>(dummy_code_ifs.tellg());
 
-    m_dummy_misc = std::shared_ptr<char>(new char[m_dummy_misc_length]());
-    m_dummy_code = std::shared_ptr<char>(new char[m_dummy_code_length]());
+    m_dummy_misc = std::make_unique<char[]>(m_dummy_misc_length);
+    m_dummy_code = std::make_unique<char[]>(m_dummy_code_length);
 
     dummy_misc_ifs.seekg(0);
     dummy_code_ifs.seekg(0);

--- a/bfelf_loader/test/test.h
+++ b/bfelf_loader/test/test.h
@@ -178,8 +178,8 @@ private:
 
 private:
 
-    std::shared_ptr<char> m_dummy_misc;
-    std::shared_ptr<char> m_dummy_code;
+    std::unique_ptr<char[]> m_dummy_misc;
+    std::unique_ptr<char[]> m_dummy_code;
     uint64_t m_dummy_misc_length;
     uint64_t m_dummy_code_length;
 

--- a/bfunwind/test/test.cpp
+++ b/bfunwind/test/test.cpp
@@ -58,7 +58,7 @@ bool bfunwind_ut::init()
 {
     std::ifstream self_ifs(c_self_filename, std::ifstream::ate);
     m_self_length = static_cast<uint64_t>(self_ifs.tellg());
-    m_self = std::shared_ptr<char>(new char[m_self_length]());
+    m_self = std::make_unique<char[]>(m_self_length);
     self_ifs.seekg(0);
     self_ifs.read(m_self.get(), static_cast<int64_t>(m_self_length));
 

--- a/bfunwind/test/test.h
+++ b/bfunwind/test/test.h
@@ -58,7 +58,7 @@ private:
 
 private:
 
-    std::shared_ptr<char> m_self;
+    std::unique_ptr<char[]> m_self;
     uint64_t m_self_length;
 };
 


### PR DESCRIPTION
This patch removes the need for delete[] in the bfdriver
unit tests. We already made this change in the unwinder tests
but never got around to it on the driver side. Interestingly
enough, this was the last remaining delete, everything else
at this point uses shared_ptr or unique_ptr.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/176

Signed-off-by: “Rian <“rianquinn@gmail.com”>