### PR TITLE
Add AVX Checks to Setup Scripts

### DIFF
--- a/bfvmm/src/misc/src/execute_entry_x64.asm
+++ b/bfvmm/src/misc/src/execute_entry_x64.asm
@@ -61,7 +61,7 @@ execute_entry:
     and rsp, 0xFFFFFFFFFFFFFFE0
 
     sub rsp, 0x20
-    vmovdqa [rsp], xmm0
+    vmovdqa [rsp], ymm0
     sub rsp, 0x20
     vmovdqa [rsp], ymm1
     sub rsp, 0x20

--- a/tools/scripts/setup_cygwin.sh
+++ b/tools/scripts/setup_cygwin.sh
@@ -37,6 +37,11 @@ if [[ ! -d "bfelf_loader" ]]; then
     exit 1
 fi
 
+if ! grep -q 'avx' /proc/cpuinfo; then
+    echo "Hardware unsupported. AVX is required"
+    exit 1
+fi
+
 # ------------------------------------------------------------------------------
 # Help
 # ------------------------------------------------------------------------------

--- a/tools/scripts/setup_debian.sh
+++ b/tools/scripts/setup_debian.sh
@@ -37,6 +37,11 @@ if [[ ! -d "bfelf_loader" ]]; then
     exit 1
 fi
 
+if ! grep -q 'avx' /proc/cpuinfo; then
+    echo "Hardware unsupported. AVX is required"
+    exit 1
+fi
+
 # ------------------------------------------------------------------------------
 # Help
 # ------------------------------------------------------------------------------

--- a/tools/scripts/setup_fedora.sh
+++ b/tools/scripts/setup_fedora.sh
@@ -39,6 +39,11 @@ if [[ ! -d "bfelf_loader" ]]; then
     exit 1
 fi
 
+if ! grep -q 'avx' /proc/cpuinfo; then
+    echo "Hardware unsupported. AVX is required"
+    exit 1
+fi
+
 # ------------------------------------------------------------------------------
 # Help
 # ------------------------------------------------------------------------------

--- a/tools/scripts/setup_opensuse.sh
+++ b/tools/scripts/setup_opensuse.sh
@@ -43,6 +43,11 @@ if [[ ! -d "bfelf_loader" ]]; then
     exit 1
 fi
 
+if ! grep -q 'avx' /proc/cpuinfo; then
+    echo "Hardware unsupported. AVX is required"
+    exit 1
+fi
+
 # ------------------------------------------------------------------------------
 # Help
 # ------------------------------------------------------------------------------

--- a/tools/scripts/setup_ubuntu.sh
+++ b/tools/scripts/setup_ubuntu.sh
@@ -37,6 +37,11 @@ if [[ ! -d "bfelf_loader" ]]; then
     exit 1
 fi
 
+if ! grep -q 'avx' /proc/cpuinfo; then
+    echo "Hardware unsupported. AVX is required"
+    exit 1
+fi
+
 # ------------------------------------------------------------------------------
 # Help
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
This patch checks for AVX support which is needed since the
execute_entry.asm code has to save the YMM registers which
do not exist if AVX is not supported.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/282

Signed-off-by: “Rian <“rianquinn@gmail.com”>