### PR TITLE
CPUID Cleanup

### DIFF
--- a/bfvmm/include/intrinsics/cpuid_x64.h
+++ b/bfvmm/include/intrinsics/cpuid_x64.h
@@ -22,6 +22,9 @@
 #ifndef CPUID_X64_H
 #define CPUID_X64_H
 
+#include <debug.h>
+#include <bitmanip.h>
+
 extern "C" uint32_t __cpuid_eax(uint32_t val) noexcept;
 extern "C" uint32_t __cpuid_ebx(uint32_t val) noexcept;
 extern "C" uint32_t __cpuid_ecx(uint32_t val) noexcept;
@@ -34,7 +37,12 @@ namespace x64
 {
 namespace cpuid
 {
-    template<class T> auto get(T eax, T ebx, T ecx, T edx) noexcept
+    template<class T1, class T2, class T3, class T4,
+             class = typename std::enable_if<std::is_integral<T1>::value>::type,
+             class = typename std::enable_if<std::is_integral<T2>::value>::type,
+             class = typename std::enable_if<std::is_integral<T3>::value>::type,
+             class = typename std::enable_if<std::is_integral<T4>::value>::type>
+    auto get(T1 eax, T2 ebx, T3 ecx, T4 edx) noexcept
     {
         __cpuid(&eax, &ebx, &ecx, &edx);
         return std::make_tuple(eax, ebx, ecx, edx);
@@ -42,26 +50,26 @@ namespace cpuid
 
     namespace eax
     {
-        template<class T> auto get(T eax) noexcept
-        { return __cpuid_eax(gsl::narrow_cast<uint32_t>(eax)); }
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto get(T eax) noexcept { return __cpuid_eax(gsl::narrow_cast<uint32_t>(eax)); }
     }
 
     namespace ebx
     {
-        template<class T> auto get(T ebx) noexcept
-        { return __cpuid_ebx(gsl::narrow_cast<uint32_t>(ebx)); }
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto get(T ebx) noexcept { return __cpuid_ebx(gsl::narrow_cast<uint32_t>(ebx)); }
     }
 
     namespace ecx
     {
-        template<class T> auto get(T ecx) noexcept
-        { return __cpuid_ecx(gsl::narrow_cast<uint32_t>(ecx)); }
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto get(T ecx) noexcept { return __cpuid_ecx(gsl::narrow_cast<uint32_t>(ecx)); }
     }
 
     namespace edx
     {
-        template<class T> auto get(T edx) noexcept
-        { return __cpuid_edx(gsl::narrow_cast<uint32_t>(edx)); }
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto get(T edx) noexcept { return __cpuid_edx(gsl::narrow_cast<uint32_t>(edx)); }
     }
 
     namespace addr_size
@@ -76,7 +84,7 @@ namespace cpuid
             constexpr const auto name = "phys";
 
             inline auto get() noexcept
-            { return (__cpuid_eax(addr) & mask) >> from; }
+            { return get_bits(__cpuid_eax(addr), mask) >> from; }
         }
 
         namespace linear
@@ -86,7 +94,7 @@ namespace cpuid
             constexpr const auto name = "linear";
 
             inline auto get() noexcept
-            { return (__cpuid_eax(addr) & mask) >> from; }
+            { return get_bits(__cpuid_eax(addr), mask) >> from; }
         }
     }
 
@@ -104,7 +112,7 @@ namespace cpuid
                 constexpr const auto name = "sse3";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace pclmulqdq
@@ -114,7 +122,7 @@ namespace cpuid
                 constexpr const auto name = "pclmulqdq";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace dtes64
@@ -124,7 +132,7 @@ namespace cpuid
                 constexpr const auto name = "dtes64";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace monitor
@@ -134,7 +142,7 @@ namespace cpuid
                 constexpr const auto name = "monitor";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace ds_cpl
@@ -144,7 +152,7 @@ namespace cpuid
                 constexpr const auto name = "ds_cpl";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace vmx
