### PR TITLE
Remove overuse of shared_ptr

### DIFF
--- a/bfvmm/include/debug_ring/debug_ring.h
+++ b/bfvmm/include/debug_ring/debug_ring.h
@@ -45,7 +45,7 @@ public:
 
     /// Debug Ring Destructor
     ///
-    virtual ~debug_ring() noexcept = default;
+    virtual ~debug_ring() noexcept;
 
     /// Write to Debug Ring
     ///
@@ -64,7 +64,8 @@ public:
 
 private:
 
-    std::shared_ptr<debug_ring_resources_t> m_drr;
+    uint64_t m_vcpuid;
+    std::unique_ptr<debug_ring_resources_t> m_drr;
 };
 
 /// Get Debug Ring Resource

--- a/bfvmm/include/memory_manager/page_table_x64.h
+++ b/bfvmm/include/memory_manager/page_table_x64.h
@@ -81,7 +81,7 @@ public:
     /// @return the resulting pte. Note that this pte is blank, and its
     ///     properties (like present) should be set by the caller
     ///
-    std::shared_ptr<page_table_entry_x64> add_page_x64(integer_pointer virt_addr);
+    gsl::not_null<page_table_entry_x64 *> add_page_x64(integer_pointer virt_addr);
 
     /// Remove Page
     ///
@@ -100,10 +100,10 @@ public:
 
 private:
 
-    template<class T> std::shared_ptr<T> add_pte(pointer p);
-    template<class T> std::shared_ptr<T> remove_pte();
+    template<class T> std::unique_ptr<T> add_pte(pointer p);
+    template<class T> std::unique_ptr<T> remove_pte();
 
-    std::shared_ptr<page_table_entry_x64> add_page_x64(integer_pointer virt_addr, integer_pointer bits);
+    gsl::not_null<page_table_entry_x64 *> add_page_x64(integer_pointer virt_addr, integer_pointer bits);
     void remove_page_x64(integer_pointer virt_addr, integer_pointer bits);
 
     auto empty() const noexcept
@@ -116,7 +116,7 @@ private:
 
     size_type m_size;
     integer_pointer m_cr3_shadow;
-    std::vector<std::shared_ptr<page_table_entry_x64>> m_ptes;
+    std::vector<std::unique_ptr<page_table_entry_x64>> m_ptes;
 
 public:
 

--- a/bfvmm/include/memory_manager/root_page_table_x64.h
+++ b/bfvmm/include/memory_manager/root_page_table_x64.h
@@ -22,6 +22,8 @@
 #ifndef ROOT_PAGE_TABLE_X64_H
 #define ROOT_PAGE_TABLE_X64_H
 
+#include <gsl/gsl>
+
 #include <memory.h>
 #include <memory_manager/page_table_x64.h>
 
@@ -110,7 +112,7 @@ private:
 
     root_page_table_x64() noexcept;
 
-    std::shared_ptr<page_table_entry_x64> add_page(integer_pointer virt);
+    gsl::not_null<page_table_entry_x64 *> add_page(integer_pointer virt);
     void remove_page(integer_pointer virt);
 
     void map_page(integer_pointer virt, integer_pointer phys, attr_type attr);

--- a/bfvmm/include/vcpu/vcpu_factory.h
+++ b/bfvmm/include/vcpu/vcpu_factory.h
@@ -60,7 +60,7 @@ public:
     /// @param attr attributes used to determine which type of vcpu to create
     /// @return returns a pointer to a newly created vCPU.
     ///
-    virtual std::shared_ptr<vcpu> make_vcpu(uint64_t vcpuid, void *attr = nullptr);
+    virtual std::unique_ptr<vcpu> make_vcpu(uint64_t vcpuid, void *attr = nullptr);
 };
 
 #endif

--- a/bfvmm/include/vcpu/vcpu_manager.h
+++ b/bfvmm/include/vcpu/vcpu_manager.h
@@ -101,20 +101,21 @@ public:
 private:
 
     vcpu_manager() noexcept;
