### PR TITLE
Updated Memory Manager

### DIFF
--- a/Makefile.bf
+++ b/Makefile.bf
@@ -174,5 +174,5 @@ doxygen_clean:
 
 tidy:
 	@cd %HYPER_ABS%; \
-	%HYPER_ABS%/tools/scripts/verify_source.sh
+	%BUILD_ABS%/build_scripts/verify_source.sh
 

--- a/bfvmm/include/memory_manager/mem_pool.h
+++ b/bfvmm/include/memory_manager/mem_pool.h
@@ -1,0 +1,214 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef MEM_POOL_H
+#define MEM_POOL_H
+
+#include <array>
+#include <mutex>
+#include <gsl/gsl>
+#include <constants.h>
+
+constexpr uintptr_t mem_pool_used_index = 0xFFFFFFFFFFFFFFFE;
+constexpr uintptr_t mem_pool_free_index = 0xFFFFFFFFFFFFFFFF;
+
+/// Memory Pool
+///
+/// The VMM has to manage a lot of memory. This includes:
+/// - Heap for new / delete
+/// - Page pool for new / delete
+/// - Virtual memory space for mapping memory
+/// - Guest memory
+///
+/// The problem is, some of these memory pools point to pre-allocated space
+/// while others point to virtual memory that simply needs to be reserved for
+/// memory mapping (classic alloc vs map problem). In all cases, a contiguous
+/// memory space needs to be divided up and managed. This memory pool provides
+/// a really simple "next fit" algorithm for managing these different memory
+/// pools. Clearly there is room for improvement with this algorithm,
+/// but it should work for basic allocations. Further optimizations could be
+/// done using custom new / delete operators at the class level if needed
+/// until we can provide a more complicated algorithm.
+///
+/// @param TS total size in bytes of the memory pool
+/// @param BS block size in bit shifts (i.e. 8 bytes == 3 bits)
+/// @param addr the starting address of the memory pool
+///
+/// @throws std::bad_alloc on failure
+/// @return valid memory address on success
+///
+template<size_t TS, size_t BS>
+class mem_pool
+{
+    static_assert(TS > 0, "total size must be larger than 0");
+    static_assert(TS % (1 << BS) == 0, "total size must be a multiple of block size");
+    static_assert(MAX_PAGE_SHIFT >= BS &&BS > 0, "block shift must be larger than 0");
+
+public:
+    mem_pool(uintptr_t addr) noexcept :
+        m_addr(addr),
+        m_size(TS >> BS)
+    {
+#ifdef CROSS_COMPILED
+        uintptr_t end;
+
+        if (__builtin_uaddl_overflow(m_addr, TS, &end))
+            std::terminate();
+#endif
+        clear();
+    }
+
+    ~mem_pool() = default;
+
+    mem_pool(const mem_pool &) = delete;
+    mem_pool &operator=(const mem_pool &) = delete;
+    mem_pool(mem_pool &&) noexcept = delete;
+    mem_pool &operator=(mem_pool &&) noexcept = delete;
+
+    uintptr_t alloc(uintptr_t size)
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        uintptr_t start = 0;
+        uintptr_t total = total_blocks(size);
+
+        if (size == 0 || size > TS)
+            throw std::bad_alloc();
+
+        if ((start = next_search(m_next, total)) != mem_pool_used_index)
+        {
+            m_next = start + total;
+            gsl::at(m_allocated, start) = total;
+
+            return m_addr + (start << BS);
+        }
+
+        throw std::bad_alloc();
+    }
+
+    void free(uintptr_t addr) noexcept
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (addr < m_addr)
+            return;
+
+        uintptr_t start = (addr - m_addr) >> BS;
+
+        if (start >= m_allocated.size())
+            return;
+
+        gsl::at(m_allocated, start) = mem_pool_free_index;
+    }
+
+    bool contains(uintptr_t addr) const noexcept
+    {
+        return (addr >= m_addr && addr < m_addr + TS);
+    }
+
+    uintptr_t size(uintptr_t addr) noexcept
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        if (!contains(addr))
+            return 0;
+
+        auto size = gsl::at(m_allocated, (addr - m_addr) >> BS);
+
+        if (size == mem_pool_free_index)
+            return 0;
+
+        return size << BS;
+    }
+
+    void clear() noexcept
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+
+        m_next = 0;
+        __builtin_memset(m_allocated.data(), 0xFF, sizeof(m_allocated));
+    }
+
+private:
+
+    uintptr_t next_search(uintptr_t initial, uintptr_t total)
+    {
+        uintptr_t check = 0;
+        uintptr_t count = 0;
+        uintptr_t start = 0;
+        uintptr_t index = initial;
+
+        while (true)
+        {
+            if (index >= m_size)
+            {
+                count = 0;
+                index = 0;
+            }
+
+            if (gsl::at(m_allocated, index) == mem_pool_free_index)
+            {
+                if (count == 0)
+                    start = index;
+
+                count++;
+                index++;
+                check++;
+            }
+            else
+            {
+                auto blocks = gsl::at(m_allocated, index);
+
+                count = 0;
+                index += blocks;
+                check += blocks;
+            }
+
+            if (count >= total)
+                return start;
+
+            if (check >= (TS >> BS))
+                return mem_pool_used_index;
+        }
+    }
+
+    uintptr_t total_blocks(uintptr_t size) const noexcept
+    {
+        uintptr_t total = size >> BS;
+
+        if ((size & ((1 << BS) - 1)) != 0)
+            total++;
+
+        return total;
+    }
+
+private:
+
+    uintptr_t m_next;
+    uintptr_t m_addr;
+    uintptr_t m_size;
+
+    std::array < uintptr_t, (TS >> BS) > m_allocated;
+
+    mutable std::mutex m_mutex;
+};
+
+#endif