@@ -154,7 +162,7 @@ namespace cpuid
                 constexpr const auto name = "vmx";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace smx
@@ -164,7 +172,7 @@ namespace cpuid
                 constexpr const auto name = "smx";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace eist
@@ -174,7 +182,7 @@ namespace cpuid
                 constexpr const auto name = "eist";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace tm2
@@ -184,7 +192,7 @@ namespace cpuid
                 constexpr const auto name = "tm2";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace ssse3
@@ -194,7 +202,7 @@ namespace cpuid
                 constexpr const auto name = "ssse3";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace cnxt_id
@@ -204,7 +212,7 @@ namespace cpuid
                 constexpr const auto name = "cnxt_id";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace sdbg
@@ -214,7 +222,7 @@ namespace cpuid
                 constexpr const auto name = "sdbg";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace fma
@@ -224,7 +232,7 @@ namespace cpuid
                 constexpr const auto name = "fma";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace cmpxchg16b
@@ -234,7 +242,7 @@ namespace cpuid
                 constexpr const auto name = "cmpxchg16b";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace xtpr_update_control
@@ -244,7 +252,7 @@ namespace cpuid
                 constexpr const auto name = "xtpr_update_control";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace pdcm
@@ -254,7 +262,7 @@ namespace cpuid
                 constexpr const auto name = "pdcm";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace pcid
@@ -264,7 +272,7 @@ namespace cpuid
                 constexpr const auto name = "pcid";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace dca
@@ -274,7 +282,7 @@ namespace cpuid
                 constexpr const auto name = "dca";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace sse41
@@ -284,7 +292,7 @@ namespace cpuid
                 constexpr const auto name = "sse41";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace sse42
@@ -294,7 +302,7 @@ namespace cpuid
                 constexpr const auto name = "sse42";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace x2apic
@@ -304,7 +312,7 @@ namespace cpuid
                 constexpr const auto name = "x2apic";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace movbe
@@ -314,7 +322,7 @@ namespace cpuid
                 constexpr const auto name = "movbe";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace popcnt
@@ -324,7 +332,7 @@ namespace cpuid
                 constexpr const auto name = "popcnt";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace tsc_deadline
@@ -334,7 +342,7 @@ namespace cpuid
                 constexpr const auto name = "tsc_deadline";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace aesni
@@ -344,7 +352,7 @@ namespace cpuid
                 constexpr const auto name = "aesni";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace xsave
@@ -354,7 +362,7 @@ namespace cpuid
                 constexpr const auto name = "xsave";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace osxsave
@@ -364,7 +372,7 @@ namespace cpuid
                 constexpr const auto name = "osxsave";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace avx
@@ -374,7 +382,7 @@ namespace cpuid
                 constexpr const auto name = "avx";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace f16c
@@ -384,7 +392,7 @@ namespace cpuid
                 constexpr const auto name = "f16c";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
             }
 
             namespace rdrand
@@ -394,7 +402,102 @@ namespace cpuid
                 constexpr const auto name = "rdrand";
 
                 inline auto get() noexcept