-    std::shared_ptr<vcpu> get_vcpu(uint64_t vcpuid) const noexcept;
+    std::unique_ptr<vcpu> &add_vcpu(uint64_t vcpuid, void *attr);
+    std::unique_ptr<vcpu> &get_vcpu(uint64_t vcpuid);
 
 private:
 
     friend class vcpu_ut;
 
-    std::map<uint64_t, std::shared_ptr<vcpu>> m_vcpus;
+    std::map<uint64_t, std::unique_ptr<vcpu>> m_vcpus;
 
 private:
 
-    std::shared_ptr<vcpu_factory> m_vcpu_factory;
+    std::unique_ptr<vcpu_factory> m_vcpu_factory;
 
-    void set_factory(const std::shared_ptr<vcpu_factory> &factory)
-    { m_vcpu_factory = factory; }
+    void set_factory(std::unique_ptr<vcpu_factory> factory)
+    { m_vcpu_factory = std::move(factory); }
 
 public:
 

--- a/bfvmm/src/memory_manager/test/test_page_table_entry_x64.cpp
+++ b/bfvmm/src/memory_manager/test/test_page_table_entry_x64.cpp
@@ -30,7 +30,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_present()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_present(true);
     this->expect_true(pte->present());
@@ -46,7 +46,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_rw()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_rw(true);
     this->expect_true(pte->rw());
@@ -62,7 +62,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_us()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_us(true);
     this->expect_true(pte->us());
@@ -78,7 +78,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_pwt()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_pwt(true);
     this->expect_true(pte->pwt());
@@ -94,7 +94,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_pcd()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_pcd(true);
     this->expect_true(pte->pcd());
@@ -110,7 +110,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_accessed()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_accessed(true);
     this->expect_true(pte->accessed());
@@ -126,7 +126,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_dirty()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_dirty(true);
     this->expect_true(pte->dirty());
@@ -142,7 +142,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_pat()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_pat(true);
     this->expect_true(pte->pat());
@@ -158,7 +158,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_ps()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_ps(true);
     this->expect_true(pte->ps());
@@ -174,7 +174,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_global()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_global(true);
     this->expect_true(pte->global());
@@ -190,7 +190,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_nx()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_nx(true);
     this->expect_true(pte->nx());
@@ -206,7 +206,7 @@ void
 memory_manager_ut::test_page_table_entry_x64_phys_addr()
 {
     pte_type entry = 0;
-    auto &&pte = std::make_shared<page_table_entry_x64>(&entry);
+    auto &&pte = std::make_unique<page_table_entry_x64>(&entry);
 
     pte->set_present(true);
     pte->set_nx(true);

--- a/bfvmm/src/memory_manager/test/test_page_table_x64.cpp
+++ b/bfvmm/src/memory_manager/test/test_page_table_x64.cpp
@@ -46,7 +46,7 @@ memory_manager_ut::test_page_table_x64_no_entry()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pt = std::make_shared<page_table_x64>();
+        auto &&pt = std::make_unique<page_table_x64>();
 
         this->expect_true(pt->phys_addr() != 0);
         this->expect_true(pt->present());
@@ -72,7 +72,7 @@ memory_manager_ut::test_page_table_x64_with_entry()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         page_table_x64::integer_pointer entry = 0;
-        auto &&pt = std::make_shared<page_table_x64>(&entry);
+        auto &&pt = std::make_unique<page_table_x64>(&entry);
 
         this->expect_true(pt->phys_addr() != 0);
         this->expect_true(pt->present());
@@ -96,7 +96,7 @@ memory_manager_ut::test_page_table_x64_add_remove_page_success()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pml4 = std::make_shared<page_table_x64>();
+        auto &&pml4 = std::make_unique<page_table_x64>();
 
         pml4->add_page_x64(virt);
         this->expect_true(pml4->global_size() == 4);
@@ -126,7 +126,7 @@ memory_manager_ut::test_page_table_x64_add_remove_many_pages_success()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pml4 = std::make_shared<page_table_x64>();
+        auto &&pml4 = std::make_unique<page_table_x64>();
 
         for (auto i = 0U; i < 512; i++)
             pml4->add_page_x64(virt + (i * 0x1000U));
@@ -148,7 +148,7 @@ memory_manager_ut::test_page_table_x64_add_page_twice_failure()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pml4 = std::make_shared<page_table_x64>();
+        auto &&pml4 = std::make_unique<page_table_x64>();
 
         pml4->add_page_x64(virt);
         this->expect_exception([&]{ pml4->add_page_x64(virt); }, ""_ut_ree);
@@ -163,7 +163,7 @@ memory_manager_ut::test_page_table_x64_remove_page_twice_failure()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pml4 = std::make_shared<page_table_x64>();
+        auto &&pml4 = std::make_unique<page_table_x64>();
 
         pml4->add_page_x64(virt);
         pml4->add_page_x64(virt + 0x1000);
@@ -184,7 +184,7 @@ memory_manager_ut::test_page_table_x64_remove_page_unknown_failure()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto &&pml4 = std::make_shared<page_table_x64>();
+        auto &&pml4 = std::make_unique<page_table_x64>();
         this->expect_exception([&]{ pml4->remove_page_x64(virt); }, ""_ut_ree);
     });
 }

