### PR TITLE
Fix Bug with Clang

### DIFF
--- a/bfdrivers/src/Makefile.bf
+++ b/bfdrivers/src/Makefile.bf
@@ -26,6 +26,7 @@
 TARGET_NAME:=driver_entry
 TARGET_TYPE:=lib
 TARGET_COMPILER:=native
+PRODUCTION=no
 
 ################################################################################
 # Compiler Flags

--- a/bfdrivers/test/Makefile.bf
+++ b/bfdrivers/test/Makefile.bf
@@ -26,6 +26,7 @@
 TARGET_NAME:=test
 TARGET_TYPE:=bin
 TARGET_COMPILER:=native
+PRODUCTION=no
 
 ################################################################################
 # Compiler Flags

--- a/bfelf_loader/src/Makefile.bf
+++ b/bfelf_loader/src/Makefile.bf
@@ -28,6 +28,7 @@ NO_ADDRESS_SANATIZE:=true
 TARGET_NAME:=bfelf_loader
 TARGET_TYPE:=lib
 TARGET_COMPILER:=native
+PRODUCTION=no
 
 ################################################################################
 # Compiler Flags

--- a/bfelf_loader/test/Makefile.bf
+++ b/bfelf_loader/test/Makefile.bf
@@ -28,6 +28,7 @@ NO_ADDRESS_SANATIZE:=true
 TARGET_NAME:=test
 TARGET_TYPE:=bin
 TARGET_COMPILER:=native
+PRODUCTION=no
 
 ################################################################################
 # Compiler Flags

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -78,7 +78,17 @@ CROSS_OUTDIR:=$(CROSS_OUTDIR)/cross
 # Exectuables
 ################################################################################
 
-ifeq ($(USE_LLVM_CLANG)$(shell uname -o),true Cygwin)
+ifeq ($(shell uname -o), Cygwin)
+    NATIVE_USE_LLVM_CLANG=false
+else
+	ifeq ($(USE_LLVM_CLANG), true)
+		NATIVE_USE_LLVM_CLANG=true
+	else
+		NATIVE_USE_LLVM_CLANG=false
+	endif
+endif
+
+ifeq ($(NATIVE_USE_LLVM_CLANG), true)
 	NATIVE_CC:=clang
 	NATIVE_CXX:=clang++
 	NATIVE_ASM:=nasm
@@ -227,8 +237,8 @@ CROSS_CXXFLAGS+=-DGSL_THROW_ON_CONTRACT_VIOLATION
 CROSS_CXXFLAGS+=$(CONFIGURED_CROSS_CXXFLAGS)
 
 ifeq ($(PRODUCTION),yes)
-	NATIVE_CXXFLAGS+=-O3 -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION -D_FORTIFY_SOURCE=2
-	CROSS_CXXFLAGS+=-O3 -DGSL_UNENFORCED_ON_CONTRACT_VIOLATION -D_FORTIFY_SOURCE=2
+	NATIVE_CXXFLAGS+=-O3 -D_FORTIFY_SOURCE=2
+	CROSS_CXXFLAGS+=-O3 -D_FORTIFY_SOURCE=2
 endif
 
 ifeq ($(COVERALLS), true)


### PR DESCRIPTION
Clang was not being used for native compilation when it should
have been on Linux. There was also a flag that should not
have been added that this removes. Finally this ensures the
unit tests actually compile and run with clang.

Signed-off-by: “Rian <“rianquinn@gmail.com”>