### PR TITLE
Remove Double Compile

### DIFF
--- a/Makefile.bf
+++ b/Makefile.bf
@@ -58,10 +58,10 @@ endif
 # Subdirs
 ################################################################################
 
-PARENT_SUBDIRS += bfcrt
-PARENT_SUBDIRS += bfunwind
 PARENT_SUBDIRS += bfc
 PARENT_SUBDIRS += bfcxx
+PARENT_SUBDIRS += bfcrt
+PARENT_SUBDIRS += bfunwind
 PARENT_SUBDIRS += bfdrivers
 PARENT_SUBDIRS += bfelf_loader
 PARENT_SUBDIRS += bfm

--- a/bfcrt/src/crt.cpp
+++ b/bfcrt/src/crt.cpp
@@ -17,6 +17,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <gsl/gsl>
+
 #include <crt.h>
 #include <eh_frame_list.h>
 
@@ -25,7 +27,7 @@ typedef void (*dtor_t)();
 typedef void (*init_array_t)();
 typedef void (*fini_array_t)();
 
-int64_t
+extern "C" int64_t
 local_init(struct section_info_t *info)
 {
     if (info == nullptr)
@@ -35,20 +37,20 @@ local_init(struct section_info_t *info)
     {
         if (info->ctors_addr != nullptr)
         {
-            auto n = info->ctors_size >> 3;
-            auto ctors = static_cast<ctor_t *>(info->ctors_addr);
+            auto n = static_cast<std::ptrdiff_t>(info->ctors_size >> 3);
+            auto ctors = gsl::make_span(static_cast<ctor_t *>(info->ctors_addr), n);
 
-            for (auto i = 0U; i < n && ctors[i] != nullptr; i++)
-                ctors[i]();
+            for (auto i = 0U; i < n && ctors.at(i) != nullptr; i++)
+                ctors.at(i)();
         }
 
         if (info->init_array_addr != nullptr)
         {
-            auto n = info->init_array_size >> 3;
-            auto init_array = static_cast<init_array_t *>(info->init_array_addr);
+            auto n = static_cast<std::ptrdiff_t>(info->init_array_size >> 3);
+            auto init_array = gsl::make_span(static_cast<init_array_t *>(info->init_array_addr), n);
 
-            for (auto i = 0U; i < n && init_array[i] != nullptr; i++)
-                init_array[i]();
+            for (auto i = 0U; i < n && init_array.at(i) != nullptr; i++)
+                init_array.at(i)();
         }
     }
     catch (...)
@@ -63,7 +65,7 @@ local_init(struct section_info_t *info)
     return CRT_SUCCESS;
 }
 
