### PR TITLE
Cleanup Doxygen

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,15 @@ matrix:
       - if [[ -n $(./tools/astyle/run.sh | grep Formatted) ]]; then echo "You must run astyle before submitting a pull request"; exit -1; fi
 
   #
+  # Doxygen
+  #
+  - os: linux
+    env:
+      - TEST="Doxygen"
+    script:
+      - if [[ -n $(./tools/doxygen/linux/run.sh | grep warning) ]]; then echo "You must fix doxygen before submitting a pull request"; exit -1; fi
+
+  #
   # Git Check
   #
   - os: linux

--- a/bfdrivers/src/arch/osx/README.md
+++ b/bfdrivers/src/arch/osx/README.md
@@ -1,3 +1,5 @@
 ## OS X Driver Compilation Instructions
 
-OS X is currently not supported
+Although there is code here, OS X is currently not supported, and this code
+is known not to compile. Please continue to watch this repo as we will be adding
+support for OS X in the future.

--- a/tools/doxygen/config.txt
+++ b/tools/doxygen/config.txt
@@ -768,7 +768,7 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = ../include/json.h
+EXCLUDE                = ../include/json.h  ../bfdrivers/src/arch/osx/
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded


### PR DESCRIPTION
This patch cleans up a long standing issue with doxygen and OSX,
and as a result, we can not start checking doxygen in our PR
process

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/280

Signed-off-by: “Rian <“rianquinn@gmail.com”>