-                { return (__cpuid_ecx(addr) & mask) >> from; }
+                { return get_bit(__cpuid_ecx(addr), from) != 0; }
+            }
+
+            inline void dump() noexcept
+            {
+                bfdebug << "cpuid::feature_information::ecx enabled flags:" << bfendl;
+
+                if (sse3::get())
+                    bfdebug << "    - sse3" << bfendl;
+
+                if (pclmulqdq::get())
+                    bfdebug << "    - pclmulqdq" << bfendl;
+
+                if (dtes64::get())
+                    bfdebug << "    - dtes64" << bfendl;
+
+                if (monitor::get())
+                    bfdebug << "    - monitor" << bfendl;
+
+                if (ds_cpl::get())
+                    bfdebug << "    - ds_cpl" << bfendl;
+
+                if (vmx::get())
+                    bfdebug << "    - vmx" << bfendl;
+
+                if (smx::get())
+                    bfdebug << "    - smx" << bfendl;
+
+                if (eist::get())
+                    bfdebug << "    - eist" << bfendl;
+
+                if (tm2::get())
+                    bfdebug << "    - tm2" << bfendl;
+
+                if (ssse3::get())
+                    bfdebug << "    - ssse3" << bfendl;
+
+                if (cnxt_id::get())
+                    bfdebug << "    - cnxt_id" << bfendl;
+
+                if (sdbg::get())
+                    bfdebug << "    - sdbg" << bfendl;
+
+                if (fma::get())
+                    bfdebug << "    - fma" << bfendl;
+
+                if (cmpxchg16b::get())
+                    bfdebug << "    - cmpxchg16b" << bfendl;
+
+                if (xtpr_update_control::get())
+                    bfdebug << "    - xtpr_update_control" << bfendl;
+
+                if (pdcm::get())
+                    bfdebug << "    - pdcm" << bfendl;
+
+                if (pcid::get())
+                    bfdebug << "    - pcid" << bfendl;
+
+                if (dca::get())
+                    bfdebug << "    - dca" << bfendl;
+
+                if (sse41::get())
+                    bfdebug << "    - sse41" << bfendl;
+
+                if (sse42::get())
+                    bfdebug << "    - sse42" << bfendl;
+
+                if (x2apic::get())
+                    bfdebug << "    - x2apic" << bfendl;
+
+                if (movbe::get())
+                    bfdebug << "    - movbe" << bfendl;
+
+                if (popcnt::get())
+                    bfdebug << "    - popcnt" << bfendl;
+
+                if (tsc_deadline::get())
+                    bfdebug << "    - tsc_deadline" << bfendl;
+
+                if (aesni::get())
+                    bfdebug << "    - aesni" << bfendl;
+
+                if (xsave::get())
+                    bfdebug << "    - xsave" << bfendl;
+
+                if (osxsave::get())
+                    bfdebug << "    - osxsave" << bfendl;
+
+                if (avx::get())
+                    bfdebug << "    - avx" << bfendl;
+
+                if (f16c::get())
+                    bfdebug << "    - f16c" << bfendl;
+
+                if (rdrand::get())
+                    bfdebug << "    - rdrand" << bfendl;
             }
         }
     }

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -395,6 +395,7 @@ intrinsics_ut::list()
     this->test_cpuid_x64_cpuid_feature_information_ecx_avx();
     this->test_cpuid_x64_cpuid_feature_information_ecx_f16c();
     this->test_cpuid_x64_cpuid_feature_information_ecx_rdrand();
+    this->test_cpuid_x64_cpuid_feature_information_ecx_dump();
 
     this->test_pm_x64_halt();
     this->test_pm_x64_stop();

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -394,6 +394,7 @@ private:
     void test_cpuid_x64_cpuid_feature_information_ecx_avx();
     void test_cpuid_x64_cpuid_feature_information_ecx_f16c();
     void test_cpuid_x64_cpuid_feature_information_ecx_rdrand();
+    void test_cpuid_x64_cpuid_feature_information_ecx_dump();
 
     void test_pm_x64_halt();
     void test_pm_x64_stop();

--- a/bfvmm/src/intrinsics/test/test_cpuid_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_cpuid_x64.cpp
@@ -53,14 +53,7 @@ __cpuid_edx(uint32_t val) noexcept
 
 extern "C" void
 __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