--- a/bfvmm/src/memory_manager/src/memory_manager.cpp
+++ b/bfvmm/src/memory_manager/src/memory_manager.cpp
@@ -19,48 +19,29 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-
-#include <array>
-#include <limits>
 #include <gsl/gsl>
 
-#include <debug.h>
 #include <constants.h>
 #include <guard_exceptions.h>
 #include <memory_manager/memory_manager.h>
 
-// -----------------------------------------------------------------------------
-// Macros
-// -----------------------------------------------------------------------------
-
-#define ALLOCATED 0x8000000000000000ULL
+#include <memory_manager/mem_pool.h>
 
 // -----------------------------------------------------------------------------
 // Global Memory
 // -----------------------------------------------------------------------------
 
-struct mmpage_t
-{ uint8_t mem[MAX_PAGE_SIZE]; };
+uint8_t g_heap_pool_owner[MAX_HEAP_POOL] __attribute__((aligned(MAX_PAGE_SIZE))) = {};
+mem_pool<MAX_HEAP_POOL, MAX_CACHE_LINE_SHIFT> g_heap_pool(reinterpret_cast<uintptr_t>(g_heap_pool_owner));
 
-uint64_t g_heap_pool_owner[MAX_HEAP_POOL] __attribute__((aligned(MAX_PAGE_SIZE))) = {};
-gsl::span<uint64_t> g_heap_pool{g_heap_pool_owner};
-
-mmpage_t g_page_pool_owner[MAX_PAGE_POOL] __attribute__((aligned(MAX_PAGE_SIZE))) = {};
-gsl::span<mmpage_t> g_page_pool{g_page_pool_owner};
-
-uint64_t g_page_allocated_owner[MAX_PAGE_POOL] __attribute__((aligned(MAX_PAGE_SIZE))) = {};
-gsl::span<uint64_t> g_page_allocated{g_page_allocated_owner};
+uint8_t g_page_pool_owner[MAX_PAGE_POOL] __attribute__((aligned(MAX_PAGE_SIZE))) = {};
+mem_pool<MAX_PAGE_POOL, MAX_PAGE_SHIFT> g_page_pool(reinterpret_cast<uintptr_t>(g_page_pool_owner));
 
 // -----------------------------------------------------------------------------
 // Mutexes
 // -----------------------------------------------------------------------------
 
 #include <mutex>
-
-std::mutex g_malloc_mutex;
 std::mutex g_add_md_mutex;
 
 // -----------------------------------------------------------------------------