--- a/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
+++ b/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
@@ -40,7 +40,7 @@ __outb(uint16_t port, uint8_t val) noexcept
 void
 serial_ut::test_serial_null_intrinsics()
 {
-    EXPECT_NO_EXCEPTION(std::make_shared<serial_port_intel_x64>());
+    EXPECT_NO_EXCEPTION(std::make_unique<serial_port_intel_x64>());
 }
 
 void
@@ -65,7 +65,7 @@ serial_ut::test_serial_success()
 void
 serial_ut::test_serial_set_baud_rate_success()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_50);
     EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_50);
@@ -108,7 +108,7 @@ serial_ut::test_serial_set_baud_rate_success()
 void
 serial_ut::test_serial_set_data_bits_success()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_data_bits(serial_port_intel_x64::char_length_5);
     EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::char_length_5);
@@ -123,7 +123,7 @@ serial_ut::test_serial_set_data_bits_success()
 void
 serial_ut::test_serial_set_data_bits_success_extra_bits()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     auto bits = serial_port_intel_x64::DEFAULT_DATA_BITS | ~LINE_CONTROL_DATA_MASK;
     serial->set_data_bits(static_cast<serial_port_intel_x64::data_bits_t>(bits));
@@ -136,7 +136,7 @@ serial_ut::test_serial_set_data_bits_success_extra_bits()
 void
 serial_ut::test_serial_set_stop_bits_success()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_stop_bits(serial_port_intel_x64::stop_bits_1);
     EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::stop_bits_1);
@@ -147,7 +147,7 @@ serial_ut::test_serial_set_stop_bits_success()
 void
 serial_ut::test_serial_set_stop_bits_success_extra_bits()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     auto bits = serial_port_intel_x64::DEFAULT_STOP_BITS | ~LINE_CONTROL_STOP_MASK;
     serial->set_stop_bits(static_cast<serial_port_intel_x64::stop_bits_t>(bits));
@@ -160,7 +160,7 @@ serial_ut::test_serial_set_stop_bits_success_extra_bits()
 void
 serial_ut::test_serial_set_parity_bits_success()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_parity_bits(serial_port_intel_x64::parity_none);
     EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_none);
