### PR TITLE
Add Custom URLs for LLVM

### DIFF
--- a/tools/scripts/fetch_clang.sh
+++ b/tools/scripts/fetch_clang.sh
@@ -24,10 +24,34 @@ pushd /tmp/bareflank/
 
 rm -Rf source_llvm
 
+if [[ -z "$CUSTOM_LLVM_BRANCH" ]]; then
+    llvm_branch=$LLVM_RELEASE
+else
+    llvm_branch=$CUSTOM_LLVM_BRANCH
+fi
+
+if [[ -z "$CUSTOM_LLVM_URL" ]]; then
+    llvm_url="http://llvm.org/git/llvm"
+else
+    llvm_url=$CUSTOM_LLVM_URL
+fi
+
+if [[ -z "$CUSTOM_CLANG_BRANCH" ]]; then
+    clang_branch=$CLANG_RELEASE
+else
+    clang_branch=$CUSTOM_CLANG_BRANCH
+fi
+
+if [[ -z "$CUSTOM_CLANG_URL" ]]; then
+    clang_url="http://llvm.org/git/clang.git"
+else
+    clang_url=$CUSTOM_CLANG_URL
+fi
+
 n=0
 until [ $n -ge 5 ]
 do
-    git clone --depth 1 -b $LLVM_RELEASE http://llvm.org/git/llvm source_llvm && break
+    git clone --depth 1 -b $llvm_branch $llvm_url source_llvm && break
     n=$[$n+1]
     sleep 15
 done
@@ -37,7 +61,7 @@ cd source_llvm/tools
 n=0
 until [ $n -ge 5 ]
 do
-    git clone --depth 1 -b $LLVM_RELEASE http://llvm.org/git/clang.git && break
+    git clone --depth 1 -b $clang_branch $clang_url && break
     n=$[$n+1]
     sleep 15
 done

--- a/tools/scripts/fetch_libcxx.sh
+++ b/tools/scripts/fetch_libcxx.sh
@@ -24,10 +24,22 @@
 
 pushd $BUILD_ABS
 
+if [[ -z "$CUSTOM_LIBCXX_BRANCH" ]]; then
+    branch=$LLVM_RELEASE
+else
+    branch=$CUSTOM_LIBCXX_BRANCH
+fi
+
+if [[ -z "$CUSTOM_LIBCXX_URL" ]]; then
+    url="http://llvm.org/git/libcxx"
+else
+    url=$CUSTOM_LIBCXX_URL
+fi
+
 n=0
 until [ $n -ge 5 ]
 do
-    git clone --depth 1 -b $LLVM_RELEASE http://llvm.org/git/libcxx source_libcxx && break
+    git clone --depth 1 -b $branch $url source_libcxx && break
     n=$[$n+1]
     sleep 15
 done

--- a/tools/scripts/fetch_libcxxabi.sh
+++ b/tools/scripts/fetch_libcxxabi.sh
@@ -24,10 +24,22 @@
 
 pushd $BUILD_ABS
 
+if [[ -z "$CUSTOM_LIBCXXABI_BRANCH" ]]; then
+    branch=$LLVM_RELEASE
+else
+    branch=$CUSTOM_LIBCXXABI_BRANCH
+fi
+
+if [[ -z "$CUSTOM_LIBCXXABI_URL" ]]; then
+    url="http://llvm.org/git/libcxxabi"
+else
+    url=$CUSTOM_LIBCXXABI_URL
+fi
+
 n=0
 until [ $n -ge 5 ]
 do
-    git clone --depth 1 -b $LLVM_RELEASE http://llvm.org/git/libcxxabi source_libcxxabi && break
+    git clone --depth 1 -b $branch $url source_libcxxabi && break
     n=$[$n+1]
     sleep 15
 done

--- a/tools/scripts/fetch_llvm.sh
+++ b/tools/scripts/fetch_llvm.sh
@@ -24,10 +24,22 @@
 
 pushd $BUILD_ABS
 
+if [[ -z "$CUSTOM_LLVM_BRANCH" ]]; then
+    branch=$LLVM_RELEASE
+else
+    branch=$CUSTOM_LLVM_BRANCH
+fi
+
+if [[ -z "$CUSTOM_LLVM_URL" ]]; then
+    url="http://llvm.org/git/llvm"
+else
+    url=$CUSTOM_LLVM_URL
+fi
+
 n=0
 until [ $n -ge 5 ]
 do
-    git clone --depth 1 -b $LLVM_RELEASE http://llvm.org/git/llvm source_llvm && break
+    git clone --depth 1 -b $branch $url source_llvm && break
     n=$[$n+1]
     sleep 15
 done


### PR DESCRIPTION
This patch adds custom URLs for LLVM so that custom versions
of clang, llvm, libcxx and libcxxabi may be used if so desired

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/251

Signed-off-by: “Rian <“rianquinn@gmail.com”>