@@ -75,45 +56,45 @@ memory_manager::instance() noexcept
 }
 
 void *
-memory_manager::malloc(size_t size) noexcept
+memory_manager::alloc(size_t size) noexcept
 {
-    if (size == 0)
+    try
+    {
+        if ((size & (MAX_PAGE_SIZE - 1)) == 0)
+            return reinterpret_cast<void *>(g_page_pool.alloc(size));
+
+        return reinterpret_cast<void *>(g_heap_pool.alloc(size));
+    }
+    catch (...)
+    {
         return nullptr;
-
-    if (size > static_cast<size_t>(std::numeric_limits<int64_t>::max()))
-        return nullptr;
-
-    // We ensure that when allocating memory that if it is a multiple of a page,
-    // we use the page pool instead of the heap. The page pool is page aligned
-    // which is needed for a lot of tasks.
-    //
-    // Note that when creating a shared_ptr, the reference counter is allocated
-    // with the memory which means that if you std::make_shared<page>() you
-    // will allocate more than a page, resulting in unaligned memory. The
-    // solution to this is to new the memory, and pass the resulting ptr to
-    // share_ptr constructor (which will create it's own reference on it's own)
-    //
-    // Note the heap uses a header to keep track of each segment, while the
-    // page pool uses a seperate allocated buffer. The page pool needs it's
-    // own buffer to ensure each page is page aligned.
-
-    if ((size & (MAX_PAGE_SIZE - 1)) == 0)
-        return malloc_page(static_cast<int64_t>(size));
-
-    return malloc_heap(static_cast<int64_t>(size));
+    }
 }
 
 void
 memory_manager::free(void *ptr) noexcept
 {
-    if (ptr == nullptr)
-        return;
+    auto uintptr = reinterpret_cast<uintptr_t>(ptr);
 
-    if (g_heap_pool.contains(static_cast<uint64_t *>(ptr)))
-        free_heap(ptr);
+    if (g_heap_pool.contains(uintptr))
+        g_heap_pool.free(reinterpret_cast<uintptr_t>(ptr));
 
-    if (g_page_pool.contains(static_cast<mmpage_t *>(ptr)))
-        free_page(ptr);
+    if (g_page_pool.contains(uintptr))
+        g_page_pool.free(reinterpret_cast<uintptr_t>(ptr));
+}
+
+uintptr_t
+memory_manager::size(void *ptr) const noexcept
+{
+    auto uintptr = reinterpret_cast<uintptr_t>(ptr);
+
+    if (g_heap_pool.contains(uintptr))
+        return g_heap_pool.size(uintptr);
+
+    if (g_page_pool.contains(uintptr))
+        return g_page_pool.size(uintptr);
+
+    return 0;
 }
 
 uintptr_t
@@ -184,145 +165,6 @@ memory_manager::physptr_to_virtptr(void *phys)
     return reinterpret_cast<void *>(this->physptr_to_virtint(phys));
 }
 
