### PR TITLE
Exit Handler Cleanup

### DIFF
--- a/bfvmm/include/exit_handler/exit_handler_intel_x64.h
+++ b/bfvmm/include/exit_handler/exit_handler_intel_x64.h
@@ -23,8 +23,11 @@
 #define EXIT_HANDLER_INTEL_X64_H
 
 #include <memory>
+
+#include <json.h>
 #include <vmcall_interface.h>
 #include <vmcs/vmcs_intel_x64.h>
+#include <memory_manager/map_ptr_x64.h>
 
 // -----------------------------------------------------------------------------
 // Exit Handler
@@ -53,7 +56,7 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    exit_handler_intel_x64();
+    exit_handler_intel_x64() = default;
 
     /// Destructor
     ///
@@ -153,6 +156,16 @@ protected:
     virtual void handle_vmcall_data(vmcall_registers_t &regs);
     virtual void handle_vmcall_event(vmcall_registers_t &regs);
     virtual void handle_vmcall_unittest(vmcall_registers_t &regs);
+
+    virtual void handle_vmcall_data_string_unformatted(vmcall_registers_t &regs, const std::string &str,
+            const bfn::unique_map_ptr_x64<char> &omap);
+
+    virtual void handle_vmcall_data_string_json(vmcall_registers_t &regs, const json &str,
+            const bfn::unique_map_ptr_x64<char> &omap);
+
+    virtual void handle_vmcall_data_binary_unformatted(vmcall_registers_t &regs,
+            const bfn::unique_map_ptr_x64<char> &imap,
+            const bfn::unique_map_ptr_x64<char> &omap);
 
 protected:
 

--- a/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
@@ -629,14 +629,18 @@ exit_handler_intel_x64_ut::test_vm_exit_reason_vmcall_data_unknown()
     MockRepository mocks;
     auto &&vmcs = setup_vmcs_handled(mocks, exit_reason::basic_exit_reason::vmcall);
     auto &&ehlr = setup_ehlr(vmcs);
+    setup_mm(mocks);
+    setup_pt(mocks);
 
     ehlr.m_state_save->rax = VMCALL_DATA;                        // r00
     ehlr.m_state_save->rdx = VMCALL_MAGIC_NUMBER;                // r01
-    ehlr.m_state_save->rsi = 0x0000BEEF;                         // r04
+    ehlr.m_state_save->rsi = 0x0000BEEF;     // r04
     ehlr.m_state_save->r08 = 0x1234U;                            // r05
     ehlr.m_state_save->r09 = g_msg.size();                       // r06
     ehlr.m_state_save->r11 = 0x1234U;                            // r08
     ehlr.m_state_save->r12 = g_msg.size();                       // r09
+
+    __builtin_memcpy(g_map.get(), g_msg.data(), g_msg.size());
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {


### PR DESCRIPTION
This cleans up the exit handler a bit due to a lot of changes
in the code. It also adds functions that can be hooked by a
user to further simplify what a user has to do to handle a
vmcall.

Signed-off-by: “Rian <“rianquinn@gmail.com”>