### PR TITLE
GDT Cleanup

### DIFF
--- a/bfvmm/include/intrinsics/gdt_x64.h
+++ b/bfvmm/include/intrinsics/gdt_x64.h
@@ -290,7 +290,6 @@ public:
         segment_descriptor_type sd2 = 0;
 
         expects(index != 0);
-        expects(index < m_gdt.size());
 
         sd1 = m_gdt.at(index);
         sd1 = (sd1 & 0x00FFFF000000FFFF);
@@ -321,8 +320,6 @@ public:
 
         if ((sd1 & 0x100000000000) == 0)
         {
-            expects(index + 1U < m_gdt.size());
-
             sd2 = m_gdt.at(index + 1U);
             sd2 = (sd2 & 0xFFFFFFFF00000000);
 
@@ -360,7 +357,6 @@ public:
         segment_descriptor_type sd2 = 0;
 
         expects(index != 0);
-        expects(index < m_gdt.size());
 
         // The segment base description can be found in the Intel's software
         // developer's manual, volume 3, chapter 3.4.5 as well as volume 3,
@@ -388,8 +384,6 @@ public:
 
         if ((sd1 & 0x100000000000) == 0)
         {
-            expects(index + 1U < m_gdt.size());
-
             sd2 = m_gdt.at(index + 1U);
             base_type base_63_32 = ((sd2 & 0x00000000FFFFFFFF) << 32);
 
@@ -416,8 +410,6 @@ public:
     void set_limit(index_type index, limit_type limit)
     {
         expects(index != 0);
-        expects(index < m_gdt.size());
-
         segment_descriptor_type sd1 = (m_gdt.at(index) & 0xFFF0FFFFFFFF0000);
 
         // The segment limit description can be found in the Intel's software
@@ -453,8 +445,6 @@ public:
     limit_type limit(index_type index) const
     {
         expects(index != 0);
-        expects(index < m_gdt.size());
-
         segment_descriptor_type sd1 = m_gdt.at(index);
 
         // The segment limit description can be found in the Intel's software
@@ -505,8 +495,6 @@ public:
     void set_access_rights(index_type index, access_rights_type access_rights)
     {
         expects(index != 0);
-        expects(index < m_gdt.size());
-
         segment_descriptor_type sd1 = (m_gdt.at(index) & 0xFF0F00FFFFFFFFFF);
 
         // The segment access description can be found in the intel's software
@@ -540,8 +528,6 @@ public:
     access_rights_type access_rights(index_type index) const
     {
         expects(index != 0);
-        expects(index < m_gdt.size());
-
         segment_descriptor_type sd1 = m_gdt.at(index);
 
         // The segment access description can be found in the Intel's software

--- a/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
@@ -110,14 +110,14 @@ void
 intrinsics_ut::test_gdt_set_base_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.set_base(1000, 0x10); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.set_base(1000, 0x10); }, ""_ut_ore);
 }
 
 void
 intrinsics_ut::test_gdt_set_base_tss_at_end_of_gdt()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.set_base(3, 0x10); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.set_base(3, 0x10); }, ""_ut_ore);
 }
 
 void
@@ -150,14 +150,14 @@ void
 intrinsics_ut::test_gdt_base_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.base(1000); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.base(1000); }, ""_ut_ore);
 }
 
 void
 intrinsics_ut::test_gdt_base_tss_at_end_of_gdt()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.base(3); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.base(3); }, ""_ut_ore);
 }
 
 void
@@ -190,7 +190,7 @@ void
 intrinsics_ut::test_gdt_set_limit_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.set_limit(1000, 0x10); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.set_limit(1000, 0x10); }, ""_ut_ore);
 }
 
 void
@@ -213,7 +213,7 @@ void
 intrinsics_ut::test_gdt_limit_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.limit(1000); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.limit(1000); }, ""_ut_ore);
 }
 
 void
@@ -245,7 +245,7 @@ void
 intrinsics_ut::test_gdt_set_access_rights_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.set_access_rights(1000, 0x10); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.set_access_rights(1000, 0x10); }, ""_ut_ore);
 }
 
 void
@@ -268,7 +268,7 @@ void
 intrinsics_ut::test_gdt_access_rights_invalid_index()
 {
     gdt_x64 gdt;
-    this->expect_exception([&] { gdt.access_rights(1000); }, ""_ut_ffe);
+    this->expect_exception([&] { gdt.access_rights(1000); }, ""_ut_ore);
 }
 
 void


### PR DESCRIPTION
This fixes a double bounds check issue with the GDT

Signed-off-by: “Rian <“rianquinn@gmail.com”>