-void *
-memory_manager::malloc_heap(int64_t size) noexcept
-{
-    int64_t blocks = (size & (0x7)) != 0 ? (size >> 3) + 2 : (size >> 3) + 1;
-
-    if (blocks > g_heap_pool.size())
-        return nullptr;
-
-    std::lock_guard<std::mutex> guard(g_malloc_mutex);
-
-    int64_t sidx = m_heap_index;
-    int64_t cidx = m_heap_index;
-    int64_t fragment_size = 0;
-
-    auto fa1 = gsl::finally([&]
-    { m_heap_index = sidx + blocks; });
-
-    auto fa2 = gsl::finally([&]
-    { g_heap_pool[sidx] = static_cast<uint64_t>(blocks) | ALLOCATED; });
-
-    while (cidx < g_heap_pool.size() && sidx + blocks <= g_heap_pool.size())
-    {
-        if (g_heap_pool[cidx] == 0)
-            return &g_heap_pool[sidx + 1];
-
-        auto allocated = ((g_heap_pool[cidx] & ALLOCATED) == 0);
-
-        if (allocated)
-        {
-            fragment_size += static_cast<int64_t>(g_heap_pool[cidx]);
-
-            if (fragment_size == blocks)
-                return &g_heap_pool[sidx + 1];
-
-            if (fragment_size < blocks)
-                fa1.dismiss();
-
-            if (fragment_size > blocks)
-            {
-                g_heap_pool[sidx + blocks] = static_cast<uint64_t>(fragment_size - blocks);
-                return &g_heap_pool[sidx + 1];
-            }
-        }
-
-        cidx += static_cast<int64_t>(g_heap_pool[cidx] & ~ALLOCATED);
-
-        if (!allocated)
-        {
-            sidx = cidx;
-            fragment_size = 0;
-        }
-    }
-
-    fa1.dismiss();
-    fa2.dismiss();
-
-    return nullptr;
-}
-
-void *
-memory_manager::malloc_page(int64_t size) noexcept
-{
-    int64_t pages = size >> 12;
-
-    if (pages > g_page_allocated.size())
-        return nullptr;
-
-    std::lock_guard<std::mutex> guard(g_malloc_mutex);
-
-    int64_t sidx = m_page_index;
-    int64_t cidx = m_page_index;
-    int64_t fragment_size = 0;
-
-    auto fa1 = gsl::finally([&]
-    { m_page_index = sidx + pages; });
-
-    auto fa2 = gsl::finally([&]
-    { g_page_allocated[sidx] = static_cast<uint64_t>(pages) | ALLOCATED; });
-
-    while (cidx < g_page_pool.size() && sidx + pages <= g_page_pool.size())
-    {
-        if (g_page_allocated[cidx] == 0)
-            return &g_page_pool[sidx];
-
-        auto allocated = ((g_page_allocated[cidx] & ALLOCATED) == 0);
-
-        if (allocated)
-        {
-            fragment_size += static_cast<int64_t>(g_page_allocated[cidx]);
-
-            if (fragment_size == pages)
-                return &g_page_pool[sidx];
-
-            if (fragment_size < pages)
-                fa1.dismiss();
-
-            if (fragment_size > pages)
-            {
-                g_page_allocated[sidx + pages] = static_cast<uint64_t>(fragment_size - pages);
-                return &g_page_pool[sidx];
-            }
-        }
-
-        cidx += static_cast<int64_t>(g_page_allocated[cidx] & ~ALLOCATED);
-
-        if (!allocated)
-        {
-            sidx = cidx;
-            fragment_size = 0;
-        }
-    }
-
-    fa1.dismiss();
-    fa2.dismiss();
-
-    return nullptr;
-}
-
-void
-memory_manager::free_heap(void *ptr) noexcept
-{
-    auto idx = g_heap_pool.index_from_ptr(static_cast<uint64_t *>(ptr)) - 1;
-
-    g_heap_pool[idx] &= ~ALLOCATED;
-
-    if (m_heap_index > idx)
-        m_heap_index = idx;
-}
-void
-memory_manager::free_page(void *ptr) noexcept
-{
-    auto idx = g_page_pool.index_from_ptr(static_cast<mmpage_t *>(ptr));
-
-    g_page_allocated[idx] &= ~ALLOCATED;
-
-    if (m_page_index > idx)
-        m_page_index = idx;
-}
-
 void
 memory_manager::add_md(memory_descriptor *md)
 {
@@ -360,23 +202,6 @@ memory_manager::add_md(memory_descriptor *md)
     }
 }
 
