### PR TITLE
Fix setup_ubuntu.sh for 16.04

### DIFF
--- a/tools/scripts/setup_ubuntu.sh
+++ b/tools/scripts/setup_ubuntu.sh
@@ -111,6 +111,13 @@ install_clang_1404() {
     rm -Rf clang*
 }
 
+install_clang_1604() {
+    wget http://llvm.org/releases/3.8.1/clang+llvm-3.8.1-x86_64-linux-gnu-ubuntu-16.04.tar.xz
+    tar xf clang*
+    sudo cp -R clang*/* /usr/local/
+    rm -Rf clang*
+}
+
 install_clang() {
     sudo apt-get install --yes clang
 }


### PR DESCRIPTION
setup_ubuntu.sh fails because install_clang_1604 is not found.
commit 72ac0c2f94565cfb260fa932d7cf66331d3e4c9 added 2 new functions
to install clang 'install_clang' (use apt), 'install_clang_1404' (use tar),
but call install_clang_1604.

Fix:
-Add install_clang_1604 similar to install_clang_1404.
-does not use install_clang as apt seems to have a slightly different package
 3.8 instead of 3.8.1 from the tar in 14.04

Test:
make -j2 complete successfully