@@ -177,7 +177,7 @@ serial_ut::test_serial_set_parity_bits_success()
 void
 serial_ut::test_serial_set_parity_bits_success_extra_bits()
 {
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
 
     auto bits = serial_port_intel_x64::DEFAULT_PARITY_BITS | ~LINE_CONTROL_PARITY_MASK;
     serial->set_parity_bits(static_cast<serial_port_intel_x64::parity_bits_t>(bits));
@@ -192,7 +192,7 @@ serial_ut::test_serial_write_character()
 {
     g_ports[DEFAULT_COM_PORT + LINE_STATUS_REG] = 0xFF;
 
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write('c');
 }
 
@@ -201,6 +201,6 @@ serial_ut::test_serial_write_string()
 {
     g_ports[DEFAULT_COM_PORT + LINE_STATUS_REG] = 0xFF;
 
-    auto serial = std::make_shared<serial_port_intel_x64>();
+    auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write("hello world");
 }

--- a/bfvmm/src/vcpu/test/test_vcpu.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu.cpp
@@ -26,13 +26,13 @@
 void
 vcpu_ut::test_vcpu_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_shared<vcpu>(VCPUID_RESERVED, nullptr), std::invalid_argument);
+    EXPECT_EXCEPTION(std::make_unique<vcpu>(VCPUID_RESERVED, nullptr), std::invalid_argument);
 }
 
 void
 vcpu_ut::test_vcpu_null_debug_ring()
 {
-    EXPECT_NO_EXCEPTION(std::make_shared<vcpu>(0, nullptr));
+    EXPECT_NO_EXCEPTION(std::make_unique<vcpu>(0, nullptr));
 }
 
 void
@@ -40,7 +40,7 @@ vcpu_ut::test_vcpu_valid()
 {
     auto dr = std::shared_ptr<debug_ring>(nullptr);
 
-    EXPECT_NO_EXCEPTION(std::make_shared<vcpu>(0, dr));
+    EXPECT_NO_EXCEPTION(std::make_unique<vcpu>(0, dr));
 }
 
 void
