### PR TITLE
VMCall Cleanup

### DIFF
--- a/bfdrivers/src/arch/linux/entry.c
+++ b/bfdrivers/src/arch/linux/entry.c
@@ -348,7 +348,13 @@ ioctl_vmcall(struct vmcall_registers_t *regs)
     int64_t ret;
     struct vmcall_registers_t r;
 
-    ret = copy_from_user(&r, regs, sizeof(r));
+    if (regs == 0)
+    {
+        ALERT("IOCTL_VMCALL: regs == NULL\n");
+        return BF_IOCTL_FAILURE;
+    }
+
+    ret = copy_from_user(&r, regs, sizeof(struct vmcall_registers_t));
     if (ret != 0)
     {
         ALERT("IOCTL_VMCALL: failed to copy memory from userspace\n");
@@ -363,7 +369,12 @@ ioctl_vmcall(struct vmcall_registers_t *regs)
         return BF_IOCTL_FAILURE;
     }
 
-    ret = copy_to_user(regs, &r, sizeof(*regs));
+    ret = copy_to_user(regs, &r, sizeof(struct vmcall_registers_t));
+    if (ret != 0)
+    {
+        ALERT("IOCTL_VMCALL: failed to copy memory to userspace\n");
+        return BF_IOCTL_FAILURE;
+    }
 
     return BF_IOCTL_SUCCESS;
 }

--- a/include/vmcall_interface.h
+++ b/include/vmcall_interface.h
@@ -175,7 +175,7 @@ enum vmcall_opcode
      * VMM extensions to decide if an event can actually fail.
      *
      * In:
-     * r0 = VMCALL_VERSIONS
+     * r0 = VMCALL_EVENT
      * r1 = VMCALL_MAGIC_NUMBER
      * r2 = index
      *

--- a/tools/tests/test_hypervisor.sh
+++ b/tools/tests/test_hypervisor.sh
@@ -26,6 +26,7 @@
 
 CB='\033[1;35m'
 CC='\033[1;36m'
+CG='\033[1;32m'
 CE='\033[0m'
 
 # ------------------------------------------------------------------------------
@@ -45,6 +46,7 @@ stress_test() {
     make quick
     make clean
     make
+    make test
     make stop
     make driver_unload > /dev/null 2>&1
 }
@@ -154,3 +156,11 @@ vmcall_unittest
 vmcall_string_unformatted
 vmcall_string_json
 vmcall_data_unformatted
+
+# ------------------------------------------------------------------------------
+# Done
+# ------------------------------------------------------------------------------
+
+echo -e ""
+echo -e "$CC""completed:$CG Success$CE"
+echo -e ""


### PR DESCRIPTION
This patch cleans up some missing error handling in the
vmcall patch for Linux. This also extends the hypervisor
test to make it more complete, and easier to see if the
tests have passed

Signed-off-by: “Rian <“rianquinn@gmail.com”>