-{
-    (void) eax;
-    (void) ebx;
-    (void) ecx;
-    (void) edx;
-
-    return;
-}
+{ (void) eax; (void) ebx; (void) ecx; (void) edx; }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid()
@@ -113,14 +106,14 @@ intrinsics_ut::test_cpuid_x64_cpuid_edx()
 void
 intrinsics_ut::test_cpuid_x64_cpuid_addr_size_phys()
 {
-    g_eax_cpuid[cpuid::addr_size::addr] = 0x00000010;
+    g_eax_cpuid[cpuid::addr_size::addr] = 0x12345610;
     this->expect_true(cpuid::addr_size::phys::get() == 0x10);
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_addr_size_linear()
 {
-    g_eax_cpuid[cpuid::addr_size::addr] = 0x00001000;
+    g_eax_cpuid[cpuid::addr_size::addr] = 0x12341056;
     this->expect_true(cpuid::addr_size::linear::get() == 0x10);
 }
 
@@ -128,298 +121,305 @@ void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse3()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 0;
-    this->expect_true(cpuid::feature_information::ecx::sse3::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::sse3::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 0);
-    this->expect_true(cpuid::feature_information::ecx::sse3::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::sse3::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pclmulqdq()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 1;
-    this->expect_true(cpuid::feature_information::ecx::pclmulqdq::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::pclmulqdq::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 1);
-    this->expect_true(cpuid::feature_information::ecx::pclmulqdq::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::pclmulqdq::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dtes64()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 2;
-    this->expect_true(cpuid::feature_information::ecx::dtes64::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::dtes64::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 2);
-    this->expect_true(cpuid::feature_information::ecx::dtes64::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::dtes64::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_monitor()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 3;
-    this->expect_true(cpuid::feature_information::ecx::monitor::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::monitor::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 3);
-    this->expect_true(cpuid::feature_information::ecx::monitor::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::monitor::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_ds_cpl()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 4;
-    this->expect_true(cpuid::feature_information::ecx::ds_cpl::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::ds_cpl::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 4);
-    this->expect_true(cpuid::feature_information::ecx::ds_cpl::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::ds_cpl::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_vmx()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 5;
-    this->expect_true(cpuid::feature_information::ecx::vmx::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::vmx::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 5);
-    this->expect_true(cpuid::feature_information::ecx::vmx::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::vmx::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_smx()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 6;
-    this->expect_true(cpuid::feature_information::ecx::smx::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::smx::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 6);
-    this->expect_true(cpuid::feature_information::ecx::smx::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::smx::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_eist()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 7;
-    this->expect_true(cpuid::feature_information::ecx::eist::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::eist::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 7);
-    this->expect_true(cpuid::feature_information::ecx::eist::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::eist::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_tm2()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 8;
-    this->expect_true(cpuid::feature_information::ecx::tm2::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::tm2::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 8);
-    this->expect_true(cpuid::feature_information::ecx::tm2::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::tm2::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_ssse3()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 9;
-    this->expect_true(cpuid::feature_information::ecx::ssse3::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::ssse3::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 9);
-    this->expect_true(cpuid::feature_information::ecx::ssse3::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::ssse3::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_cnxt_id()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 10;
-    this->expect_true(cpuid::feature_information::ecx::cnxt_id::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::cnxt_id::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 10);
-    this->expect_true(cpuid::feature_information::ecx::cnxt_id::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::cnxt_id::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sdbg()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 11;
-    this->expect_true(cpuid::feature_information::ecx::sdbg::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::sdbg::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 11);
-    this->expect_true(cpuid::feature_information::ecx::sdbg::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::sdbg::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_fma()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 12;
-    this->expect_true(cpuid::feature_information::ecx::fma::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::fma::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 12);
-    this->expect_true(cpuid::feature_information::ecx::fma::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::fma::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_cmpxchg16b()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 13;
-    this->expect_true(cpuid::feature_information::ecx::cmpxchg16b::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::cmpxchg16b::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 13);
-    this->expect_true(cpuid::feature_information::ecx::cmpxchg16b::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::cmpxchg16b::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_xtpr_update_control()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 14;
-    this->expect_true(cpuid::feature_information::ecx::xtpr_update_control::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::xtpr_update_control::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 14);
-    this->expect_true(cpuid::feature_information::ecx::xtpr_update_control::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::xtpr_update_control::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pdcm()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 15;
-    this->expect_true(cpuid::feature_information::ecx::pdcm::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::pdcm::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 15);
-    this->expect_true(cpuid::feature_information::ecx::pdcm::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::pdcm::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_pcid()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 17;
-    this->expect_true(cpuid::feature_information::ecx::pcid::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::pcid::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 17);
-    this->expect_true(cpuid::feature_information::ecx::pcid::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::pcid::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dca()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 18;
-    this->expect_true(cpuid::feature_information::ecx::dca::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::dca::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 18);
-    this->expect_true(cpuid::feature_information::ecx::dca::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::dca::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse41()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 19;
-    this->expect_true(cpuid::feature_information::ecx::sse41::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::sse41::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 19);
-    this->expect_true(cpuid::feature_information::ecx::sse41::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::sse41::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_sse42()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 20;
-    this->expect_true(cpuid::feature_information::ecx::sse42::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::sse42::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 20);
-    this->expect_true(cpuid::feature_information::ecx::sse42::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::sse42::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_x2apic()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 21;
-    this->expect_true(cpuid::feature_information::ecx::x2apic::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::x2apic::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 21);
-    this->expect_true(cpuid::feature_information::ecx::x2apic::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::x2apic::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_movbe()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 22;
-    this->expect_true(cpuid::feature_information::ecx::movbe::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::movbe::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 22);
-    this->expect_true(cpuid::feature_information::ecx::movbe::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::movbe::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_popcnt()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 23;
-    this->expect_true(cpuid::feature_information::ecx::popcnt::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::popcnt::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 23);
-    this->expect_true(cpuid::feature_information::ecx::popcnt::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::popcnt::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_tsc_deadline()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 24;
-    this->expect_true(cpuid::feature_information::ecx::tsc_deadline::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::tsc_deadline::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 24);
-    this->expect_true(cpuid::feature_information::ecx::tsc_deadline::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::tsc_deadline::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_aesni()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 25;
-    this->expect_true(cpuid::feature_information::ecx::aesni::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::aesni::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 25);
-    this->expect_true(cpuid::feature_information::ecx::aesni::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::aesni::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_xsave()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 26;
-    this->expect_true(cpuid::feature_information::ecx::xsave::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::xsave::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 26);
-    this->expect_true(cpuid::feature_information::ecx::xsave::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::xsave::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_osxsave()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 27;
-    this->expect_true(cpuid::feature_information::ecx::osxsave::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::osxsave::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 27);
-    this->expect_true(cpuid::feature_information::ecx::osxsave::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::osxsave::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_avx()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 28;
-    this->expect_true(cpuid::feature_information::ecx::avx::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::avx::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 28);
-    this->expect_true(cpuid::feature_information::ecx::avx::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::avx::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_f16c()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 29;
-    this->expect_true(cpuid::feature_information::ecx::f16c::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::f16c::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 29);
-    this->expect_true(cpuid::feature_information::ecx::f16c::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::f16c::get());
 }
 
 void
 intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_rdrand()
 {
     g_ecx_cpuid[cpuid::feature_information::addr] = 0x1UL << 30;
-    this->expect_true(cpuid::feature_information::ecx::rdrand::get() == 1U);
+    this->expect_true(cpuid::feature_information::ecx::rdrand::get());
 
     g_ecx_cpuid[cpuid::feature_information::addr] = ~(0x1U << 30);
-    this->expect_true(cpuid::feature_information::ecx::rdrand::get() == 0U);
+    this->expect_false(cpuid::feature_information::ecx::rdrand::get());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_feature_information_ecx_dump()
+{
+    g_ecx_cpuid[cpuid::feature_information::addr] = 0xFFFFFFFFU;
+    cpuid::feature_information::ecx::dump();
 }

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -85,7 +85,7 @@ vmxon_intel_x64::stop()
 void
 vmxon_intel_x64::check_cpuid_vmx_supported()
 {
-    if (cpuid::feature_information::ecx::vmx::get() == 0)
+    if (!cpuid::feature_information::ecx::vmx::get())
         throw std::logic_error("VMX extensions not supported");
 }
 


### PR DESCRIPTION
This patch moves the CPUID code to use the enable_if and bitmanip
functions

Signed-off-by: “Rian <“rianquinn@gmail.com”>