### PR TITLE
rm std string

### DIFF
--- a/bfvmm/include/intrinsics/vmx_intel_x64.h
+++ b/bfvmm/include/intrinsics/vmx_intel_x64.h
@@ -57,7 +57,7 @@ namespace vm
 {
     using field_type = uint64_t;
     using value_type = uint64_t;
-    using name_type = const std::string;
+    using name_type = const char *;
 
     inline void clear(gsl::not_null<void *> ptr)
     {
@@ -77,7 +77,7 @@ namespace vm
             throw std::runtime_error("vm::reset failed");
     }
 
-    inline auto read(field_type field, name_type &name = {})
+    inline auto read(field_type field, name_type name = "")
     {
         value_type value;
 
@@ -92,7 +92,7 @@ namespace vm
         return value;
     }
 
-    inline void write(field_type field, value_type value, name_type &name = {})
+    inline void write(field_type field, value_type value, name_type name = "")
     {
         if (!__vmwrite(field, value))
         {

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_control_fields.h
@@ -70,28 +70,28 @@ namespace pin_based_vm_execution_controls
         constexpr const auto name = "external_interrupt_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace nmi_exiting
@@ -101,28 +101,28 @@ namespace pin_based_vm_execution_controls
         constexpr const auto name = "nmi_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace virtual_nmis
@@ -132,28 +132,28 @@ namespace pin_based_vm_execution_controls
         constexpr const auto name = "virtual_nmis";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace activate_vmx_preemption_timer
@@ -163,28 +163,28 @@ namespace pin_based_vm_execution_controls
         constexpr const auto name = "activate_vmx_preemption_timer";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace process_posted_interrupts
@@ -194,28 +194,28 @@ namespace pin_based_vm_execution_controls
         constexpr const auto name = "process_posted_interrupts";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 }
 
@@ -248,28 +248,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "interrupt_window_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace use_tsc_offsetting
@@ -279,28 +279,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "use_tsc_offsetting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace hlt_exiting
@@ -310,28 +310,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "hlt_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace invlpg_exiting
@@ -341,28 +341,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "invlpg_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace mwait_exiting
@@ -372,28 +372,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "mwait_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace rdpmc_exiting
@@ -403,28 +403,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "rdpmc_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace rdtsc_exiting
@@ -434,28 +434,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "rdtsc_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace cr3_load_exiting
@@ -465,28 +465,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "cr3_load_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace cr3_store_exiting
@@ -496,28 +496,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "cr3_store_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace cr8_load_exiting
@@ -527,28 +527,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "cr8_load_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace cr8_store_exiting
@@ -558,28 +558,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "cr8_store_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace use_tpr_shadow
@@ -589,28 +589,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "use_tpr_shadow";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace nmi_window_exiting
@@ -620,28 +620,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "nmi_window_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace mov_dr_exiting
@@ -651,28 +651,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "mov_dr_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace unconditional_io_exiting
@@ -682,28 +682,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "unconditional_io_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace use_io_bitmaps
@@ -713,28 +713,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "use_io_bitmaps";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace monitor_trap_flag
@@ -743,30 +743,29 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto from = 27;
         constexpr const auto name = "monitor_trap_flag";
 
-        inline auto
-        is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        inline auto is_enabled()
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace use_msr_bitmaps
@@ -776,29 +775,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "use_msr_bitmaps";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
-        inline auto
-        is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        inline auto is_disabled_if_exists(bool verbose = false) noexcept
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace monitor_exiting
@@ -808,28 +806,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "monitor_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace pause_exiting
@@ -839,28 +837,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "pause_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace activate_secondary_controls
@@ -870,28 +868,28 @@ namespace primary_processor_based_vm_execution_controls
         constexpr const auto name = "activate_secondary_controls";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 }
 
@@ -1012,28 +1010,28 @@ namespace vm_exit_controls
         constexpr const auto name = "save_debug_controls";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace host_address_space_size
@@ -1043,28 +1041,28 @@ namespace vm_exit_controls
         constexpr const auto name = "host_address_space_size";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_perf_global_ctrl
@@ -1074,28 +1072,28 @@ namespace vm_exit_controls
         constexpr const auto name = "load_ia32_perf_global_ctrl";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace acknowledge_interrupt_on_exit
@@ -1105,28 +1103,28 @@ namespace vm_exit_controls
         constexpr const auto name = "acknowledge_interrupt_on_exit";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace save_ia32_pat
@@ -1136,28 +1134,28 @@ namespace vm_exit_controls
         constexpr const auto name = "save_ia32_pat";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_pat
@@ -1167,28 +1165,28 @@ namespace vm_exit_controls
         constexpr const auto name = "load_ia32_pat";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace save_ia32_efer
@@ -1198,28 +1196,28 @@ namespace vm_exit_controls
         constexpr const auto name = "save_ia32_efer";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_efer
@@ -1229,28 +1227,28 @@ namespace vm_exit_controls
         constexpr const auto name = "load_ia32_efer";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace save_vmx_preemption_timer_value
@@ -1260,28 +1258,28 @@ namespace vm_exit_controls
         constexpr const auto name = "save_vmx_preemption_timer_value";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 }
 
