### PR TITLE
file.h: Correct typographical error in API documentation

### DIFF
--- a/bfm/include/file.h
+++ b/bfm/include/file.h
@@ -30,7 +30,7 @@
 /// This class is responsible for working with a file. Specifically, this
 /// class wraps calls to ifstream and fstream to simplify their interface
 /// as well as provide an implementation for the rest of the Bareflank
-/// Manager, such that testing is eaiser.
+/// Manager, such that testing is easier.
 class file
 {
 public:


### PR DESCRIPTION
Signed-off-by: “Rico <“ricoantoniofelix@yahoo.com”>