@@ -48,7 +48,7 @@ vcpu_ut::test_vcpu_write_empty_string()
 {
     char rb[DEBUG_RING_SIZE];
     debug_ring_resources_t *drr = nullptr;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->write("");
     get_drr(0, &drr);
@@ -61,7 +61,7 @@ vcpu_ut::test_vcpu_write_hello_world()
 {
     char rb[DEBUG_RING_SIZE];
     debug_ring_resources_t *drr = nullptr;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->write("hello world");
     get_drr(0, &drr);
@@ -72,7 +72,7 @@ vcpu_ut::test_vcpu_write_hello_world()
 void
 vcpu_ut::test_vcpu_init_null_attr()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_initialized());
     vc->init(nullptr);
@@ -83,7 +83,7 @@ void
 vcpu_ut::test_vcpu_init_valid_attr()
 {
     int i = 0;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_initialized());
     vc->init(&i);
@@ -93,7 +93,7 @@ vcpu_ut::test_vcpu_init_valid_attr()
 void
 vcpu_ut::test_vcpu_fini_null_attr()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
 
@@ -106,7 +106,7 @@ void
 vcpu_ut::test_vcpu_fini_valid_attr()
 {
     int i = 0;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
 
@@ -118,7 +118,7 @@ vcpu_ut::test_vcpu_fini_valid_attr()
 void
 vcpu_ut::test_vcpu_fini_without_init_without_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     EXPECT_FALSE(vc->is_initialized());
@@ -130,7 +130,7 @@ vcpu_ut::test_vcpu_fini_without_init_without_run()
 void
 vcpu_ut::test_vcpu_fini_with_init_without_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
 
@@ -144,7 +144,7 @@ vcpu_ut::test_vcpu_fini_with_init_without_run()
 void
 vcpu_ut::test_vcpu_fini_without_init_with_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->run();
 
@@ -158,7 +158,7 @@ vcpu_ut::test_vcpu_fini_without_init_with_run()
 void
 vcpu_ut::test_vcpu_fini_with_init_with_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
     vc->run();
@@ -173,7 +173,7 @@ vcpu_ut::test_vcpu_fini_with_init_with_run()
 void
 vcpu_ut::test_vcpu_run_null_attr()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->run(nullptr);
@@ -184,7 +184,7 @@ void
 vcpu_ut::test_vcpu_run_valid_attr()
 {
     int i = 0;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->run(&i);
@@ -194,7 +194,7 @@ vcpu_ut::test_vcpu_run_valid_attr()
 void
 vcpu_ut::test_vcpu_run_without_init()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->run();
@@ -204,7 +204,7 @@ vcpu_ut::test_vcpu_run_without_init()
 void
 vcpu_ut::test_vcpu_run_with_init()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
 
@@ -216,7 +216,7 @@ vcpu_ut::test_vcpu_run_with_init()
 void
 vcpu_ut::test_vcpu_hlt_null_attr()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->hlt(nullptr);
@@ -227,7 +227,7 @@ void
 vcpu_ut::test_vcpu_hlt_valid_attr()
 {
     int i = 0;
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->hlt(&i);
@@ -237,7 +237,7 @@ vcpu_ut::test_vcpu_hlt_valid_attr()
 void
 vcpu_ut::test_vcpu_hlt_without_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
     vc->hlt();
@@ -247,7 +247,7 @@ vcpu_ut::test_vcpu_hlt_without_run()
 void
 vcpu_ut::test_vcpu_hlt_with_run()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->run();
 
@@ -259,7 +259,7 @@ vcpu_ut::test_vcpu_hlt_with_run()
 void
 vcpu_ut::test_vcpu_id()
 {
-    auto vc = std::make_shared<vcpu>(1);
+    auto vc = std::make_unique<vcpu>(1);
 
     EXPECT_TRUE(vc->id() == 1);
 }
@@ -267,7 +267,7 @@ vcpu_ut::test_vcpu_id()
 void
 vcpu_ut::test_vcpu_is_bootstrap_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_TRUE(vc->is_bootstrap_vcpu());
 }
@@ -275,7 +275,7 @@ vcpu_ut::test_vcpu_is_bootstrap_vcpu()
 void
 vcpu_ut::test_vcpu_is_not_bootstrap_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(1);
+    auto vc = std::make_unique<vcpu>(1);
 
     EXPECT_FALSE(vc->is_bootstrap_vcpu());
 }
@@ -283,7 +283,7 @@ vcpu_ut::test_vcpu_is_not_bootstrap_vcpu()
 void
 vcpu_ut::test_vcpu_is_host_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(1);
+    auto vc = std::make_unique<vcpu>(1);
 
     EXPECT_TRUE(vc->is_host_vm_vcpu());
 }
@@ -291,7 +291,7 @@ vcpu_ut::test_vcpu_is_host_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_not_host_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0x0000000100000000);
+    auto vc = std::make_unique<vcpu>(0x0000000100000000);
 
     EXPECT_FALSE(vc->is_host_vm_vcpu());
 }
@@ -299,7 +299,7 @@ vcpu_ut::test_vcpu_is_not_host_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_guest_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0x0000000100000000);
+    auto vc = std::make_unique<vcpu>(0x0000000100000000);
 
     EXPECT_TRUE(vc->is_guest_vm_vcpu());
 }
@@ -307,7 +307,7 @@ vcpu_ut::test_vcpu_is_guest_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_not_guest_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(1);
+    auto vc = std::make_unique<vcpu>(1);
 
     EXPECT_FALSE(vc->is_guest_vm_vcpu());
 }
@@ -315,7 +315,7 @@ vcpu_ut::test_vcpu_is_not_guest_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_running_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->run();
     EXPECT_TRUE(vc->is_running());
@@ -324,7 +324,7 @@ vcpu_ut::test_vcpu_is_running_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_not_running_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_running());
 }
@@ -332,7 +332,7 @@ vcpu_ut::test_vcpu_is_not_running_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_initialized_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
     EXPECT_TRUE(vc->is_initialized());