-void
-memory_manager::clear() noexcept
-{
-    m_heap_index = 0;
-    m_page_index = 0;
-
-    __builtin_memset(static_cast<void *>(g_heap_pool_owner), 0, MAX_HEAP_POOL * sizeof(uint64_t));
-    __builtin_memset(static_cast<void *>(g_page_pool_owner), 0, MAX_PAGE_POOL * sizeof(mmpage_t));
-    __builtin_memset(static_cast<void *>(g_page_allocated_owner), 0, MAX_PAGE_POOL * sizeof(uint64_t));
-}
-
-memory_manager::memory_manager() noexcept :
-    m_heap_index(0),
-    m_page_index(0)
-{
-}
-
 extern "C" int64_t
 add_md(struct memory_descriptor *md) noexcept
 {
@@ -389,35 +214,42 @@ add_md(struct memory_descriptor *md) noexcept
 #ifdef CROSS_COMPILED
 
 extern "C" void *
-_malloc_r(struct _reent *reent, size_t size)
+_malloc_r(struct _reent *, size_t size)
 {
-    (void) reent;
-
-    if (auto ptr = g_mm->malloc(size))
-        return __builtin_memset(ptr, 0, size);
-
-    return nullptr;
+    return g_mm->alloc(size);
 }
 
 extern "C" void
-_free_r(struct _reent *reent, void *ptr)
+_free_r(struct _reent *, void *ptr)
 {
-    (void) reent;
-
     g_mm->free(ptr);
 }
 
 extern "C" void *
-_calloc_r(struct _reent *reent, size_t nmemb, size_t size)
+_calloc_r(struct _reent *, size_t nmemb, size_t size)
 {
-    return _malloc_r(reent, nmemb * size);
+    if (auto ptr = g_mm->alloc(nmemb * size))
+        return __builtin_memset(ptr, 0, nmemb * size);
+
+    return nullptr;
 }
 
 extern "C" void *
-_realloc_r(struct _reent *reent, void *ptr, size_t size)
+_realloc_r(struct _reent *, void *ptr, size_t size)
 {
-    _free_r(reent, ptr);
-    return _malloc_r(reent, size);
+    auto old_sze = g_mm->size(ptr);
+    auto new_ptr = g_mm->alloc(size);
+
+    if (!new_ptr || old_sze == 0)
+        return nullptr;
+
+    if (ptr)
+    {
+        __builtin_memcpy(new_ptr, ptr, size > old_sze ? old_sze : size);
+        g_mm->free(ptr);
+    }
+
+    return new_ptr;
 }
 
 #endif

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -67,32 +67,24 @@ memory_manager_ut::fini()
 bool
 memory_manager_ut::list()
 {
-    this->test_memory_manager_malloc_zero();
     this->test_memory_manager_free_zero();
-    this->test_memory_manager_malloc_heap_valid();
-    this->test_memory_manager_multiple_malloc_heap_should_be_contiguous();
-    this->test_memory_manager_malloc_heap_free_malloc();
     this->test_memory_manager_free_heap_twice();
+    this->test_memory_manager_malloc_zero();
+    this->test_memory_manager_multiple_malloc_heap_should_be_contiguous();
     this->test_memory_manager_malloc_heap_all_of_memory();
     this->test_memory_manager_malloc_heap_all_of_memory_one_block();
     this->test_memory_manager_malloc_heap_all_memory_fragmented();
     this->test_memory_manager_malloc_heap_too_much_memory_one_block();
     this->test_memory_manager_malloc_heap_too_much_memory_non_block_size();
-    this->test_memory_manager_malloc_heap_really_small_fragment();
-    this->test_memory_manager_malloc_heap_sparse_fragments();
     this->test_memory_manager_malloc_heap_massive();
-    this->test_memory_manager_malloc_heap_resize_fragments();
-    this->test_memory_manager_malloc_page_valid();
-    this->test_memory_manager_multiple_malloc_page_should_be_contiguous();
-    this->test_memory_manager_malloc_page_free_malloc();
-    this->test_memory_manager_free_page_twice();
-    this->test_memory_manager_malloc_page_all_of_memory();
-    this->test_memory_manager_malloc_page_all_of_memory_one_block();
-    this->test_memory_manager_malloc_page_all_memory_fragmented();
-    this->test_memory_manager_malloc_page_too_much_memory_one_block();
-    this->test_memory_manager_malloc_page_sparse_fragments();
-    this->test_memory_manager_malloc_page_resize_fragments();
-    this->test_memory_manager_malloc_page_alignment();
+    this->test_memory_manager_size_out_of_bounds();
+    this->test_memory_manager_size_unallocated();
+    this->test_memory_manager_size();
+    this->test_memory_manager_contains_out_of_bounds();
+    this->test_memory_manager_contains();
+    this->test_memory_manager_malloc_out_of_memory();
+    this->test_memory_manager_malloc_heap();
+    this->test_memory_manager_malloc_page();
     this->test_memory_manager_add_md_no_exceptions();
     this->test_memory_manager_add_md_invalid_md();
     this->test_memory_manager_add_md_invalid_virt();

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -39,36 +39,24 @@ protected:
 
 private:
 
-    // Test the smae things for pages (single page, multiple pages)
-    // Malloc a bunc of pages, free them, and then malloc one giant page
-    //    to prove that we can unfragment memory. Do this in
-
-    void test_memory_manager_malloc_zero();
     void test_memory_manager_free_zero();
-    void test_memory_manager_malloc_heap_valid();
-    void test_memory_manager_multiple_malloc_heap_should_be_contiguous();
-    void test_memory_manager_malloc_heap_free_malloc();
     void test_memory_manager_free_heap_twice();
+    void test_memory_manager_malloc_zero();
+    void test_memory_manager_multiple_malloc_heap_should_be_contiguous();
     void test_memory_manager_malloc_heap_all_of_memory();
     void test_memory_manager_malloc_heap_all_of_memory_one_block();
     void test_memory_manager_malloc_heap_all_memory_fragmented();
     void test_memory_manager_malloc_heap_too_much_memory_one_block();
     void test_memory_manager_malloc_heap_too_much_memory_non_block_size();
-    void test_memory_manager_malloc_heap_really_small_fragment();
-    void test_memory_manager_malloc_heap_sparse_fragments();
     void test_memory_manager_malloc_heap_massive();
-    void test_memory_manager_malloc_heap_resize_fragments();
-    void test_memory_manager_malloc_page_valid();
-    void test_memory_manager_multiple_malloc_page_should_be_contiguous();
-    void test_memory_manager_malloc_page_free_malloc();
-    void test_memory_manager_free_page_twice();
-    void test_memory_manager_malloc_page_all_of_memory();
-    void test_memory_manager_malloc_page_all_of_memory_one_block();
-    void test_memory_manager_malloc_page_all_memory_fragmented();
-    void test_memory_manager_malloc_page_too_much_memory_one_block();
-    void test_memory_manager_malloc_page_sparse_fragments();
-    void test_memory_manager_malloc_page_resize_fragments();
-    void test_memory_manager_malloc_page_alignment();
+    void test_memory_manager_size_out_of_bounds();
+    void test_memory_manager_size_unallocated();
+    void test_memory_manager_size();
+    void test_memory_manager_contains_out_of_bounds();
+    void test_memory_manager_contains();
+    void test_memory_manager_malloc_out_of_memory();
+    void test_memory_manager_malloc_heap();
+    void test_memory_manager_malloc_page();
     void test_memory_manager_add_md_no_exceptions();
     void test_memory_manager_add_md_invalid_md();
     void test_memory_manager_add_md_invalid_virt();

--- a/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
@@ -78,12 +78,12 @@ vcpu_intel_x64::fini(void *attr)
     m_guest_state.reset();
     m_vmm_state.reset();
 
-    m_state_save.reset();
-
     m_exit_handler.reset();
     m_vmcs.reset();
     m_vmxon.reset();
     m_intrinsics.reset();
+
+    m_state_save.reset();
 
     vcpu::fini(attr);
 }

--- a/configure
+++ b/configure
@@ -533,6 +533,7 @@ copy_scripts() {
     copy_script "fetch_libcxxabi.sh"
     copy_script "fetch_llvm.sh"
     copy_script "fetch_libbfc.sh"
+    copy_script "verify_source.sh"
 }
 
 # ------------------------------------------------------------------------------

--- a/include/constants.h
+++ b/include/constants.h
@@ -87,10 +87,10 @@
  * anything that uses a std::container uses this heap so it does need to
  * have some size to it. Pages do not come from this pool.
  *
- * Note: defined in bytes (defaults to 8MB)
+ * Note: defined in bytes
  */
 #ifndef MAX_HEAP_POOL
-#define MAX_HEAP_POOL (256ULL * MAX_PAGE_SIZE)
+#define MAX_HEAP_POOL (256ULL * MAX_PAGE_SIZE * MAX_CACHE_LINE_SIZE)
 #endif
 
 /*
@@ -102,7 +102,7 @@
  * Note: defined in bytes (defaults to 8MB)
  */
 #ifndef MAX_PAGE_POOL
-#define MAX_PAGE_POOL (256ULL)
+#define MAX_PAGE_POOL (256ULL * MAX_PAGE_SIZE)
 #endif
 
 /*

--- a/tools/scripts/verify_source.sh
+++ b/tools/scripts/verify_source.sh
@@ -128,9 +128,23 @@ run_clang_tidy() {
 }
 
 #
-# bfcrt
+# bfvmm
 #
-pushd bfcrt > /dev/null
+pushd bfvmm > /dev/null
+header $PWD
+run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode,-clang-analyzer-unix.MismatchedDeallocator"
+run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
+run_clang_tidy "misc*,-clang-analyzer*"
+run_clang_tidy "perf*,-clang-analyzer*"
+run_clang_tidy "cppc*,-clang-analyzer*,-cppcoreguidelines-pro-type-reinterpret-cast"
+run_clang_tidy "read*,-clang-analyzer*,-readability-braces-around-statements"
+run_clang_tidy "mode*,-clang-analyzer*"
+popd > /dev/null
+
+#
+# bfm
+#
+pushd bfm > /dev/null
 header $PWD
 run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode"
 run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
@@ -156,11 +170,11 @@ run_clang_tidy "mode*,-clang-analyzer*"
 popd > /dev/null
 
 #
-# bfelf_loader
+# bfcrt
 #
-pushd bfelf_loader > /dev/null
+pushd bfcrt > /dev/null
 header $PWD
-run_clang_tidy "clan*,-clang-analyzer-alpha.core.CastToStruct"
+run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode"
 run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
 run_clang_tidy "misc*,-clang-analyzer*"
 run_clang_tidy "perf*,-clang-analyzer*"
@@ -170,11 +184,11 @@ run_clang_tidy "mode*,-clang-analyzer*"
 popd > /dev/null
 
 #
-# bfm
+# bfelf_loader
 #
-pushd bfm > /dev/null
+pushd bfelf_loader > /dev/null
 header $PWD
-run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode"
+run_clang_tidy "clan*,-clang-analyzer-alpha.core.CastToStruct"
 run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
 run_clang_tidy "misc*,-clang-analyzer*"
 run_clang_tidy "perf*,-clang-analyzer*"
@@ -195,18 +209,4 @@ run_clang_tidy "perf*,-clang-analyzer*"
 run_clang_tidy "cppc*,-clang-analyzer*,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-array-to-pointer-decay"
 run_clang_tidy "read*,-clang-analyzer*,-readability-braces-around-statements"
 run_clang_tidy "mode*,-clang-analyzer*,-modernize-pass-by-value"
-popd > /dev/null
-
-#
-# bfvmm
-#
-pushd bfvmm > /dev/null
-header $PWD
-run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode,-clang-analyzer-unix.MismatchedDeallocator"
-run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
-run_clang_tidy "misc*,-clang-analyzer*"
-run_clang_tidy "perf*,-clang-analyzer*"
-run_clang_tidy "cppc*,-clang-analyzer*,-cppcoreguidelines-pro-type-reinterpret-cast"
-run_clang_tidy "read*,-clang-analyzer*,-readability-braces-around-statements"
-run_clang_tidy "mode*,-clang-analyzer*"
 popd > /dev/null


### PR DESCRIPTION
Round three on this. While working on the VMCall interface,
realized that we need a method for managing virtual memory
for memory mapping. The algorithm would be the same for the
memory manager. This patch moves the logic from the memory
manager to a generic memory pool class that can be used
for both the memory manager, but also for managing virtual
memory that will be used for mapping, as well as guest memory
in the future.

In addition, the algorithm was updated to a simple next fit
algorithm. Looking at how heap memory is allocted in our
current baseline, a block size of a CACHE_LINE_SIZE will
cover the vast majority of allocations without fragmentation
issues. Further optimizations would be better accomplished by:
- Creating more than one heap pool with a different block
  size
- Creating custom new / delete operators for classes

Signed-off-by: “Rian <“rianquinn@gmail.com”>