### PR TITLE
Update 16-bit control field namespaces

### DIFF
--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -612,14 +612,23 @@ namespace virtual_processor_identifier
     constexpr const auto addr = 0x0000000000000000UL;
     constexpr const auto name = "virtual_processor_identifier";
 
-    inline auto get()
-    { return vm::read(addr, name); }
-
-    template<class T> constexpr void set(T val)
-    { vm::write(addr, val, name); }
-
     inline bool exists() noexcept
-    { return msrs::ia32_vmx_procbased_ctls2::enable_vpid::get() == 1; }
+    {
+        return msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1() &&
+               msrs::ia32_vmx_procbased_ctls2::enable_vpid::is_allowed1();
+    }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+
+    template <class T> void set(T val)
+    { set_vmcs_field(val, addr, name, exists()); }
+
+    template <class T> void set_if_exists(T val, bool verbose = false) noexcept
+    { set_vmcs_field_if_exists(val, addr, name, verbose, exists()); }
 }
 
 namespace posted_interrupt_notification_vector
@@ -627,14 +636,20 @@ namespace posted_interrupt_notification_vector
     constexpr const auto addr = 0x0000000000000002UL;
     constexpr const auto name = "posted_interrupt_notification_vector";
 
-    inline auto get()
-    { return vm::read(addr, name); }
-
-    template<class T> void set(T val)
-    { vm::write(addr, val, name); }
-
     inline bool exists() noexcept
-    { return msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::get() == 1; }
+    { return msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::is_allowed1(); }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+
+    template <class T> void set(T val)
+    { set_vmcs_field(val, addr, name, exists()); }
+
+    template <class T> void set_if_exists(T val, bool verbose = false) noexcept
+    { set_vmcs_field_if_exists(val, addr, name, verbose, exists()); }
 }
 
 namespace eptp_index
@@ -642,14 +657,24 @@ namespace eptp_index
     constexpr const auto addr = 0x0000000000000004UL;
     constexpr const auto name = "eptp_index";
 
-    inline auto get()
-    { return vm::read(addr, name); }
-
-    template<class T> void set(T val)
-    { vm::write(addr, val, name); }
-
     inline bool exists() noexcept
-    { return msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::get() == 1; }
+    {
+        return msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::is_allowed1() &&
+               msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::is_allowed1();
+    }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+
+    template <class T> void set(T val)
+    { set_vmcs_field(val, addr, name, exists()); }
+
+    template <class T> void set_if_exists(T val, bool verbose = false) noexcept
+    { set_vmcs_field_if_exists(val, addr, name, verbose, exists()); }
+
 }
 
 // -----------------------------------------------------------------------------

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_controls.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_controls.cpp
@@ -344,7 +344,7 @@ vmcs_intel_x64::check_control_vpid_checks()
     if (secondary_processor_based_vm_execution_controls::enable_vpid::is_disabled_if_exists())
         return;
 
-    if (virtual_processor_identifier::get() == 0)
+    if (virtual_processor_identifier::get_if_exists() == 0)
         throw std::logic_error("vpid cannot equal 0");
 }
 

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
@@ -508,11 +508,16 @@ vmcs_ut::test_set_vm_control_if_allowed()
 void
 vmcs_ut::test_vmcs_virtual_processor_identifier()
 {
-    vmcs::virtual_processor_identifier::set(100UL);
-    g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = msrs::ia32_vmx_procbased_ctls2::enable_vpid::mask;
+    g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::mask << 32;
+    g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = msrs::ia32_vmx_procbased_ctls2::enable_vpid::mask << 32;
 
-    this->expect_true(vmcs::virtual_processor_identifier::get() == 100UL);
     this->expect_true(vmcs::virtual_processor_identifier::exists());
+
+    vmcs::virtual_processor_identifier::set(100UL);
+    this->expect_true(vmcs::virtual_processor_identifier::get() == 100UL);
+
+    vmcs::virtual_processor_identifier::set_if_exists(100UL);
+    this->expect_true(vmcs::virtual_processor_identifier::get_if_exists() == 100UL);
 
     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0x0;
 
@@ -522,11 +527,15 @@ vmcs_ut::test_vmcs_virtual_processor_identifier()
 void
 vmcs_ut::test_vmcs_posted_interrupt_notification_vector()
 {
-    vmcs::posted_interrupt_notification_vector::set(100UL);
-    g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::mask;
+    g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::mask << 32;
 
-    this->expect_true(vmcs::posted_interrupt_notification_vector::get() == 100UL);
     this->expect_true(vmcs::posted_interrupt_notification_vector::exists());
+
+    vmcs::posted_interrupt_notification_vector::set(100UL);
+    this->expect_true(vmcs::posted_interrupt_notification_vector::get() == 100UL);
+
+    vmcs::posted_interrupt_notification_vector::set_if_exists(100UL);
+    this->expect_true(vmcs::posted_interrupt_notification_vector::get_if_exists() == 100UL);
 
     g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 0x0;
 
@@ -536,11 +545,16 @@ vmcs_ut::test_vmcs_posted_interrupt_notification_vector()
 void
 vmcs_ut::test_vmcs_eptp_index()
 {
-    vmcs::eptp_index::set(100UL);
-    g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::mask;
+    g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::mask << 32;
+    g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = msrs::ia32_vmx_procbased_ctls2::ept_violation_ve::mask << 32;
 
-    this->expect_true(vmcs::eptp_index::get() == 100UL);
     this->expect_true(vmcs::eptp_index::exists());
+
+    vmcs::eptp_index::set(100UL);
+    this->expect_true(vmcs::eptp_index::get() == 100UL);
+
+    vmcs::eptp_index::set_if_exists(200UL);
+    this->expect_true(vmcs::eptp_index::get_if_exists() == 200UL);
 
     g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] = 0x0;
 

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
@@ -543,7 +543,11 @@ setup_check_control_virtual_interrupt_and_external_interrupt_paths(std::vector<s
 static void
 setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct control_flow_path> &cfg)
 {
-    path.setup = [&] { disable_pin_ctl(vmcs::pin_based_vm_execution_controls::process_posted_interrupts::mask); };
+    path.setup = [&]
+    {
+        g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = msrs::ia32_vmx_true_pinbased_ctls::process_posted_interrupts::mask << 32;
+        disable_pin_ctl(vmcs::pin_based_vm_execution_controls::process_posted_interrupts::mask);
+    };
     path.throws_exception = false;
     cfg.push_back(path);
 


### PR DESCRIPTION
This updates the three 16-bit control fields' namespaces
to use get_if_exists and set_if_exists.