@@ -1358,28 +1356,28 @@ namespace vm_entry_controls
         constexpr const auto name = "load_debug_controls";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace ia_32e_mode_guest
@@ -1389,28 +1387,28 @@ namespace vm_entry_controls
         constexpr const auto name = "ia_32e_mode_guest";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace entry_to_smm
@@ -1420,28 +1418,28 @@ namespace vm_entry_controls
         constexpr const auto name = "entry_to_smm";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace deactivate_dual_monitor_treatment
@@ -1451,28 +1449,28 @@ namespace vm_entry_controls
         constexpr const auto name = "deactivate_dual_monitor_treatment";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_perf_global_ctrl
@@ -1482,28 +1480,28 @@ namespace vm_entry_controls
         constexpr const auto name = "load_ia32_perf_global_ctrl";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_pat
@@ -1513,28 +1511,28 @@ namespace vm_entry_controls
         constexpr const auto name = "load_ia32_pat";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace load_ia32_efer
@@ -1544,28 +1542,28 @@ namespace vm_entry_controls
         constexpr const auto name = "load_ia32_efer";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 }
 
@@ -1696,7 +1694,8 @@ namespace vm_entry_interruption_information_field
         inline void enable()
         {
             auto&& field = get_vmcs_field(addr, name, exists());
-            set_vmcs_field(set_bit(field, from), addr, name, exists()); }
+            set_vmcs_field(set_bit(field, from), addr, name, exists());
+        }
 
         inline void enable_if_exists(bool verbose = false) noexcept
         {
@@ -1882,28 +1881,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "virtualize_apic_accesses";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_ept
@@ -1913,28 +1912,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_ept";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace descriptor_table_exiting
@@ -1944,28 +1943,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "descriptor_table_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_rdtscp
@@ -1975,28 +1974,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_rdtscp";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace virtualize_x2apic_mode
@@ -2006,28 +2005,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "virtualize_x2apic_mode";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_vpid
@@ -2037,28 +2036,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_vpid";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace wbinvd_exiting
@@ -2068,28 +2067,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "wbinvd_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace unrestricted_guest
@@ -2099,28 +2098,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "unrestricted_guest";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace apic_register_virtualization
@@ -2130,28 +2129,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "apic_register_virtualization";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace virtual_interrupt_delivery
@@ -2161,28 +2160,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "virtual_interrupt_delivery";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace pause_loop_exiting
@@ -2192,28 +2191,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "pause_loop_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace rdrand_exiting
@@ -2223,28 +2222,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "rdrand_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_invpcid
@@ -2254,28 +2253,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_invpcid";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_vm_functions
@@ -2285,28 +2284,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_vm_functions";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace vmcs_shadowing
@@ -2316,28 +2315,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "vmcs_shadowing";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace rdseed_exiting
@@ -2347,28 +2346,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "rdseed_exiting";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_pml
@@ -2378,28 +2377,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_pml";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace ept_violation_ve
@@ -2409,28 +2408,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "ept_violation_ve";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 
     namespace enable_xsaves_xrstors
@@ -2440,28 +2439,28 @@ namespace secondary_processor_based_vm_execution_controls
         constexpr const auto name = "enable_xsaves_xrstors";
 
         inline auto is_enabled()
-        { return get_vm_control(addr, name, mask, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_enabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) != 0U; }
+        { return is_bit_set(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline auto is_disabled()
-        { return get_vm_control(addr, name, mask, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field(addr, name, exists()), from); }
 
         inline auto is_disabled_if_exists(bool verbose = false) noexcept
-        { return get_vm_control_if_exists(addr, name, mask, verbose, exists()) == 0U; }
+        { return is_bit_cleared(get_vmcs_field_if_exists(addr, name, verbose, exists()), from); }
 
         inline void enable()
-        { set_vm_control(1UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(true, msr_addr, addr, name, mask, exists()); }
 
         inline void enable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(1UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(true, msr_addr, addr, name, mask, verbose, exists()); }
 
         inline void disable()
-        { set_vm_control(0UL, msr_addr, addr, name, mask, exists()); }
+        { set_vm_control(false, msr_addr, addr, name, mask, exists()); }
 
         inline void disable_if_allowed(bool verbose = false) noexcept
-        { set_vm_control_if_allowed(0UL, msr_addr, addr, name, mask, verbose, exists()); }
+        { set_vm_control_if_allowed(false, msr_addr, addr, name, mask, verbose, exists()); }
     }
 }
 

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
@@ -1,0 +1,55 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+// Author: Connor Davis      <davisc@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_INTEL_X64_32BIT_READ_ONLY_DATA_FIELDS_H
+#define VMCS_INTEL_X64_32BIT_READ_ONLY_DATA_FIELDS_H
+
+#include <bitmanip.h>
+#include <vmcs/vmcs_intel_x64.h>
+
+// *INDENT-OFF*
+namespace intel_x64
+{
+namespace vmcs
+{
+
+namespace vm_exit_instruction_length
+{
+    constexpr const auto addr = 0x000000000000440CUL;
+    constexpr const auto name = "vm_exit_instruction_length";
+
+    inline auto exists() noexcept
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -38,6 +38,7 @@
 #include <intrinsics/vmx_intel_x64.h>
 
 #include <vmcs/vmcs_intel_x64_32bit_guest_state_fields.h>
+#include <vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h>
 
 using namespace x64;
 using namespace intel_x64;
@@ -61,7 +62,7 @@ exit_handler_intel_x64::dispatch()
     m_exit_qualification =
         vm::read(VMCS_EXIT_QUALIFICATION);
     m_exit_instruction_length =
-        vm::read(VMCS_VM_EXIT_INSTRUCTION_LENGTH);
+        vmcs::vm_exit_instruction_length::get();
     m_exit_instruction_information =
         vm::read(VMCS_VM_EXIT_INSTRUCTION_INFORMATION);
 

--- a/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
@@ -29,6 +29,8 @@
 
 #include <intrinsics/msrs_intel_x64.h>
 
+#include <vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h>
+
 using namespace x64;
 using namespace intel_x64;
 
@@ -54,7 +56,7 @@ __vmread(uint64_t field, uint64_t *val) noexcept
         case VMCS_EXIT_QUALIFICATION:
             *val = g_exit_qualification;
             break;
-        case VMCS_VM_EXIT_INSTRUCTION_LENGTH:
+        case vmcs::vm_exit_instruction_length::addr:
             *val = g_exit_instruction_length;
             break;
         case VMCS_VM_EXIT_INSTRUCTION_INFORMATION:

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -205,8 +205,6 @@ vmcs_ut::list()
     this->test_get_vmcs_field_if_exists();
     this->test_set_vmcs_field();
     this->test_set_vmcs_field_if_exists();
-    this->test_get_vm_control();
-    this->test_get_vm_control_if_exists();
     this->test_set_vm_control();
     this->test_set_vm_control_if_allowed();
     this->test_vmcs_virtual_processor_identifier();

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -116,8 +116,6 @@ private:
     void test_get_vmcs_field_if_exists();
     void test_set_vmcs_field();
     void test_set_vmcs_field_if_exists();
-    void test_get_vm_control();
-    void test_get_vm_control_if_exists();
     void test_set_vm_control();
     void test_set_vm_control_if_allowed();
     void test_vmcs_virtual_processor_identifier();

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
@@ -361,21 +361,20 @@ vmcs_ut::test_resume_failure()
 void
 vmcs_ut::test_get_vmcs_field()
 {
-    std::string name("field");
-    std::string what = std::string("get_vmcs_field_failed: ") + name + " field doesn't exist";
+    constexpr const auto name = "field";
     auto exists = true;
 
-    this->expect_exception([&] { get_vmcs_field(0U, name, !exists); }, std::make_shared<std::logic_error>(what));
+    this->expect_exception([&] { get_vmcs_field(0U, name, !exists); },
+                           std::make_shared<std::logic_error>("field doesn't exist"));
 
     g_vmcs_fields[0U] = 42U;
-
     this->expect_true(get_vmcs_field(0U, name, exists) == 42U);
 }
 
 void
 vmcs_ut::test_get_vmcs_field_if_exists()
 {
-    std::string name("field");
+    constexpr const auto name = "field";
 
     auto exists = true;
     auto verbose = true;
@@ -388,13 +387,12 @@ vmcs_ut::test_get_vmcs_field_if_exists()
 void
 vmcs_ut::test_set_vmcs_field()
 {
-    std::string name("field");
-    std::string what = std::string("set_vmcs_field failed: ") + name + "field doesn't exist";
-
+    constexpr const auto name("field");
     auto exists = true;
     g_vmcs_fields[0U] = 0U;
+
     this->expect_exception([&] { set_vmcs_field(1U, 0U, name, !exists); },
-                           std::make_shared<std::logic_error>(what));
+                           std::make_shared<std::logic_error>("doesn't exist"));
     this->expect_true(g_vmcs_fields[0U] == 0U);
 
     this->expect_no_exception([&] { set_vmcs_field(1U, 0U, name, exists); });
@@ -404,8 +402,7 @@ vmcs_ut::test_set_vmcs_field()
 void
 vmcs_ut::test_set_vmcs_field_if_exists()
 {
-    std::string name("field");
-
+    constexpr const auto name("field");
     auto exists = true;
     auto verbose = true;
     g_vmcs_fields[0U] = 42U;
@@ -424,44 +421,16 @@ vmcs_ut::test_set_vmcs_field_if_exists()
 }
 
 void
-vmcs_ut::test_get_vm_control()
-{
-    auto name("control");
-    std::string what = std::string("can't get ") + name + ": corresponding vmcs field doesn't exist";
-
-    auto exists = true;
-    auto mask = 0x0000000000000002UL;
-    g_vmcs_fields[0U] = mask;
-
-    this->expect_exception([&] { get_vm_control(0U, name, mask, !exists); },
-                           std::make_shared<std::logic_error>(what));
-    this->expect_true(get_vm_control(0U, name, mask, exists) == mask);
-}
-
-void
-vmcs_ut::test_get_vm_control_if_exists()
-{
-    auto name("control");
-    auto exists = true;
-    auto verbose = true;
-    auto mask = 0x8UL;
-    g_vmcs_fields[0U] = mask;
-
-    this->expect_true(get_vm_control_if_exists(0U, name, mask, verbose, !exists) == 0UL);
-    this->expect_true(get_vm_control_if_exists(0U, name, mask, verbose, exists) == mask);
-}
-
-void
 vmcs_ut::test_set_vm_control()
 {
-    auto name("control");
+    constexpr const auto name = "control";
     auto exists = true;
     auto mask = 0x0000000000000040UL;
     auto ctls_addr = 0UL;
     auto msr_addr = 0U;
 
     this->expect_exception([&] { set_vm_control(1UL, msr_addr, ctls_addr, name, mask, !exists); },
-                           std::make_shared<std::logic_error>(std::string(name) + "'s corresponding vmcs field doesn't exist"));
+                           std::make_shared<std::logic_error>("vmcs field doesn't exist"));
 
     g_msrs[msr_addr] = ~mask;
     this->expect_no_exception([&] { set_vm_control(0UL, msr_addr, ctls_addr, name, mask, exists); });
@@ -469,7 +438,7 @@ vmcs_ut::test_set_vm_control()
 
     g_msrs[msr_addr] = mask;
     this->expect_exception([&] { set_vm_control(0UL, msr_addr, ctls_addr, name, mask, exists); },
-                           std::make_shared<std::logic_error>(std::string(name) + " is not allowed to be cleared to 0"));
+                           std::make_shared<std::logic_error>("control is not allowed to be cleared to 0"));
 
     g_msrs[msr_addr] = mask << 32;
     this->expect_no_exception([&] { set_vm_control(1UL, msr_addr, ctls_addr, name, mask, exists); });
@@ -477,13 +446,13 @@ vmcs_ut::test_set_vm_control()
 
     g_msrs[msr_addr] = ~(mask << 32);
     this->expect_exception([&] { set_vm_control(1UL, msr_addr, ctls_addr, name, mask, exists); },
-                           std::make_shared<std::logic_error>(std::string(name) + " is not allowed to be set to 1"));
+                           std::make_shared<std::logic_error>("control is not allowed to be set to 1"));
 }
 
 void
 vmcs_ut::test_set_vm_control_if_allowed()
 {
-    auto name("control");
+    constexpr const auto name = "control";
     auto exists = true;
     auto verbose = true;
     auto mask = 0x0000000000000040UL;


### PR DESCRIPTION
This removes the use of std::string in namespace vmcs and
namespace vm in order to prevent freezing of the system.

I believe the source of the freeze problem is too high
a perf sampling rate.  The lower the perf_cpu_time_max_percent
is, the less time is spent sampling NMIs. Disabling it
completely makes the system act as if bareflank isn't running at all.