@@ -341,7 +341,7 @@ vcpu_ut::test_vcpu_is_initialized_vm_vcpu()
 void
 vcpu_ut::test_vcpu_is_not_initialized_vm_vcpu()
 {
-    auto vc = std::make_shared<vcpu>(0);
+    auto vc = std::make_unique<vcpu>(0);
 
     EXPECT_FALSE(vc->is_initialized());
 }

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -113,7 +113,7 @@ setup_pt(MockRepository &mocks)
 void
 vcpu_ut::test_vcpu_intel_x64_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_shared<vcpu_intel_x64>(VCPUID_RESERVED), std::invalid_argument);
+    EXPECT_EXCEPTION(std::make_unique<vcpu_intel_x64>(VCPUID_RESERVED), std::invalid_argument);
 }
 
 void
@@ -129,7 +129,7 @@ vcpu_ut::test_vcpu_intel_x64_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs));
+        EXPECT_NO_EXCEPTION(std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs));
     });
 }
 
@@ -142,7 +142,7 @@ vcpu_ut::test_vcpu_intel_x64_init_null_params()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr);
         vc->init();
     });
 }
@@ -168,7 +168,7 @@ vcpu_ut::test_vcpu_intel_x64_init_valid_params()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
     });
 }
@@ -194,7 +194,7 @@ vcpu_ut::test_vcpu_intel_x64_init_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
     });
 }
@@ -220,7 +220,7 @@ vcpu_ut::test_vcpu_intel_x64_init_vmcs_throws()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         EXPECT_EXCEPTION(vc->init(), std::logic_error);
     });
 }
@@ -234,7 +234,7 @@ vcpu_ut::test_vcpu_intel_x64_fini_null_params()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, nullptr, nullptr, nullptr, nullptr, nullptr);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, nullptr, nullptr, nullptr, nullptr, nullptr);
         vc->init();
         vc->fini();
     });
@@ -261,7 +261,7 @@ vcpu_ut::test_vcpu_intel_x64_fini_valid_params()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->fini();
     });
@@ -288,7 +288,7 @@ vcpu_ut::test_vcpu_intel_x64_fini_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->fini();
     });
@@ -310,7 +310,7 @@ vcpu_ut::test_vcpu_intel_x64_fini_no_init()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->fini();
     });
 }
@@ -342,7 +342,7 @@ vcpu_ut::test_vcpu_intel_x64_run_launch()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
     });
@@ -375,7 +375,7 @@ vcpu_ut::test_vcpu_intel_x64_run_launch_is_host_vcpu()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
     });
@@ -408,7 +408,7 @@ vcpu_ut::test_vcpu_intel_x64_run_resume()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
         vc->run();
@@ -442,7 +442,7 @@ vcpu_ut::test_vcpu_intel_x64_run_no_init()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         EXPECT_EXCEPTION(vc->run(), std::runtime_error);
     });
 }
@@ -474,7 +474,7 @@ vcpu_ut::test_vcpu_intel_x64_run_vmxon_throws()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         EXPECT_EXCEPTION(vc->run(), std::runtime_error);
     });
@@ -507,7 +507,7 @@ vcpu_ut::test_vcpu_intel_x64_run_vmcs_throws()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         EXPECT_EXCEPTION(vc->run(), std::runtime_error);
     });
@@ -540,7 +540,7 @@ vcpu_ut::test_vcpu_intel_x64_hlt_no_init()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
         vc->hlt();
     });
 }
@@ -572,7 +572,7 @@ vcpu_ut::test_vcpu_intel_x64_hlt_no_run()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->hlt();
     });
@@ -605,7 +605,7 @@ vcpu_ut::test_vcpu_intel_x64_hlt_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0x0001000000000000, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
         vc->hlt();
@@ -639,7 +639,7 @@ vcpu_ut::test_vcpu_intel_x64_hlt_valid_is_host_vcpu()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
         vc->hlt();
