### PR TITLE
Add Libcxx Unit Tests

### DIFF
--- a/bfcxx/README.md
+++ b/bfcxx/README.md
@@ -1,9 +1,18 @@
 # Libc++
 
-Bareflank leverages [libc++](http://libcxx.llvm.org) to provide support for the C++ STL. In addition, Bareflank leverages Microsoft's Guideline Support Library ([GSL](https://github.com/Microsoft/GSL)) to provide support for the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines). Although the C++ STL is supported, not all of the STL is supported. For example, `fstream` makes no sense in the VMM and will likely never be supported. The following provides a list of supported features in the STL that are known to work, and have been unit tested:
+Bareflank leverages [libc++](http://libcxx.llvm.org) to provide support for the C++ STL. In addition, Bareflank leverages Microsoft's Guideline Support Library ([GSL](https://github.com/Microsoft/GSL)) to provide support for the [C++ Core Guidelines](https://github.com/isocpp/CppCoreGuidelines). Although the C++ STL is supported, not all of the STL is supported. For example, `fstream` makes no sense in the VMM and will likely never be supported. The following provides a list of supported features in the STL that are known to work, and have been unit tested. If a C++ feature is not listed, it might still work, but simply has not been formally tested. Feel free use untested C++ features, but be warned that some might fail, and in unexpected ways.
 
 ## [Containers](http://www.cplusplus.com/reference/stl/)
-\<complete once unit tests are done\>
+- [std::array](http://www.cplusplus.com/reference/array/array/)
+- [std::vector](http://www.cplusplus.com/reference/vector/vector/)
+- [std::deque](http://www.cplusplus.com/reference/deque/deque/)
+- [std::forward_list](http://www.cplusplus.com/reference/forward_list/forward_list/)
+- [std::list](http://www.cplusplus.com/reference/list/list/)
+- [std::stack](http://www.cplusplus.com/reference/stack/stack/)
+- [std::queue](http://www.cplusplus.com/reference/queue/queue/)
+- [std::priority_queue](http://www.cplusplus.com/reference/queue/priority_queue/)
+- [std::set](http://www.cplusplus.com/reference/set/set/)
+- [std::map](http://www.cplusplus.com/reference/map/map/)
 
 ## [Input/Output](http://www.cplusplus.com/reference/iolibrary/)
 \<complete once unit tests are done\>

--- a/bfm/src/ioctl_driver.cpp
+++ b/bfm/src/ioctl_driver.cpp
@@ -359,7 +359,7 @@ void
 ioctl_driver::vmcall_unittest(registers_type &regs)
 {
     vmcall_send_regs(regs);
-    std::cout << "success" << std::endl;
+    std::cout << "\033[1;36m" << std::hex << "0x" << regs.r02 << std::dec << ":\033[1;32m passed\033[0m\n";
 }
 
 ioctl_driver::status_type

--- a/bfvmm/include/exit_handler/exit_handler_intel_x64.h
+++ b/bfvmm/include/exit_handler/exit_handler_intel_x64.h
@@ -179,6 +179,23 @@ protected:
 
 private:
 
+#ifdef INCLUDE_LIBCXX_UNITTESTS
+
+    void unittest_1001_containers_array() const;
+    void unittest_1002_containers_vector() const;
+    void unittest_1003_containers_deque() const;
+    void unittest_1004_containers_forward_list() const;
+    void unittest_1005_containers_list() const;
+    void unittest_1006_containers_stack() const;
+    void unittest_1007_containers_queue() const;
+    void unittest_1008_containers_priority_queue() const;
+    void unittest_1009_containers_set() const;
+    void unittest_100A_containers_map() const;
+
+#endif
+
+private:
+
     virtual void set_vmcs(const std::shared_ptr<vmcs_intel_x64> &vmcs)
     { m_vmcs = vmcs; }
 

--- a/bfvmm/src/exit_handler/src/Makefile.bf
+++ b/bfvmm/src/exit_handler/src/Makefile.bf
@@ -27,9 +27,13 @@ TARGET_NAME:=exit_handler
 TARGET_TYPE:=lib
 
 ifeq ($(shell uname -s), Linux)
-    TARGET_COMPILER:=both
+	TARGET_COMPILER:=both
 else
-    TARGET_COMPILER:=cross
+	TARGET_COMPILER:=cross
+endif
+
+ifeq ($(INCLUDE_LIBCXX_UNITTESTS), yes)
+	NATIVE_DEFINES+=INCLUDE_LIBCXX_UNITTESTS
 endif
 
 ################################################################################
@@ -67,7 +71,7 @@ NATIVE_OUTDIR+=%BUILD_REL%/../bin
 SOURCES+=exit_handler_intel_x64.cpp
 SOURCES+=exit_handler_intel_x64_entry.cpp
 SOURCES+=exit_handler_intel_x64_support.asm
-
+SOURCES+=exit_handler_intel_x64_unittests.cpp
 
 INCLUDE_PATHS+=./
 INCLUDE_PATHS+=%HYPER_ABS%/include/

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -917,13 +917,6 @@ exit_handler_intel_x64::handle_vmcall_event(vmcall_registers_t &regs)
 }
 
 void
-exit_handler_intel_x64::handle_vmcall_unittest(vmcall_registers_t &regs)
-{
-    bfdebug << "vmcall unittest:" << bfendl;
-    bfdebug << "r02: " << view_as_pointer(regs.r02) << bfendl;
-}
-
-void
 exit_handler_intel_x64::handle_vmcall_data_string_unformatted(vmcall_registers_t &regs, const std::string &str,
         const bfn::unique_map_ptr_x64<char> &omap)
 {

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64_unittests.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64_unittests.cpp
@@ -1,0 +1,569 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <gsl/gsl>
+
+#include <debug.h>
+#include <exit_handler/exit_handler_intel_x64.h>
+
+#ifndef INCLUDE_LIBCXX_UNITTESTS
+
+void
+exit_handler_intel_x64::handle_vmcall_unittest(vmcall_registers_t &regs)
+{ (void) regs; }
+
+#else
+
+#include <array>
+#include <vector>
+#include <deque>
+#include <forward_list>
+#include <list>
+#include <stack>
+#include <queue>
+#include <set>
+#include <map>
+
+static void
+expect_true_with_args(bool cond, const char *func, int line)
+{ if (!cond) throw std::runtime_error("unittest failed ["_s + std::to_string(line) + "]: "_s + func); }
+
+static void
+expect_false_with_args(bool cond, const char *func, int line)
+{ if (cond) throw std::runtime_error("unittest failed ["_s + std::to_string(line) + "]: "_s + func); }
+
+#define expect_true(a) expect_true_with_args(a, __FUNC__, __LINE__);
+#define expect_false(a) expect_false_with_args(a, __FUNC__, __LINE__);
+
+void
+exit_handler_intel_x64::handle_vmcall_unittest(vmcall_registers_t &regs)
+{
+    switch (regs.r02)
+    {
+        case 0x1001: unittest_1001_containers_array(); break;
+        case 0x1002: unittest_1002_containers_vector(); break;
+        case 0x1003: unittest_1003_containers_deque(); break;
+        case 0x1004: unittest_1004_containers_forward_list(); break;
+        case 0x1005: unittest_1005_containers_list(); break;
+        case 0x1006: unittest_1006_containers_stack(); break;
+        case 0x1007: unittest_1007_containers_queue(); break;
+        case 0x1008: unittest_1008_containers_priority_queue(); break;
+        case 0x1009: unittest_1009_containers_set(); break;
+        case 0x100A: unittest_100A_containers_map(); break;
+        default:
+            throw std::runtime_error("unknown unit test #");
+    }
+}
+
+void
+exit_handler_intel_x64::unittest_1001_containers_array() const
+{
+    auto myarray = std::array<int, 4>({0, 1, 2, 3});
+    auto myarray2 = std::array<int, 4>({0, 1, 2, 3});
+
+    auto total = 0;
+    for (auto iter = myarray.begin(); iter != myarray.end(); iter++)
+        total += *iter;
+
+    auto rtotal = 0;
+    for (auto iter = myarray.rbegin(); iter != myarray.rend(); iter++)
+        rtotal += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = myarray.cbegin(); iter != myarray.cend(); iter++)
+        ctotal += *iter;
+
+    auto crtotal = 0;
+    for (auto iter = myarray.crbegin(); iter != myarray.crend(); iter++)
+        crtotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(myarray.size() == 4);
+    expect_true(myarray.max_size() == 4);
+    expect_false(myarray.empty());
+
+    expect_true(myarray.at(0) == 0);
+    expect_true(myarray.at(3) == 3);
+    expect_true(myarray.front() == 0);
+    expect_true(myarray.back() == 3);
+    expect_true(myarray.data() != nullptr);
+
+    myarray.fill(0);
+    myarray.swap(myarray2);
+
+    expect_true(std::get<0>(myarray) == 0);
+    expect_true(std::get<3>(myarray) == 3);
+
+    expect_false(myarray == myarray2);
+    expect_true(myarray != myarray2);
+    expect_false(myarray < myarray2);
+    expect_true(myarray > myarray2);
+    expect_false(myarray <= myarray2);
+    expect_true(myarray >= myarray2);
+}
+
+void
+exit_handler_intel_x64::unittest_1002_containers_vector() const
+{
+    auto myvector = std::vector<int>({0, 1, 2, 3});
+    auto myvector2 = std::vector<int>({0, 1, 2, 3});
+
+    myvector = myvector2;
+
+    auto total = 0;
+    for (auto iter = myvector.begin(); iter != myvector.end(); iter++)
+        total += *iter;
+
+    auto rtotal = 0;
+    for (auto iter = myvector.rbegin(); iter != myvector.rend(); iter++)
+        rtotal += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = myvector.cbegin(); iter != myvector.cend(); iter++)
+        ctotal += *iter;
+
+    auto crtotal = 0;
+    for (auto iter = myvector.crbegin(); iter != myvector.crend(); iter++)
+        crtotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(myvector.size() == 4);
+    expect_true(myvector.max_size() >= 4);
+    myvector.resize(4);
+    expect_true(myvector.capacity() >= 4);
+    expect_false(myvector.empty());
+    myvector.reserve(4);
+    myvector.shrink_to_fit();
+
+    expect_true(myvector.at(0) == 0);
+    expect_true(myvector.at(3) == 3);
+    expect_true(myvector.front() == 0);
+    expect_true(myvector.back() == 3);
+    expect_true(myvector.data() != nullptr);
+
+    myvector.assign(4, 0);
+    myvector.push_back(4);
+    myvector.pop_back();
+    myvector.insert(myvector.begin(), 0);
+    myvector.erase(myvector.begin());
+    myvector.clear();
+    myvector.swap(myvector2);
+    myvector2.emplace(myvector.begin());
+    myvector2.emplace_back();
+
+    myvector.get_allocator();
+
+    expect_false(myvector == myvector2);
+    expect_true(myvector != myvector2);
+    expect_false(myvector < myvector2);
+    expect_true(myvector > myvector2);
+    expect_false(myvector <= myvector2);
+    expect_true(myvector >= myvector2);
+
+    std::swap(myvector, myvector2);
+}
+
+void
+exit_handler_intel_x64::unittest_1003_containers_deque() const
+{
+    auto mydeque = std::deque<int>({0, 1, 2, 3});
+    auto mydeque2 = std::deque<int>({0, 1, 2, 3});
+
+    mydeque = mydeque2;
+
+    auto total = 0;
+    for (auto iter = mydeque.begin(); iter != mydeque.end(); iter++)
+        total += *iter;
+
+    auto rtotal = 0;
+    for (auto iter = mydeque.rbegin(); iter != mydeque.rend(); iter++)
+        rtotal += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = mydeque.cbegin(); iter != mydeque.cend(); iter++)
+        ctotal += *iter;
+
+    auto crtotal = 0;
+    for (auto iter = mydeque.crbegin(); iter != mydeque.crend(); iter++)
+        crtotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(mydeque.size() == 4);
+    expect_true(mydeque.max_size() >= 4);
+    mydeque.resize(4);
+    expect_false(mydeque.empty());
+    mydeque.shrink_to_fit();
+
+    expect_true(mydeque.at(0) == 0);
+    expect_true(mydeque.at(3) == 3);
+    expect_true(mydeque.front() == 0);
+    expect_true(mydeque.back() == 3);
+
+    mydeque.assign(4, 0);
+    mydeque.push_back(4);
+    mydeque.pop_back();
+    mydeque.push_front(4);
+    mydeque.pop_front();
+    mydeque.insert(mydeque.begin(), 0);
+    mydeque.erase(mydeque.begin());
+    mydeque.clear();
+    mydeque.swap(mydeque2);
+    mydeque2.emplace(mydeque.begin());
+    mydeque2.emplace_back();
+    mydeque2.emplace_front();
+
+    mydeque.get_allocator();
+
+    expect_false(mydeque == mydeque2);
+    expect_true(mydeque != mydeque2);
+    expect_false(mydeque < mydeque2);
+    expect_true(mydeque > mydeque2);
+    expect_false(mydeque <= mydeque2);
+    expect_true(mydeque >= mydeque2);
+
+    std::swap(mydeque, mydeque2);
+}
+
+void
+exit_handler_intel_x64::unittest_1004_containers_forward_list() const
+{
+    auto mylist = std::forward_list<int>({0, 1, 2, 3});
+    auto mylist2 = std::forward_list<int>({0, 1, 2, 3});
+
+    mylist = mylist2;
+
+    mylist.insert_after(mylist.before_begin(), 10);
+    mylist.erase_after(mylist.begin());
+    mylist.insert_after(mylist.cbefore_begin(), 10);
+    mylist.erase_after(mylist.cbegin());
+
+    auto total = 0;
+    for (auto iter = mylist.begin(); iter != mylist.end(); iter++)
+        total += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = mylist.cbegin(); iter != mylist.cend(); iter++)
+        ctotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(ctotal == 6);
+
+    expect_true(mylist.max_size() >= 4);
+    expect_false(mylist.empty());
+
+    expect_true(mylist.front() == 0);
+
+    mylist.assign(4, 0);
+    mylist.push_front(4);
+    mylist.pop_front();
+    mylist.clear();
+    mylist.swap(mylist2);
+    mylist.resize(4);
+    mylist2.emplace_front();
+    mylist2.emplace_after(mylist.begin());
+
+    mylist.get_allocator();
+
+    expect_false(mylist == mylist2);
+    expect_true(mylist != mylist2);
+    expect_false(mylist < mylist2);
+    expect_true(mylist > mylist2);
+    expect_false(mylist <= mylist2);
+    expect_true(mylist >= mylist2);
+
+    mylist.splice_after(mylist.before_begin(), mylist2);
+    mylist.remove(0);
+    mylist.unique();
+    mylist.merge(mylist2, std::greater<int>());
+    mylist.sort(std::greater<int>());
+    mylist.reverse();
+
+    std::swap(mylist, mylist2);
+}
+
+void
+exit_handler_intel_x64::unittest_1005_containers_list() const
+{
+    auto mylist = std::list<int>({0, 1, 2, 3});
+    auto mylist2 = std::list<int>({0, 1, 2, 3});
+
+    mylist = mylist2;
+
+    auto total = 0;
+    for (auto iter = mylist.begin(); iter != mylist.end(); iter++)
+        total += *iter;
+
+    auto rtotal = 0;
+    for (auto iter = mylist.rbegin(); iter != mylist.rend(); iter++)
+        rtotal += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = mylist.cbegin(); iter != mylist.cend(); iter++)
+        ctotal += *iter;
+
+    auto crtotal = 0;
+    for (auto iter = mylist.crbegin(); iter != mylist.crend(); iter++)
+        crtotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(mylist.size() == 4);
+    expect_true(mylist.max_size() >= 4);
+    expect_false(mylist.empty());
+
+    expect_true(mylist.front() == 0);
+    expect_true(mylist.back() == 3);
+
+    mylist.assign(4, 0);
+    mylist.push_back(4);
+    mylist.pop_back();
+    mylist.push_front(4);
+    mylist.pop_front();
+    mylist.insert(mylist.begin(), 0);
+    mylist.erase(mylist.begin());
+    mylist.clear();
+    mylist.resize(4);
+    mylist.swap(mylist2);
+    mylist2.emplace(mylist.begin());
+    mylist2.emplace_back();
+    mylist2.emplace_front();
+
+    mylist.get_allocator();
+
+    expect_false(mylist == mylist2);
+    expect_true(mylist != mylist2);
+    expect_false(mylist < mylist2);
+    expect_true(mylist > mylist2);
+    expect_false(mylist <= mylist2);
+    expect_true(mylist >= mylist2);
+
+    mylist.splice(mylist.begin(), mylist2);
+    mylist.remove(0);
+    mylist.unique();
+    mylist.merge(mylist2, std::greater<int>());
+    mylist.sort(std::greater<int>());
+    mylist.reverse();
+
+    std::swap(mylist, mylist2);
+}
+
+void
+exit_handler_intel_x64::unittest_1006_containers_stack() const
+{
+    auto mystack = std::stack<int>({0, 1, 2, 3});
+    auto mystack2 = std::stack<int>({0, 1, 2, 3});
+
+    expect_true(mystack.size() == 4);
+    expect_false(mystack.empty());
+
+    expect_true(mystack.top() == 3);
+
+    mystack.push(4);
+    mystack.emplace();
+    mystack.pop();
+    mystack.swap(mystack2);
+
+    expect_false(mystack == mystack2);
+    expect_true(mystack != mystack2);
+    expect_false(mystack < mystack2);
+    expect_true(mystack > mystack2);
+    expect_false(mystack <= mystack2);
+    expect_true(mystack >= mystack2);
+
+    std::swap(mystack, mystack2);
+}
+
+void
+exit_handler_intel_x64::unittest_1007_containers_queue() const
+{
+    auto myqueue = std::queue<int>({0, 1, 2, 3});
+    auto myqueue2 = std::queue<int>({0, 1, 2, 3});
+
+    expect_true(myqueue.size() == 4);
+    expect_false(myqueue.empty());
+
+    expect_true(myqueue.front() == 0);
+    expect_true(myqueue.back() == 3);
+
+    myqueue.push(4);
+    myqueue.emplace();
+    myqueue.pop();
+    myqueue.swap(myqueue2);
+
+    expect_false(myqueue == myqueue2);
+    expect_true(myqueue != myqueue2);
+    expect_false(myqueue < myqueue2);
+    expect_true(myqueue > myqueue2);
+    expect_false(myqueue <= myqueue2);
+    expect_true(myqueue >= myqueue2);
+
+    std::swap(myqueue, myqueue2);
+}
+
+void
+exit_handler_intel_x64::unittest_1008_containers_priority_queue() const
+{
+    int myints[] = {0, 1, 2, 3};
+
+    auto myqueue = std::priority_queue<int>(myints, myints + 4);
+    auto myqueue2 = std::priority_queue<int>(myints, myints + 4);
+
+    expect_true(myqueue.size() == 4);
+    expect_false(myqueue.empty());
+
+    expect_true(myqueue.top() == 3);
+
+    myqueue.push(4);
+    myqueue.emplace();
+    myqueue.pop();
+    myqueue.swap(myqueue2);
+
+    std::swap(myqueue, myqueue2);
+}
+
+void
+exit_handler_intel_x64::unittest_1009_containers_set() const
+{
+    auto myset = std::set<int>({0, 1, 2, 3});
+    auto myset2 = std::set<int>({0, 1, 2, 3});
+
+    myset = myset2;
+
+    auto total = 0;
+    for (auto iter = myset.begin(); iter != myset.end(); iter++)
+        total += *iter;
+
+    auto rtotal = 0;
+    for (auto iter = myset.rbegin(); iter != myset.rend(); iter++)
+        rtotal += *iter;
+
+    auto ctotal = 0;
+    for (auto iter = myset.cbegin(); iter != myset.cend(); iter++)
+        ctotal += *iter;
+
+    auto crtotal = 0;
+    for (auto iter = myset.crbegin(); iter != myset.crend(); iter++)
+        crtotal += *iter;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(myset.size() == 4);
+    expect_true(myset.max_size() >= 4);
+    expect_false(myset.empty());
+
+    myset.insert(myset.begin(), 0);
+    myset.erase(myset.begin());
+    myset.clear();
+    myset.swap(myset2);
+    myset2.emplace();
+    myset2.emplace_hint(myset.begin());
+
+    myset.key_comp();
+    myset.value_comp();
+
+    expect_true(myset.find(0) != myset.end());
+    expect_true(myset.count(0) == 1);
+    expect_true(myset.lower_bound(0) != myset.end());
+    expect_true(myset.upper_bound(0) != myset.end());
+    myset.equal_range(0);
+
+    myset.get_allocator();
+}
+
+void
+exit_handler_intel_x64::unittest_100A_containers_map() const
+{
+    auto mymap = std::map<int, int>();
+    auto mymap2 = std::map<int, int>();
+
+    mymap2[0] = 0;
+    mymap2[1] = 1;
+    mymap2[2] = 2;
+    mymap2[3] = 3;
+
+    mymap = mymap2;
+
+    auto total = 0;
+    for (auto iter = mymap.begin(); iter != mymap.end(); iter++)
+        total += iter->second;
+
+    auto rtotal = 0;
+    for (auto iter = mymap.rbegin(); iter != mymap.rend(); iter++)
+        rtotal += iter->second;
+
+    auto ctotal = 0;
+    for (auto iter = mymap.cbegin(); iter != mymap.cend(); iter++)
+        ctotal += iter->second;
+
+    auto crtotal = 0;
+    for (auto iter = mymap.crbegin(); iter != mymap.crend(); iter++)
+        crtotal += iter->second;
+
+    expect_true(total == 6);
+    expect_true(rtotal == 6);
+    expect_true(ctotal == 6);
+    expect_true(crtotal == 6);
+
+    expect_true(mymap.size() == 4);
+    expect_true(mymap.max_size() >= 4);
+    expect_false(mymap.empty());
+
+    expect_true(mymap.at(0) == 0);
+    expect_true(mymap.at(3) == 3);
+
+    mymap.insert(std::pair<int, int>(4, 4));
+    mymap.erase(4);
+    mymap.clear();
+    mymap.swap(mymap2);
+    mymap2.emplace();
+    mymap2.emplace_hint(mymap.begin(), std::pair<int, int>(4, 4));
+
+    mymap.key_comp();
+    mymap.value_comp();
+
+    expect_true(mymap.find(0) != mymap.end());
+    expect_true(mymap.count(0) == 1);
+    expect_true(mymap.lower_bound(0) != mymap.end());
+    expect_true(mymap.upper_bound(0) != mymap.end());
+    mymap.equal_range(0);
+
+    mymap.get_allocator();
+}
+
+#endif

--- a/tools/tests/test_hypervisor.sh
+++ b/tools/tests/test_hypervisor.sh
@@ -94,8 +94,17 @@ vmcall_unittest() {
     echo -e "$CC""testing:$CB vmcall_unittest$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="unittest 1" make vmcall
-    ARGS="unittest 2" make vmcall
+    echo -e ""
+    ARGS="unittest 0x1001" make vmcall
+    ARGS="unittest 0x1002" make vmcall
+    ARGS="unittest 0x1003" make vmcall
+    ARGS="unittest 0x1004" make vmcall
+    ARGS="unittest 0x1005" make vmcall
+    ARGS="unittest 0x1006" make vmcall
+    ARGS="unittest 0x1007" make vmcall
+    ARGS="unittest 0x1008" make vmcall
+    ARGS="unittest 0x1009" make vmcall
+    ARGS="unittest 0x100A" make vmcall
     make driver_unload > /dev/null 2>&1
 }
 


### PR DESCRIPTION
This patch adds unit tests for all of the supported containers
in version 1.1. Currently, unordered_map and multimap are not
supported. In version 1.2 we plan to provide support for
unordered_map. Also note that more unit tests will come to
complete some of the other STL type functionality.

Signed-off-by: “Rian <“rianquinn@gmail.com”>