### PR TITLE
Revise vmlaunch tests

### DIFF
--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -5930,7 +5930,7 @@ constexpr const auto VMCS_HOST_RIP                                             =
 
 // VM-Exit Control Fields
 // intel's software developers manual, volume 3, chapter 24.7.1
-#define VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS                       (1ULL << 2)
+//#define VM_EXIT_CONTROL_SAVE_DEBUG_CONTROLS                       (1ULL << 2)
 #define VM_EXIT_CONTROL_HOST_ADDRESS_SPACE_SIZE                   (1ULL << 9)
 #define VM_EXIT_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL                (1ULL << 12)
 #define VM_EXIT_CONTROL_ACKNOWLEDGE_INTERRUPT_ON_EXIT             (1ULL << 15)

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_host.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_host.cpp
@@ -53,7 +53,7 @@ vmcs_intel_x64::check_host_cr0_for_unsupported_bits()
 
     if (0 != ((~cr0 & ia32_vmx_cr0_fixed0) | (cr0 & ~ia32_vmx_cr0_fixed1)))
     {
-        bferror << " failed: check_guest_cr0_for_unsupported_bits" << bfendl;
+        bferror << " failed: check_host_cr0_for_unsupported_bits" << bfendl;
         bferror << "    - ia32_vmx_cr0_fixed0: " << view_as_pointer(ia32_vmx_cr0_fixed0) << bfendl;
         bferror << "    - ia32_vmx_cr0_fixed1: " << view_as_pointer(ia32_vmx_cr0_fixed1) << bfendl;
         bferror << "    - cr0: " << view_as_pointer(cr0) << bfendl;
@@ -71,7 +71,7 @@ vmcs_intel_x64::check_host_cr4_for_unsupported_bits()
 
     if (0 != ((~cr4 & ia32_vmx_cr4_fixed0) | (cr4 & ~ia32_vmx_cr4_fixed1)))
     {
-        bferror << " failed: check_guest_cr4_for_unsupported_bits" << bfendl;
+        bferror << " failed: check_host_cr4_for_unsupported_bits" << bfendl;
         bferror << "    - ia32_vmx_cr4_fixed0: " << view_as_pointer(ia32_vmx_cr4_fixed0) << bfendl;
         bferror << "    - ia32_vmx_cr4_fixed1: " << view_as_pointer(ia32_vmx_cr4_fixed1) << bfendl;
         bferror << "    - cr4: " << view_as_pointer(cr4) << bfendl;

--- a/bfvmm/src/vmcs/test/Makefile.bf
+++ b/bfvmm/src/vmcs/test/Makefile.bf
@@ -53,6 +53,7 @@ SOURCES+=test.cpp
 SOURCES+=test_vmcs_intel_x64.cpp
 SOURCES+=test_vmcs_intel_x64_check_controls.cpp
 SOURCES+=test_vmcs_intel_x64_check_host.cpp
+SOURCES+=test_vmcs_intel_x64_check_guest.cpp
 
 INCLUDE_PATHS+=./
 INCLUDE_PATHS+=%HYPER_ABS%/include/

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -525,6 +525,10 @@ vmcs_ut::list()
     this->test_vmcs_vm_entry_exception_error_code();
     this->test_vmcs_vm_entry_instruction_length();
 
+    this->test_check_vmcs_control_state();
+    this->test_checks_on_vm_execution_control_fields();
+    this->test_checks_on_vm_exit_control_fields();
+    this->test_checks_on_vm_entry_control_fields();
     this->test_check_control_pin_based_ctls_reserved_properly_set();
     this->test_check_control_proc_based_ctls_reserved_properly_set();
     this->test_check_control_proc_based_ctls2_reserved_properly_set();
@@ -557,6 +561,10 @@ vmcs_ut::list()
     this->test_check_control_event_injection_instr_length_checks();
     this->test_check_control_entry_msr_load_address();
 
+    this->test_check_vmcs_host_state();
+    this->test_check_host_control_registers_and_msrs();
+    this->test_check_host_segment_and_descriptor_table_registers();
+    this->test_check_host_checks_related_to_address_space_size();
     this->test_check_host_cr0_for_unsupported_bits();
     this->test_check_host_cr4_for_unsupported_bits();
     this->test_check_host_cr3_for_unsupported_bits();
@@ -565,20 +573,13 @@ vmcs_ut::list()
     this->test_check_host_verify_load_ia32_perf_global_ctrl();
     this->test_check_host_verify_load_ia32_pat();
     this->test_check_host_verify_load_ia32_efer();
-    this->test_check_host_es_selector_rpl_equal_zero();
-    this->test_check_host_cs_selector_rpl_equal_zero();
-    this->test_check_host_ss_selector_rpl_equal_zero();
-    this->test_check_host_ds_selector_rpl_equal_zero();
-    this->test_check_host_fs_selector_rpl_equal_zero();
-    this->test_check_host_gs_selector_rpl_equal_zero();
-    this->test_check_host_tr_selector_rpl_equal_zero();
-    this->test_check_host_es_selector_ti_equal_zero();
-    this->test_check_host_cs_selector_ti_equal_zero();
-    this->test_check_host_ss_selector_ti_equal_zero();
-    this->test_check_host_ds_selector_ti_equal_zero();
-    this->test_check_host_fs_selector_ti_equal_zero();
-    this->test_check_host_gs_selector_ti_equal_zero();
-    this->test_check_host_tr_selector_ti_equal_zero();
+    this->test_check_host_es_selector_rpl_ti_equal_zero();
+    this->test_check_host_cs_selector_rpl_ti_equal_zero();
+    this->test_check_host_ss_selector_rpl_ti_equal_zero();
+    this->test_check_host_ds_selector_rpl_ti_equal_zero();
+    this->test_check_host_fs_selector_rpl_ti_equal_zero();
+    this->test_check_host_gs_selector_rpl_ti_equal_zero();
+    this->test_check_host_tr_selector_rpl_ti_equal_zero();
     this->test_check_host_cs_not_equal_zero();
     this->test_check_host_tr_not_equal_zero();
     this->test_check_host_ss_not_equal_zero();

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -438,6 +438,10 @@ private:
     void test_vmcs_vm_entry_exception_error_code();
     void test_vmcs_vm_entry_instruction_length();
 
+    void test_check_vmcs_control_state();
+    void test_checks_on_vm_execution_control_fields();
+    void test_checks_on_vm_exit_control_fields();
+    void test_checks_on_vm_entry_control_fields();
     void test_check_control_pin_based_ctls_reserved_properly_set();
     void test_check_control_proc_based_ctls_reserved_properly_set();
     void test_check_control_proc_based_ctls2_reserved_properly_set();
@@ -470,6 +474,10 @@ private:
     void test_check_control_event_injection_instr_length_checks();
     void test_check_control_entry_msr_load_address();
 
+    void test_check_vmcs_host_state();
+    void test_check_host_control_registers_and_msrs();
+    void test_check_host_segment_and_descriptor_table_registers();
+    void test_check_host_checks_related_to_address_space_size();
     void test_check_host_cr0_for_unsupported_bits();
     void test_check_host_cr4_for_unsupported_bits();
     void test_check_host_cr3_for_unsupported_bits();
@@ -478,20 +486,13 @@ private:
     void test_check_host_verify_load_ia32_perf_global_ctrl();
     void test_check_host_verify_load_ia32_pat();
     void test_check_host_verify_load_ia32_efer();
-    void test_check_host_es_selector_rpl_equal_zero();
-    void test_check_host_cs_selector_rpl_equal_zero();
-    void test_check_host_ss_selector_rpl_equal_zero();
-    void test_check_host_ds_selector_rpl_equal_zero();
-    void test_check_host_fs_selector_rpl_equal_zero();
-    void test_check_host_gs_selector_rpl_equal_zero();
-    void test_check_host_tr_selector_rpl_equal_zero();
-    void test_check_host_es_selector_ti_equal_zero();
-    void test_check_host_cs_selector_ti_equal_zero();
-    void test_check_host_ss_selector_ti_equal_zero();
-    void test_check_host_ds_selector_ti_equal_zero();
-    void test_check_host_fs_selector_ti_equal_zero();
-    void test_check_host_gs_selector_ti_equal_zero();
-    void test_check_host_tr_selector_ti_equal_zero();
+    void test_check_host_es_selector_rpl_ti_equal_zero();
+    void test_check_host_cs_selector_rpl_ti_equal_zero();
+    void test_check_host_ss_selector_rpl_ti_equal_zero();
+    void test_check_host_ds_selector_rpl_ti_equal_zero();
+    void test_check_host_fs_selector_rpl_ti_equal_zero();
+    void test_check_host_gs_selector_rpl_ti_equal_zero();
+    void test_check_host_tr_selector_rpl_ti_equal_zero();
     void test_check_host_cs_not_equal_zero();
     void test_check_host_tr_not_equal_zero();
     void test_check_host_ss_not_equal_zero();
@@ -500,7 +501,6 @@ private:
     void test_check_host_gdtr_canonical_base_address();
     void test_check_host_idtr_canonical_base_address();
     void test_check_host_tr_canonical_base_address();
-    void test_check_host_checks_related_to_address_space_size();
     void test_check_host_if_outside_ia32e_mode();
     void test_check_host_vmcs_host_address_space_size_is_set();
     void test_check_host_host_address_space_disabled();

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_guest.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_guest.cpp
@@ -1,0 +1,68 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+// Author: Connor Davis      <davisc@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+
+#include <test.h>
+
+using namespace intel_x64;
+
+static struct control_flow_path path;
+
+static void
+setup_checks_on_guest_control_registers_debug_registers_and_msrs_paths(std::vector<struct control_flow_path> &cfg)
+{
+    path.setup = [&]
+    {
+        g_msrs[msrs::ia32_vmx_cr0_fixed0::addr] = 0ULL;
+        g_msrs[msrs::ia32_vmx_cr0_fixed1::addr] = 0xFFFFFFFFFFFFFFFFULL;
+        g_msrs[msrs::ia32_vmx_cr4_fixed0::addr] = 0ULL;
+        g_msrs[msrs::ia32_vmx_cr4_fixed1::addr] = 0xFFFFFFFFFFFFFFFFULL;
+        disable_entry_ctl(VM_ENTRY_CONTROL_LOAD_DEBUG_CONTROLS);
+        disable_entry_ctl(VM_ENTRY_CONTROL_IA_32E_MODE_GUEST);
+        vmcs::guest_cr4::pcid_enable_bit::set(0U);
+        g_vmcs_fields[VMCS_GUEST_IA32_SYSENTER_ESP] = 0x1000UL;
+        g_vmcs_fields[VMCS_GUEST_IA32_SYSENTER_EIP] = 0x1000UL;
+        disable_entry_ctl(VM_ENTRY_CONTROL_LOAD_IA32_PERF_GLOBAL_CTRL);
+        disable_entry_ctl(VM_ENTRY_CONTROL_LOAD_IA32_PAT);
+        disable_entry_ctl(VM_ENTRY_CONTROL_LOAD_IA32_EFER);
+    };
+    path.throws_exception = false;
+    cfg.push_back(path);
+}
+
+void
+setup_check_vmcs_guest_state_paths(std::vector<struct control_flow_path> &cfg)
+{
+    std::vector<struct control_flow_path> sub_cfg;
+
+    setup_checks_on_guest_control_registers_debug_registers_and_msrs_paths(sub_cfg);
+    // setup_checks_on_guest_segment_registers_paths(cfg);
+    // setup_checks_on_guest_descriptor_table_registers_paths(cfg);
+    // setup_checks_on_guest_rip_and_rflags_paths(cfg);
+    // setup_checks_on_guest_non_register_state_paths(cfg);
+
+    path.setup = [sub_cfg]
+    {
+        for (const auto &sub_path : sub_cfg)
+            sub_path.setup();
+    };
+    path.throws_exception = false;
+    cfg.push_back(path);
+}


### PR DESCRIPTION
This commit creates setup functions for the vmcs check functions
that call solely check functions. This allows _every_ check function
to be tested in "isolation" or among others (i.e. as the root node
in the call graph or as a child node in the call graph).

The code uses the hippomocks "After" function to implement full coverage
for the failure case of vm::launch.  Before this PR, the write_*_state and
*_controls functions in vmcs_intel_x64::launch were overwriting
the vmcs fields after the setup functions had run.  Using "After",
test_vmlaunch_failure ensures that the setup functions are the only
ones that write to the vmcs state before the launch fails.

The rest of the setup functions for the guest checks will be added
once the other guest checks are merged in a later PR.