@@ -673,7 +673,7 @@ vcpu_ut::test_vcpu_intel_x64_hlt_vmxon_throws()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        auto vc = std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
+        auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
         EXPECT_EXCEPTION(vc->hlt(), std::runtime_error);

--- a/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
@@ -24,16 +24,16 @@
 #include <vcpu/vcpu_manager.h>
 
 extern bool make_vcpu_throws;
-extern std::shared_ptr<vcpu> g_vcpu;
+extern vcpu *g_vcpu;
 
 void
 vcpu_ut::test_vcpu_manager_create_valid()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -48,10 +48,10 @@ void
 vcpu_ut::test_vcpu_manager_create_valid_twice_overwrites()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -81,10 +81,10 @@ void
 vcpu_ut::test_vcpu_manager_create_init_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init).Throw(std::runtime_error("error"));
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -99,10 +99,10 @@ void
 vcpu_ut::test_vcpu_manager_delete_valid()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -117,10 +117,10 @@ void
 vcpu_ut::test_vcpu_manager_delete_valid_twice()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -136,10 +136,10 @@ void
 vcpu_ut::test_vcpu_manager_delete_no_create()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -153,10 +153,10 @@ void
 vcpu_ut::test_vcpu_manager_delete_fini_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini).Throw(std::runtime_error("error"));
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -171,14 +171,14 @@ void
 vcpu_ut::test_vcpu_manager_run_valid()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -194,14 +194,14 @@ void
 vcpu_ut::test_vcpu_manager_run_valid_twice()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -218,14 +218,14 @@ void
 vcpu_ut::test_vcpu_manager_run_run_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run).Throw(std::runtime_error("error"));
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -241,14 +241,14 @@ void
 vcpu_ut::test_vcpu_manager_run_hlt_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run).Throw(std::runtime_error("error"));
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt).Throw(std::logic_error("error"));
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::hlt).Throw(std::logic_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -264,14 +264,14 @@ void
 vcpu_ut::test_vcpu_manager_run_is_guest_vm_vcpu_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Throw(std::runtime_error("error"));
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -287,14 +287,14 @@ void
 vcpu_ut::test_vcpu_manager_run_no_create()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -308,14 +308,14 @@ void
 vcpu_ut::test_vcpu_manager_run_is_running()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -331,14 +331,14 @@ void
 vcpu_ut::test_vcpu_manager_run_is_guest_vm()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(true);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(true);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -354,21 +354,21 @@ void
 vcpu_ut::test_vcpu_manager_hlt_valid()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
 
-        mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
+        mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
         EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
         g_vcm->delete_vcpu(0);
@@ -381,21 +381,21 @@ void
 vcpu_ut::test_vcpu_manager_hlt_valid_twice()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
 
-        mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
+        mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
         EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
         EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
@@ -409,21 +409,21 @@ void
 vcpu_ut::test_vcpu_manager_hlt_hlt_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt).Throw(std::runtime_error("error"));
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt).Throw(std::runtime_error("error"));
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
 
-        mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
+        mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
         EXPECT_EXCEPTION(g_vcm->hlt_vcpu(0), std::runtime_error);
         g_vcm->delete_vcpu(0);
@@ -436,22 +436,22 @@ void
 vcpu_ut::test_vcpu_manager_hlt_is_guest_vm_vcpu_throws()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
 
-        mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
-        mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Throw(std::runtime_error("error"));
+        mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
+        mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Throw(std::runtime_error("error"));
 
         EXPECT_EXCEPTION(g_vcm->hlt_vcpu(0), std::runtime_error);
         g_vcm->delete_vcpu(0);
@@ -464,14 +464,14 @@ void
 vcpu_ut::test_vcpu_manager_hlt_no_create()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -485,14 +485,14 @@ void
 vcpu_ut::test_vcpu_manager_hlt_is_running()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(false);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -509,21 +509,21 @@ void
 vcpu_ut::test_vcpu_manager_hlt_is_guest_vm()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.OnCall(g_vcpu.get(), vcpu::run);