-int64_t
+extern "C" int64_t
 local_fini(struct section_info_t *info)
 {
     if (info == nullptr)
@@ -73,20 +75,20 @@ local_fini(struct section_info_t *info)
     {
         if (info->fini_array_addr != nullptr)
         {
-            auto n = info->fini_array_size >> 3;
-            auto fini_array = static_cast<fini_array_t *>(info->fini_array_addr);
+            auto n = static_cast<std::ptrdiff_t>(info->fini_array_size >> 3);
+            auto fini_array = gsl::make_span(static_cast<fini_array_t *>(info->fini_array_addr), n);
 
-            for (auto i = 0U; i < n && fini_array[i] != nullptr; i++)
-                fini_array[i]();
+            for (auto i = 0U; i < n && fini_array.at(i) != nullptr; i++)
+                fini_array.at(i)();
         }
 
         if (info->dtors_addr != nullptr)
         {
-            auto n = info->dtors_size >> 3;
-            auto dtors = static_cast<dtor_t *>(info->dtors_addr);
+            auto n = static_cast<std::ptrdiff_t>(info->dtors_size >> 3);
+            auto dtors = gsl::make_span(static_cast<dtor_t *>(info->dtors_addr), n);
 
-            for (auto i = 0U; i < n && dtors[i] != nullptr; i++)
-                dtors[i]();
+            for (auto i = 0U; i < n && dtors.at(i) != nullptr; i++)
+                dtors.at(i)();
         }
     }
     catch (...)

--- a/bfcxx/Makefile.bf
+++ b/bfcxx/Makefile.bf
@@ -37,13 +37,13 @@ Makefile: $(HYPER_REL)/Makefile.bf
 
 ifneq ($(STATIC_ANALYSIS_ENABLED), true)
 
-all: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so
+all: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++abi.so $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so
 	@echo > /dev/null
 
-$(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++abi.a:
+$(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++abi.so: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc.a $(BUILD_ABS)/sysroot/x86_64-elf/lib/libbfc.a
 	$(BUILD_ABS)/build_scripts/x86_64-bareflank-docker $(BUILD_ABS)/build_scripts/build_libcxxabi.sh
 
-$(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++abi.a $(BUILD_ABS)/makefiles/bfunwind/bin/cross/libbfunwind_static.a $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc.a $(BUILD_ABS)/sysroot/x86_64-elf/lib/libbfc.a
+$(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++.so: $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc++abi.so $(BUILD_ABS)/sysroot/x86_64-elf/lib/libc.a $(BUILD_ABS)/sysroot/x86_64-elf/lib/libbfc.a
 	$(BUILD_ABS)/build_scripts/x86_64-bareflank-docker $(BUILD_ABS)/build_scripts/build_libcxx.sh
 
 build_src: all

--- a/bfdrivers/dummy_add_md_success/dummy_add_md_success.cpp
+++ b/bfdrivers/dummy_add_md_success/dummy_add_md_success.cpp
@@ -21,10 +21,11 @@
 
 #include <memory.h>
 
+int64_t return_success();
+
 extern "C" int64_t
 add_md(struct memory_descriptor *md)
 {
     (void) md;
-
-    return MEMORY_MANAGER_SUCCESS;
+    return return_success();
 }

--- a/bfdrivers/dummy_get_drr_success/dummy_get_drr_success.cpp
+++ b/bfdrivers/dummy_get_drr_success/dummy_get_drr_success.cpp
@@ -21,11 +21,13 @@
 
 #include <debug_ring_interface.h>
 
+int64_t return_success();
+
 extern "C" int64_t
 get_drr(uint64_t vcpuid, struct debug_ring_resources_t **drr)
 {
     (void) vcpuid;
     (void) drr;
 
-    return GET_DRR_SUCCESS;
+    return return_success();
 }

--- a/bfdrivers/dummy_misc/dummy_misc.cpp
+++ b/bfdrivers/dummy_misc/dummy_misc.cpp
@@ -23,19 +23,9 @@
 #include <stdint.h>
 #include <error_codes.h>
 
-int g_misc = 0;
-
-class test
-{
-public:
-    test() noexcept
-    { g_misc = 10; }
-
-    virtual ~test()
-    { g_misc = 20; }
-};
-
-test g_test;
+int64_t
+return_success()
+{ return SUCCESS; }
 
 void *
 operator new(size_t size)
@@ -69,12 +59,6 @@ sym_that_returns_success(int64_t val)
 }
 
 extern "C" int64_t
-get_misc(void)
-{
-    return g_misc;
-}
-
-extern "C" int64_t
 register_eh_frame(void *addr, uint64_t size)
 {
     (void) addr;
@@ -99,5 +83,19 @@ extern "C" int
 atexit(void (*function)(void))
 {
     (void) function;
+    return 0;
+}
+
+extern "C" int64_t
+local_init(struct section_info_t *info)
+{
+    (void) info;
+    return 0;
+}
+
+extern "C" int64_t
+local_fini(struct section_info_t *info)
+{
+    (void) info;
     return 0;
 }

--- a/bfdrivers/dummy_start_vmm_success/dummy_start_vmm_success.cpp
+++ b/bfdrivers/dummy_start_vmm_success/dummy_start_vmm_success.cpp
@@ -21,10 +21,11 @@
 
 #include <entry.h>
 
+int64_t return_success();
+
 extern "C" int64_t
 start_vmm(uint64_t arg)
 {
     (void) arg;
-
-    return ENTRY_SUCCESS;
+    return return_success();
 }

--- a/bfdrivers/dummy_stop_vmm_success/dummy_stop_vmm_success.cpp
+++ b/bfdrivers/dummy_stop_vmm_success/dummy_stop_vmm_success.cpp
@@ -21,10 +21,11 @@
 
 #include <entry.h>
 
+int64_t return_success();
+
 extern "C" int64_t
 stop_vmm(uint64_t arg)
 {
     (void) arg;
-
-    return ENTRY_SUCCESS;
+    return return_success();
 }

--- a/bfdrivers/test/test.cpp
+++ b/bfdrivers/test/test.cpp
@@ -208,7 +208,6 @@ driver_entry_ut::list()
     this->test_helper_execute_symbol_missing_symbol();
     this->test_helper_execute_symbol_sym_failed();
     this->test_helper_execute_symbol_sym_success();
-    this->test_helper_constructors_success();
     this->test_helper_add_md_to_memory_manager_null_module();
     this->test_helper_get_elf_file_size_null_module();
     this->test_helper_get_elf_file_size_get_segment_fails();

--- a/bfdrivers/test/test.h
+++ b/bfdrivers/test/test.h
@@ -124,8 +124,6 @@ private:
     void test_helper_execute_symbol_missing_symbol();
     void test_helper_execute_symbol_sym_failed();
     void test_helper_execute_symbol_sym_success();
-    void test_helper_constructors_success();
-    void test_helper_destructors_success();
     void test_helper_add_md_to_memory_manager_null_module();
     void test_helper_get_elf_file_size_null_module();
     void test_helper_get_elf_file_size_get_segment_fails();

--- a/bfdrivers/test/test_helpers.cpp
+++ b/bfdrivers/test/test_helpers.cpp
@@ -39,8 +39,6 @@ extern "C"
     int64_t add_md_to_memory_manager(struct module_t *module);
     uint64_t get_elf_file_size(struct module_t *module);
     int64_t load_elf_file(struct module_t *module);
-
-    typedef int64_t (*get_misc_t)();
 }
 
 // -----------------------------------------------------------------------------
@@ -166,21 +164,6 @@ driver_entry_ut::test_helper_execute_symbol_sym_success()
     EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
     EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
     EXPECT_TRUE(execute_symbol("sym_that_returns_success", 0, 0, 0) == 0);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-}
-
-void
-driver_entry_ut::test_helper_constructors_success()
-{
-    get_misc_t get_misc;
-
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    ASSERT_TRUE(resolve_symbol("get_misc", reinterpret_cast<void **>(&get_misc)) == BF_SUCCESS);
-    EXPECT_TRUE(get_misc() == 10);
     EXPECT_TRUE(common_fini() == BF_SUCCESS);
 }
 

--- a/bfelf_loader/dummy_code/dummy_code.cpp
+++ b/bfelf_loader/dummy_code/dummy_code.cpp
@@ -24,7 +24,6 @@
 int base::foo(int arg) noexcept
 {
     (void) arg;
-
     return 0;
 }
 

--- a/bfelf_loader/dummy_misc/dummy_misc.cpp
+++ b/bfelf_loader/dummy_misc/dummy_misc.cpp
@@ -76,7 +76,8 @@ static void dtor_func()
 extern "C" int __attribute__((weak))
 foo(int arg)
 {
-    return g_derived.foo(arg);
+    derived d;
+    return d.foo(arg);
 }
 
 void *
@@ -120,6 +121,27 @@ atexit(void (*function)(void))
 {
     (void) function;
     return 0;
+}
+
+extern "C" int64_t
+local_init(struct section_info_t *info)
+{
+    (void) info;
+    return 0;
+}
+
+extern "C" int64_t
+local_fini(struct section_info_t *info)
+{
+    (void) info;
+    return 0;
+}
+
+uintptr_t __stack_chk_guard = 0x595e9fbd94fda766;
+
+extern "C" void
+__stack_chk_fail(void) noexcept
+{
 }
 
 void func30() {}

--- a/bfm/bin/native/no_hyper_test.modules
+++ b/bfm/bin/native/no_hyper_test.modules
@@ -2,6 +2,9 @@
     "modules" :
     [
         "%BUILD_ABS%/sysroot/x86_64-elf/lib/libc++.so.1.0",
+        "%BUILD_ABS%/sysroot/x86_64-elf/lib/libc++abi.so.1.0",
+        "%BUILD_ABS%/makefiles/bfcrt/bin/cross/libbfcrt.so",
+        "%BUILD_ABS%/makefiles/bfunwind/bin/cross/libbfunwind.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/intrinsics/bin/cross/libintrinsics.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/memory_manager/bin/cross/libmemory_manager.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/misc/bin/cross/libmisc.so",

--- a/bfm/bin/native/vmm.modules
+++ b/bfm/bin/native/vmm.modules
@@ -2,6 +2,9 @@
     "modules" :
     [
         "%BUILD_ABS%/sysroot/x86_64-elf/lib/libc++.so.1.0",
+        "%BUILD_ABS%/sysroot/x86_64-elf/lib/libc++abi.so.1.0",
+        "%BUILD_ABS%/makefiles/bfcrt/bin/cross/libbfcrt.so",
+        "%BUILD_ABS%/makefiles/bfunwind/bin/cross/libbfunwind.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/debug_ring/bin/cross/libdebug_ring.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/entry/bin/cross/libentry.so",
         "%BUILD_ABS%/makefiles/bfvmm/src/exit_handler/bin/cross/libexit_handler.so",

--- a/bfvmm/src/misc/src/misc.cpp
+++ b/bfvmm/src/misc/src/misc.cpp
@@ -243,7 +243,7 @@ extern "C" int64_t
 register_eh_frame(void *addr, uint64_t size) noexcept
 {
     if (addr == nullptr || size == 0)
-        return REGISTER_EH_FRAME_FAILURE;
+        return REGISTER_EH_FRAME_SUCCESS;
 
     if (g_eh_frame_list_num >= MAX_NUM_MODULES)
         return REGISTER_EH_FRAME_FAILURE;

--- a/common/common_target.mk
+++ b/common/common_target.mk
@@ -642,11 +642,11 @@ $(CROSS_OBJDIR):
 $(CROSS_OUTDIR):
 	@$(MD) $(CROSS_OUTDIR)
 
-$(CROSS_OBJDIR)/%.o: %.c $(CROSS_OBJDIR)/%.d
+$(CROSS_OBJDIR)/%.o: %.c | $(CROSS_OBJDIR)/%.d
 	$(CROSS_CC) $(realpath $<) -o $@ -c $(CROSS_CCFLAGS) $(CROSS_DEPFLAGS)
 	$(CROSS_POSTCOMPILE)
 
-$(CROSS_OBJDIR)/%.o: %.cpp $(CROSS_OBJDIR)/%.d
+$(CROSS_OBJDIR)/%.o: %.cpp | $(CROSS_OBJDIR)/%.d
 	$(CROSS_CXX) $(realpath $<) -o $@ -c $(CROSS_CXXFLAGS) $(CROSS_DEPFLAGS)
 	$(CROSS_POSTCOMPILE)
 
@@ -703,11 +703,11 @@ $(NATIVE_OBJDIR):
 $(NATIVE_OUTDIR):
 	@$(MD) $(NATIVE_OUTDIR)
 
-$(NATIVE_OBJDIR)/%.o: %.c $(NATIVE_OBJDIR)/%.d
+$(NATIVE_OBJDIR)/%.o: %.c | $(NATIVE_OBJDIR)/%.d
 	$(NATIVE_CC) $(realpath $<) -o $@ -c $(NATIVE_CCFLAGS) $(NATIVE_DEPFLAGS)
 	$(NATIVE_POSTCOMPILE)
 
-$(NATIVE_OBJDIR)/%.o: %.cpp $(NATIVE_OBJDIR)/%.d
+$(NATIVE_OBJDIR)/%.o: %.cpp | $(NATIVE_OBJDIR)/%.d
 	$(NATIVE_CXX) $(realpath $<) -o $@ -c $(NATIVE_CXXFLAGS) $(NATIVE_DEPFLAGS)
 	$(NATIVE_POSTCOMPILE)
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -702,8 +702,8 @@ as_writeable_bytes(span<ElementType, Extent> s) noexcept
 //
 template <class ElementType>
 span<ElementType>
-make_span(ElementType *ptr, typename span<ElementType>::index_type &&count)
-{ return span<ElementType>(ptr, std::forward<typename span<ElementType>::index_type>(count)); }
+make_span(ElementType *ptr, typename span<ElementType>::index_type count)
+{ return span<ElementType>(ptr, count); }
 
 template <class ElementType>
 span<ElementType>

--- a/tools/scripts/bareflank_gcc_wrapper.sh
+++ b/tools/scripts/bareflank_gcc_wrapper.sh
@@ -270,43 +270,14 @@ done
 # Sysroot Libraries
 # ------------------------------------------------------------------------------
 
-# By default, bareflank does not support the use of libc or libc++ as static
-# libraries. Instead, libc is only used to create libc++, and libc++ must
-# be loaded at runtime, and thus does not need to be known during linking. The
-# only thing the hypervisor code should need from the sysroot is the includes.
-
-if [[ $BAREFLANK_WRAPPER_IS_LIBCXX == "true" ]]; then
-    SYSROOT_LIBS+="-lbfunwind_static -lc -lbfc "
-    SYSROOT_LIBS+="-u __cxa_throw_bad_array_new_length "
-fi
-
-SYSROOT_LIB_PATH="-L$BUILD_ABS/makefiles/bfcrt/bin/cross/ -L$BUILD_ABS/makefiles/bfunwind/bin/cross/ -L$BUILD_ABS/sysroot/x86_64-elf/lib/ "
+SYSROOT_LIBS="-lc -lbfc"
+SYSROOT_LIB_PATH="-L$BUILD_ABS/sysroot/x86_64-elf/lib/ "
 
 # ------------------------------------------------------------------------------
 # Sysroot Includes
 # ------------------------------------------------------------------------------
 
 SYSROOT_INC_PATH="-isystem $HOME/compilers/$compiler/x86_64-elf/include/ -isystem $BUILD_ABS/sysroot/x86_64-elf/include/ -isystem $BUILD_ABS/sysroot/x86_64-elf/include/c++/v1/ "
-
-# REMOVE ME ***
-# This is a dirty hack that makes sure the newlib header is there. This should
-# go away once we have our own libc
-# Note that there is another bug where running make more than once will cause
-# the libcrt and libunwind to get compiled twice. This is because the includes
-# change once installed. This will also get fixed once we have our own newlib
-if [[ -f "$BUILD_ABS/sysroot/x86_64-elf/include/newlib.h" ]]; then
-    SYSROOT_INC_PATH="-include $BUILD_ABS/sysroot/x86_64-elf/include/newlib.h $SYSROOT_INC_PATH"
-fi
-
-# ------------------------------------------------------------------------------
-# Libgcc
-# ------------------------------------------------------------------------------
-
-if [[ ! `pwd` == *"bfcrt"* && ! `pwd` == *"bfunwind"* ]]; then
-    if [[ $MODE == "link" ]] && [[ $TYPE == "shared" ]]; then
-        BAREFLANK_LIBS="-u local_init -u local_fini -lbfcrt_static "
-    fi
-fi
 
 # ------------------------------------------------------------------------------
 # Execute

--- a/tools/scripts/build_libcxx.sh
+++ b/tools/scripts/build_libcxx.sh
@@ -40,8 +40,6 @@ mkdir -p $BUILD_ABS/build_libcxx
 
 pushd $BUILD_ABS/build_libcxx
 
-export BAREFLANK_WRAPPER_IS_LIBCXX="true"
-
 if [[ $PRODUCTION == "yes" ]]; then
     BUILD_TYPE=Release
 else

--- a/tools/scripts/build_libcxxabi.sh
+++ b/tools/scripts/build_libcxxabi.sh
@@ -40,8 +40,6 @@ mkdir -p $BUILD_ABS/build_libcxxabi
 
 pushd $BUILD_ABS/build_libcxxabi
 
-export BAREFLANK_WRAPPER_IS_LIBCXXABI="true"
-
 if [[ ! -f "$BUILD_ABS/sysroot/x86_64-elf/include/unwind.h" ]]; then
     ln -s $HYPER_ABS/bfunwind/include/ia64_cxx_abi.h $BUILD_ABS/sysroot/x86_64-elf/include/unwind.h
 fi
@@ -60,7 +58,6 @@ cmake $BUILD_ABS/source_libcxxabi/ \
     -DLIBCXXABI_SYSROOT=$BUILD_ABS/sysroot/x86_64-elf/ \
     -DCMAKE_C_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-gcc \
     -DCMAKE_CXX_COMPILER=$BUILD_ABS/build_scripts/x86_64-bareflank-g++ \
-    -DLIBCXXABI_ENABLE_SHARED=OFF \
     -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
     -DLIBCXXABI_HAS_PTHREAD_API=ON \
     -DLLVM_ENABLE_LIBCXX=ON


### PR DESCRIPTION
This cleans up the dependencies of libcxx and libcxxabi, and
moves the compilation of bfcrt and bfunwind to after libcxx.
This not only cleans up a lot of the scripts and hackish
crap in the repo, but it also removes the double compile
problems. You can now:

./configure
make
make // <-- This should not recompile anything

Signed-off-by: “Rian <“rianquinn@gmail.com”>