### PR TITLE
Make rest of natural-width ro data fields

### DIFF
--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -998,16 +998,6 @@ namespace host_ia32_efer
 constexpr const auto VMCS_HOST_IA32_PERF_GLOBAL_CTRL                      = 0x0000000000002C04UL;
 
 // -----------------------------------------------------------------------------
-// Natural Width Read-Only Fields
-// -----------------------------------------------------------------------------
-
-constexpr const auto VMCS_IO_RCX                                               = 0x0000000000006402UL;
-constexpr const auto VMCS_IO_RSI                                               = 0x0000000000006404UL;
-constexpr const auto VMCS_IO_RDI                                               = 0x0000000000006406UL;
-constexpr const auto VMCS_IO_RIP                                               = 0x0000000000006408UL;
-constexpr const auto VMCS_GUEST_LINEAR_ADDRESS                                 = 0x000000000000640AUL;
-
-// -----------------------------------------------------------------------------
 // Natural Width Host State Fields
 // -----------------------------------------------------------------------------
 

--- a/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_read_only_data_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_read_only_data_fields.h
@@ -1234,8 +1234,81 @@ namespace exit_qualification
             { return get_bits(get_vmcs_field_if_exists(addr, name, verbose, exists()), mask) >> from; }
         }
     }
+}
 
-    // namespace for page-modification log-full event???
+namespace io_rcx
+{
+    constexpr const auto addr = 0x0000000000006402UL;
+    constexpr const auto name = "io_rcx";
+
+    inline auto exists()
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+}
+
+namespace io_rsi
+{
+    constexpr const auto addr = 0x0000000000006404UL;
+    constexpr const auto name = "io_rsi";
+
+    inline auto exists()
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+}
+
+namespace io_rdi
+{
+    constexpr const auto addr = 0x0000000000006406UL;
+    constexpr const auto name = "io_rdi";
+
+    inline auto exists()
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+}
+
+namespace io_rip
+{
+    constexpr const auto addr = 0x0000000000006408UL;
+    constexpr const auto name = "io_rip";
+
+    inline auto exists()
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
+}
+
+namespace guest_linear_address
+{
+    constexpr const auto addr = 0x000000000000640AUL;
+    constexpr const auto name = "guest_linear_address";
+
+    inline auto exists()
+    { return true; }
+
+    inline auto get()
+    { return get_vmcs_field(addr, name, exists()); }
+
+    inline auto get_if_exists(bool verbose = false) noexcept
+    { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
 }
 
 }

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -908,6 +908,11 @@ vmcs_ut::list()
     this->test_vmcs_exit_qualification_eoi_virtualization_vector();
     this->test_vmcs_exit_qualification_apic_write();
     this->test_vmcs_exit_qualification_apic_write_offset();
+    this->test_vmcs_io_rcx();
+    this->test_vmcs_io_rsi();
+    this->test_vmcs_io_rdi();
+    this->test_vmcs_io_rip();
+    this->test_vmcs_guest_linear_address();
 
     this->test_check_vmcs_control_state();
     this->test_checks_on_vm_execution_control_fields();

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -819,6 +819,11 @@ private:
     void test_vmcs_exit_qualification_eoi_virtualization_vector();
     void test_vmcs_exit_qualification_apic_write();
     void test_vmcs_exit_qualification_apic_write_offset();
+    void test_vmcs_io_rcx();
+    void test_vmcs_io_rsi();
+    void test_vmcs_io_rdi();
+    void test_vmcs_io_rip();
+    void test_vmcs_guest_linear_address();
 
     void test_check_vmcs_control_state();
     void test_checks_on_vm_execution_control_fields();

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64.cpp
@@ -9553,3 +9553,53 @@ vmcs_ut::test_vmcs_exit_qualification_apic_write_offset()
     g_vmcs_fields[vmcs::exit_qualification::addr] = 0x0UL;
     this->expect_true(get_if_exists() == 0UL);
 }
+
+void
+vmcs_ut::test_vmcs_io_rcx()
+{
+    g_vmcs_fields[vmcs::io_rcx::addr] = 1U;
+    this->expect_true(vmcs::io_rcx::get() == 1U);
+
+    g_vmcs_fields[vmcs::io_rcx::addr] = 0U;
+    this->expect_true(vmcs::io_rcx::get_if_exists() == 0U);
+}
+
+void
+vmcs_ut::test_vmcs_io_rsi()
+{
+    g_vmcs_fields[vmcs::io_rsi::addr] = 1U;
+    this->expect_true(vmcs::io_rsi::get() == 1U);
+
+    g_vmcs_fields[vmcs::io_rsi::addr] = 0U;
+    this->expect_true(vmcs::io_rsi::get_if_exists() == 0U);
+}
+
+void
+vmcs_ut::test_vmcs_io_rdi()
+{
+    g_vmcs_fields[vmcs::io_rdi::addr] = 1U;
+    this->expect_true(vmcs::io_rdi::get() == 1U);
+
+    g_vmcs_fields[vmcs::io_rdi::addr] = 0U;
+    this->expect_true(vmcs::io_rdi::get_if_exists() == 0U);
+}
+
+void
+vmcs_ut::test_vmcs_io_rip()
+{
+    g_vmcs_fields[vmcs::io_rip::addr] = 1U;
+    this->expect_true(vmcs::io_rip::get() == 1U);
+
+    g_vmcs_fields[vmcs::io_rip::addr] = 0U;
+    this->expect_true(vmcs::io_rip::get_if_exists() == 0U);
+}
+
+void
+vmcs_ut::test_vmcs_guest_linear_address()
+{
+    g_vmcs_fields[vmcs::guest_linear_address::addr] = 1U;
+    this->expect_true(vmcs::guest_linear_address::get() == 1U);
+
+    g_vmcs_fields[vmcs::guest_linear_address::addr] = 0U;
+    this->expect_true(vmcs::guest_linear_address::get_if_exists() == 0U);
+}


### PR DESCRIPTION
This creates namespaces for the natural-width read-only data fields other than the exit qualification (which was created in #319).