-    mocks.OnCall(g_vcpu.get(), vcpu::hlt);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(false);
-    mocks.OnCall(g_vcpu.get(), vcpu::is_guest_vm_vcpu).Return(true);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.OnCall(g_vcpu, vcpu::run);
+    mocks.OnCall(g_vcpu, vcpu::hlt);
+    mocks.OnCall(g_vcpu, vcpu::is_running).Return(false);
+    mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Return(true);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
 
-        mocks.OnCall(g_vcpu.get(), vcpu::is_running).Return(true);
+        mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
         EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
         g_vcm->delete_vcpu(0);
@@ -536,11 +536,11 @@ void
 vcpu_ut::test_vcpu_manager_write_null()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.ExpectCall(g_vcpu.get(), vcpu::write).With(""_s);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.ExpectCall(g_vcpu, vcpu::write).With(""_s);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -556,11 +556,11 @@ void
 vcpu_ut::test_vcpu_manager_write_hello()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.ExpectCall(g_vcpu.get(), vcpu::write).With("hello"_s);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.ExpectCall(g_vcpu, vcpu::write).With("hello"_s);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
@@ -576,11 +576,11 @@ void
 vcpu_ut::test_vcpu_manager_write_no_create()
 {
     MockRepository mocks;
-    g_vcpu = bfn::mock_shared<vcpu>(mocks);
+    g_vcpu = bfn::mock_no_delete<vcpu>(mocks);
 
-    mocks.OnCall(g_vcpu.get(), vcpu::init);
-    mocks.OnCall(g_vcpu.get(), vcpu::fini);
-    mocks.NeverCall(g_vcpu.get(), vcpu::write);
+    mocks.OnCall(g_vcpu, vcpu::init);
+    mocks.OnCall(g_vcpu, vcpu::fini);
+    mocks.NeverCall(g_vcpu, vcpu::write);
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {

--- a/bfvmm/src/vcpu_factory/src/vcpu_factory.cpp
+++ b/bfvmm/src/vcpu_factory/src/vcpu_factory.cpp
@@ -22,10 +22,9 @@
 #include <vcpu/vcpu_factory.h>
 #include <vcpu/vcpu_intel_x64.h>
 
-std::shared_ptr<vcpu>
+std::unique_ptr<vcpu>
 vcpu_factory::make_vcpu(uint64_t vcpuid, void *attr)
 {
     (void) attr;
-
-    return std::make_shared<vcpu_intel_x64>(vcpuid);
+    return std::make_unique<vcpu_intel_x64>(vcpuid);
 }

--- a/include/unittest.h
+++ b/include/unittest.h
@@ -515,12 +515,31 @@ namespace bfn
 ///
 /// @code
 /// MockRepository mocks;
-/// auto in = bfn::mock_shared<intrinsics_intel_x64>(mocks);
+/// auto f = bfn::mock_shared<foo>(mocks);
 /// @endcode
 ///
 template<class T> auto
 mock_shared(MockRepository &mocks)
 { return std::shared_ptr<T>(mocks.Mock<T>(), no_delete<T>); }
+
+/// Mock No Delete
+///
+/// If the destructor of the class is called, this function prevents a
+/// crash by registering a call to the destructor to do nothing.
+///
+/// @code
+/// MockRepository mocks;
+/// auto f = bfn::mock_no_delete<foo>(mocks);
+/// @endcode
+///
+template<class T> auto
+mock_no_delete(MockRepository &mocks)
+{
+    auto &&ptr = mocks.Mock<T>();
+    mocks.OnCallDestructor(ptr);
+
+    return ptr;
+}
 
 }
 


### PR DESCRIPTION
We are using shared_ptr too much when it's really not needed.
This not only adds overhead, but it is misleading. This patch
removes all but a couple instances of shared_ptr where it is
not needed. A future patch will remove the remaining uses
in an attempt to keep this patch smaller.

Signed-off-by: “Rian <“rianquinn@gmail.com”>