### PR TITLE
Remove remaining #defines

### DIFF
--- a/bfvmm/include/serial/serial_port_intel_x64.h
+++ b/bfvmm/include/serial/serial_port_intel_x64.h
@@ -25,59 +25,43 @@
 #include <string>
 #include <memory>
 
+#include <constants.h>
 #include <intrinsics/portio_x64.h>
 
-#define COM1_PORT 0x3F8U
-#define COM2_PORT 0x2F8U
-#define COM3_PORT 0x3E8U
-#define COM4_PORT 0x2E8U
+namespace serial_intel_x64
+{
+constexpr const x64::portio::port_addr_type com1_port = 0x3F8U;
+constexpr const x64::portio::port_addr_type com2_port = 0x2F8U;
+constexpr const x64::portio::port_addr_type com3_port = 0x3E8U;
+constexpr const x64::portio::port_addr_type com4_port = 0x2E8U;
 
-#ifndef DEFAULT_COM_PORT
-#define DEFAULT_COM_PORT COM1_PORT
-#endif
+constexpr const x64::portio::port_8bit_type dlab = 1U << 7;
 
-#ifndef DEFAULT_BAUD_RATE
-#define DEFAULT_BAUD_RATE baud_rate_115200
-#endif
+constexpr const x64::portio::port_addr_type baud_rate_lo_reg = 0U;
+constexpr const x64::portio::port_addr_type baud_rate_hi_reg = 1U;
+constexpr const x64::portio::port_addr_type interrupt_en_reg = 1U;
+constexpr const x64::portio::port_addr_type fifo_control_reg = 2U;
+constexpr const x64::portio::port_addr_type line_control_reg = 3U;
+constexpr const x64::portio::port_addr_type line_status_reg = 5U;
 
-#ifndef DEFAULT_DATA_BITS
-#define DEFAULT_DATA_BITS char_length_8
-#endif
+constexpr const x64::portio::port_8bit_type fifo_control_enable_fifos = 1U << 0;
+constexpr const x64::portio::port_8bit_type fifo_control_clear_recieve_fifo = 1U << 1;
+constexpr const x64::portio::port_8bit_type fifo_control_clear_transmit_fifo = 1U << 2;
+constexpr const x64::portio::port_8bit_type fifo_control_dma_mode_select = 1U << 3;
 
-#ifndef DEFAULT_STOP_BITS
-#define DEFAULT_STOP_BITS stop_bits_1
-#endif
+constexpr const x64::portio::port_8bit_type line_status_data_ready = 1U << 0;
+constexpr const x64::portio::port_8bit_type line_status_overrun_error = 1U << 1;
+constexpr const x64::portio::port_8bit_type line_status_parity_error = 1U << 2;
+constexpr const x64::portio::port_8bit_type line_status_framing_error = 1U << 3;
+constexpr const x64::portio::port_8bit_type line_status_break_interrupt = 1U << 4;
+constexpr const x64::portio::port_8bit_type line_status_empty_transmitter = 1U << 5;
+constexpr const x64::portio::port_8bit_type line_status_empty_data = 1U << 6;
+constexpr const x64::portio::port_8bit_type line_status_recieved_fifo_error = 1U << 7;
 
-#ifndef DEFAULT_PARITY_BITS
-#define DEFAULT_PARITY_BITS parity_none
-#endif
-
-#define DLAB                                                          (1U << 7)
-
-#define BAUD_RATE_LO_REG                                              (0U)
-#define BAUD_RATE_HI_REG                                              (1U)
-#define INTERRUPT_EN_REG                                              (1U)
-#define FIFO_CONTROL_REG                                              (2U)
-#define LINE_CONTROL_REG                                              (3U)
-#define LINE_STATUS_REG                                               (5U)
-
-#define FIFO_CONTROL_ENABLE_FIFOS                                     (1U << 0)
-#define FIFO_CONTROL_CLEAR_RECIEVE_FIFO                               (1U << 1)
-#define FIFO_CONTROL_CLEAR_TRANSMIT_FIFO                              (1U << 2)
-#define FIFO_CONTROL_DMA_MODE_SELECT                                  (1U << 3)
-
-#define LINE_STATUS_DATA_READY                                        (1U << 0)
-#define LINE_STATUS_OVERRUN_ERROR                                     (1U << 1)
-#define LINE_STATUS_PARITY_ERROR                                      (1U << 2)
-#define LINE_STATUS_FRAMING_ERROR                                     (1U << 3)
-#define LINE_STATUS_BREAK_INTERRUPT                                   (1U << 4)
-#define LINE_STATUS_EMPTY_TRANSMITTER                                 (1U << 5)
-#define LINE_STATUS_EMPTY_DATA                                        (1U << 6)
-#define LINE_STATUS_RECIEVED_FIFO_ERROR                               (1U << 7)
-
-#define LINE_CONTROL_DATA_MASK                                        (0x03)
-#define LINE_CONTROL_STOP_MASK                                        (0x04)
-#define LINE_CONTROL_PARITY_MASK                                      (0x38)
+constexpr const x64::portio::port_8bit_type line_control_data_mask = 0x03;
+constexpr const x64::portio::port_8bit_type line_control_stop_mask = 0x04;
+constexpr const x64::portio::port_8bit_type line_control_parity_mask = 0x38;
+}
 
 /// Serial Port (Intel x64)
 ///
@@ -95,6 +79,9 @@
 class serial_port_intel_x64
 {
 public:
+
+    using port_type = x64::portio::port_addr_type;
+    using value_type = x64::portio::port_8bit_type;
 
     enum baud_rate_t
     {
@@ -145,15 +132,24 @@ public:
 
     /// Default Constructor
     ///
-    serial_port_intel_x64(uint16_t port = DEFAULT_COM_PORT) noexcept;
+    /// @expects none
+    /// @ensures none
+    ///
+    serial_port_intel_x64(port_type port = serial_intel_x64::DEFAULT_COM_PORT) noexcept;
 
     /// Destructor
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     ~serial_port_intel_x64() = default;
 
     /// Get Instance
     ///
     /// Get an instance to the class.
+    ///
+    /// @expects none
+    /// @ensures ret != nullptr
     ///
     static serial_port_intel_x64 *instance() noexcept;
 
@@ -163,6 +159,9 @@ public:
     /// rate paramter is actually the divisor that is used, and a custom one
     /// can be used if desired. If 0 is provided, the default baud rate is
     /// used instead.
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     /// @param rate desired baud rate
     ///
@@ -174,6 +173,9 @@ public:
     /// set to a baud rate that this code does not recognize, unknown is
     /// returned.
     ///
+    /// @expects none
+    /// @ensures none
+    ///
     /// @return the baud rate
     ///
     baud_rate_t baud_rate() const noexcept;
@@ -183,11 +185,17 @@ public:
     /// Sets the size of the data that is transmitted. For more information
     /// on the this field, please see http://wiki.osdev.org/Serial_Ports.
     ///
+    /// @expects none
+    /// @ensures none
+    ///
     /// @param bits the desired data bits
     ///
     void set_data_bits(data_bits_t bits) noexcept;
 
     /// Data Bits
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     /// @return the serial device's data bits
     ///
@@ -198,11 +206,17 @@ public:
     /// Sets the stop bits used for transmission. For more information
     /// on the this field, please see http://wiki.osdev.org/Serial_Ports.
     ///
+    /// @expects none
+    /// @ensures none
+    ///
     /// @param bits the desired stop bits
     ///
     void set_stop_bits(stop_bits_t bits) noexcept;
 
     /// Stop Bits
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     /// @return the serial device's stop bits
     ///
@@ -213,11 +227,17 @@ public:
     /// Sets the parity bits used for transmission. For more information
     /// on the this field, please see http://wiki.osdev.org/Serial_Ports.
     ///
+    /// @expects none
+    /// @ensures none
+    ///
     /// @param bits the desired parity bits
     ///
     void set_parity_bits(parity_bits_t bits) noexcept;
 
     /// Parity Bits
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     /// @return the serial device's parity bits
     ///
@@ -225,14 +245,20 @@ public:
 
     // Port
     //
+    /// @expects none
+    /// @ensures none
+    ///
     /// @return the serial device's port
     ///
-    uint16_t port() const noexcept
+    port_type port() const noexcept
     { return m_port; }
 
     /// Write Character
     ///
     /// Writes a character to the serial device.
+    ///
+    /// @expects none
+    /// @ensures none
     ///
     /// @param c character to write
     ///
@@ -242,30 +268,30 @@ public:
     ///
     /// Writes a string to the serial device.
     ///
+    /// @expects none
+    /// @ensures none
+    ///
     /// @param str string to write
     ///
     void write(const std::string &str) noexcept;
-
-public:
-
-    /// Disable the copy consturctor
-    ///
-    serial_port_intel_x64(const serial_port_intel_x64 &) = delete;
-
-    /// Disable the copy operator
-    ///
-    serial_port_intel_x64 &operator=(const serial_port_intel_x64 &) = delete;
 
 private:
 
     void enable_dlab() const noexcept;
     void disable_dlab() const noexcept;
 
-    bool line_status_empty_transmitter() const noexcept;
+    bool get_line_status_empty_transmitter() const noexcept;
 
 private:
 
-    uint16_t m_port;
+    port_type m_port;
+
+public:
+
+    serial_port_intel_x64(serial_port_intel_x64 &&) noexcept = default;
+    serial_port_intel_x64 &operator=(serial_port_intel_x64 &&) noexcept = default;
+    serial_port_intel_x64(const serial_port_intel_x64 &) = delete;
+    serial_port_intel_x64 &operator=(const serial_port_intel_x64 &) = delete;
 };
 
 #endif

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -26,8 +26,11 @@
 #include <memory>
 #include <debug_ring/debug_ring.h>
 
-#define VCPUID_RESERVED 0x8000000000000000
-#define VCPUID_GUEST_MASK 0xFFFFFFFF00000000
+namespace vcpuid
+{
+constexpr const auto reserved = 0x8000000000000000UL;
+constexpr const auto guest_mask = 0xFFFFFFFF00000000UL;
+}
 
 /// Virtual CPU
 ///
@@ -218,14 +221,14 @@ public:
     /// @return true if this vCPU belongs to the host VM, false otherwise
     ///
     virtual bool is_host_vm_vcpu()
-    { return (m_id & (VCPUID_GUEST_MASK & ~VCPUID_RESERVED)) == 0; }
+    { return (m_id & (vcpuid::guest_mask & ~vcpuid::reserved)) == 0; }
 
     /// Is Guest VM vCPU
     ///
     /// @return true if this vCPU belongs to a guest VM, false otherwise
     ///
     virtual bool is_guest_vm_vcpu()
-    { return (m_id & (VCPUID_GUEST_MASK & ~VCPUID_RESERVED)) != 0; }
+    { return (m_id & (vcpuid::guest_mask & ~vcpuid::reserved)) != 0; }
 
     /// Write to Debug Ring
     ///

--- a/bfvmm/src/serial/src/serial_port_intel_x64.cpp
+++ b/bfvmm/src/serial/src/serial_port_intel_x64.cpp
@@ -22,20 +22,21 @@
 #include <serial/serial_port_intel_x64.h>
 
 using namespace x64;
+using namespace serial_intel_x64;
 
-serial_port_intel_x64::serial_port_intel_x64(uint16_t port) noexcept :
+serial_port_intel_x64::serial_port_intel_x64(serial_port_intel_x64::port_type port) noexcept :
     m_port(port)
 {
-    uint8_t bits = 0;
+    serial_port_intel_x64::value_type bits = 0;
 
     this->disable_dlab();
 
-    bits |= FIFO_CONTROL_ENABLE_FIFOS;
-    bits |= FIFO_CONTROL_CLEAR_RECIEVE_FIFO;
-    bits |= FIFO_CONTROL_CLEAR_TRANSMIT_FIFO;
+    bits |= fifo_control_enable_fifos;
+    bits |= fifo_control_clear_recieve_fifo;
+    bits |= fifo_control_clear_transmit_fifo;
 
-    portio::outb(m_port + INTERRUPT_EN_REG, 0x00);
-    portio::outb(m_port + FIFO_CONTROL_REG, bits);
+    portio::outb(m_port + interrupt_en_reg, 0x00);
+    portio::outb(m_port + fifo_control_reg, bits);
 
     this->set_baud_rate(DEFAULT_BAUD_RATE);
     this->set_data_bits(DEFAULT_DATA_BITS);
@@ -58,8 +59,8 @@ serial_port_intel_x64::set_baud_rate(baud_rate_t rate) noexcept
 
     this->enable_dlab();
 
-    portio::outb(m_port + BAUD_RATE_LO_REG, lsb);
-    portio::outb(m_port + BAUD_RATE_HI_REG, msb);
+    portio::outb(m_port + baud_rate_lo_reg, lsb);
+    portio::outb(m_port + baud_rate_hi_reg, msb);
 
     this->disable_dlab();
 }
@@ -69,8 +70,8 @@ serial_port_intel_x64::baud_rate() const noexcept
 {
     this->enable_dlab();
 
-    auto lsb = portio::inb(m_port + BAUD_RATE_LO_REG);
-    auto msb = portio::inb(m_port + BAUD_RATE_HI_REG);
+    auto lsb = portio::inb(m_port + baud_rate_lo_reg);
+    auto msb = portio::inb(m_port + baud_rate_hi_reg);
 
     this->disable_dlab();
 
@@ -118,20 +119,20 @@ serial_port_intel_x64::baud_rate() const noexcept
 void
 serial_port_intel_x64::set_data_bits(data_bits_t bits) noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    reg = reg & gsl::narrow_cast<decltype(reg)>(~LINE_CONTROL_DATA_MASK);
-    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & LINE_CONTROL_DATA_MASK);
+    reg = reg & gsl::narrow_cast<decltype(reg)>(~line_control_data_mask);
+    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & line_control_data_mask);
 
-    portio::outb(m_port + LINE_CONTROL_REG, reg);
+    portio::outb(m_port + line_control_reg, reg);
 }
 
 serial_port_intel_x64::data_bits_t
 serial_port_intel_x64::data_bits() const noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    switch (reg & LINE_CONTROL_DATA_MASK)
+    switch (reg & line_control_data_mask)
     {
         case char_length_5:
             return char_length_5;
@@ -147,20 +148,20 @@ serial_port_intel_x64::data_bits() const noexcept
 void
 serial_port_intel_x64::set_stop_bits(stop_bits_t bits) noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    reg = reg & gsl::narrow_cast<decltype(reg)>(~LINE_CONTROL_STOP_MASK);
-    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & LINE_CONTROL_STOP_MASK);
+    reg = reg & gsl::narrow_cast<decltype(reg)>(~line_control_stop_mask);
+    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & line_control_stop_mask);
 
-    portio::outb(m_port + LINE_CONTROL_REG, reg);
+    portio::outb(m_port + line_control_reg, reg);
 }
 
 serial_port_intel_x64::stop_bits_t
 serial_port_intel_x64::stop_bits() const noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    switch (reg & LINE_CONTROL_STOP_MASK)
+    switch (reg & line_control_stop_mask)
     {
         case stop_bits_1:
             return stop_bits_1;
@@ -172,20 +173,20 @@ serial_port_intel_x64::stop_bits() const noexcept
 void
 serial_port_intel_x64::set_parity_bits(parity_bits_t bits) noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    reg = reg & gsl::narrow_cast<decltype(reg)>(~LINE_CONTROL_PARITY_MASK);
-    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & LINE_CONTROL_PARITY_MASK);
+    reg = reg & gsl::narrow_cast<decltype(reg)>(~line_control_parity_mask);
+    reg = reg | gsl::narrow_cast<decltype(reg)>(bits & line_control_parity_mask);
 
-    portio::outb(m_port + LINE_CONTROL_REG, reg);
+    portio::outb(m_port + line_control_reg, reg);
 }
 
 serial_port_intel_x64::parity_bits_t
 serial_port_intel_x64::parity_bits() const noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
+    auto reg = portio::inb(m_port + line_control_reg);
 
-    switch (reg & LINE_CONTROL_PARITY_MASK)
+    switch (reg & line_control_parity_mask)
     {
         case parity_odd:
             return parity_odd;
@@ -203,8 +204,7 @@ serial_port_intel_x64::parity_bits() const noexcept
 void
 serial_port_intel_x64::write(char c) noexcept
 {
-    while (!line_status_empty_transmitter());
-
+    while (!get_line_status_empty_transmitter());
     portio::outb(m_port, c);
 }
 
@@ -218,21 +218,21 @@ serial_port_intel_x64::write(const std::string &str) noexcept
 void
 serial_port_intel_x64::enable_dlab() const noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
-    reg = reg | gsl::narrow_cast<decltype(reg)>(DLAB);
-    portio::outb(m_port + LINE_CONTROL_REG, reg);
+    auto reg = portio::inb(m_port + line_control_reg);
+    reg = reg | gsl::narrow_cast<decltype(reg)>(dlab);
+    portio::outb(m_port + line_control_reg, reg);
 }
 
 void
 serial_port_intel_x64::disable_dlab() const noexcept
 {
-    auto reg = portio::inb(m_port + LINE_CONTROL_REG);
-    reg = reg & gsl::narrow_cast<decltype(reg)>(~DLAB);
-    portio::outb(m_port + LINE_CONTROL_REG, reg);
+    auto reg = portio::inb(m_port + line_control_reg);
+    reg = reg & gsl::narrow_cast<decltype(reg)>(~(dlab));
+    portio::outb(m_port + line_control_reg, reg);
 }
 
 bool
-serial_port_intel_x64::line_status_empty_transmitter() const noexcept
+serial_port_intel_x64::get_line_status_empty_transmitter() const noexcept
 {
-    return (portio::inb(m_port + LINE_STATUS_REG) & LINE_STATUS_EMPTY_TRANSMITTER) != 0;
+    return (portio::inb(m_port + line_status_reg) & line_status_empty_transmitter) != 0;
 }

--- a/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
+++ b/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
@@ -46,20 +46,20 @@ serial_ut::test_serial_null_intrinsics()
 void
 serial_ut::test_serial_success()
 {
-    EXPECT_TRUE(serial_port_intel_x64::instance()->port() == DEFAULT_COM_PORT);
+    EXPECT_TRUE(serial_port_intel_x64::instance()->port() == serial_intel_x64::DEFAULT_COM_PORT);
     EXPECT_TRUE(serial_port_intel_x64::instance()->baud_rate() == serial_port_intel_x64::DEFAULT_BAUD_RATE);
     EXPECT_TRUE(serial_port_intel_x64::instance()->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
     EXPECT_TRUE(serial_port_intel_x64::instance()->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
     EXPECT_TRUE(serial_port_intel_x64::instance()->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + BAUD_RATE_LO_REG]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + BAUD_RATE_HI_REG]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + FIFO_CONTROL_REG] & FIFO_CONTROL_ENABLE_FIFOS) != 0);
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + FIFO_CONTROL_REG] & FIFO_CONTROL_CLEAR_RECIEVE_FIFO) != 0);
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + FIFO_CONTROL_REG] & FIFO_CONTROL_CLEAR_TRANSMIT_FIFO) != 0);
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + LINE_CONTROL_REG] & LINE_CONTROL_DATA_MASK) == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + LINE_CONTROL_REG] & LINE_CONTROL_STOP_MASK) == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE((g_ports[DEFAULT_COM_PORT + LINE_CONTROL_REG] & LINE_CONTROL_PARITY_MASK) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_lo_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_hi_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_enable_fifos) != 0);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_recieve_fifo) != 0);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_transmit_fifo) != 0);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_data_mask) == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_stop_mask) == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_parity_mask) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void
@@ -125,7 +125,7 @@ serial_ut::test_serial_set_data_bits_success_extra_bits()
 {
     auto serial = std::make_unique<serial_port_intel_x64>();
 
-    auto bits = serial_port_intel_x64::DEFAULT_DATA_BITS | ~LINE_CONTROL_DATA_MASK;
+    auto bits = serial_port_intel_x64::DEFAULT_DATA_BITS | ~serial_intel_x64::line_control_data_mask;
     serial->set_data_bits(static_cast<serial_port_intel_x64::data_bits_t>(bits));
 
     EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
@@ -149,7 +149,7 @@ serial_ut::test_serial_set_stop_bits_success_extra_bits()
 {
     auto serial = std::make_unique<serial_port_intel_x64>();
 
-    auto bits = serial_port_intel_x64::DEFAULT_STOP_BITS | ~LINE_CONTROL_STOP_MASK;
+    auto bits = serial_port_intel_x64::DEFAULT_STOP_BITS | ~serial_intel_x64::line_control_stop_mask;
     serial->set_stop_bits(static_cast<serial_port_intel_x64::stop_bits_t>(bits));
 
     EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
@@ -179,7 +179,7 @@ serial_ut::test_serial_set_parity_bits_success_extra_bits()
 {
     auto serial = std::make_unique<serial_port_intel_x64>();
 
-    auto bits = serial_port_intel_x64::DEFAULT_PARITY_BITS | ~LINE_CONTROL_PARITY_MASK;
+    auto bits = serial_port_intel_x64::DEFAULT_PARITY_BITS | ~serial_intel_x64::line_control_parity_mask;
     serial->set_parity_bits(static_cast<serial_port_intel_x64::parity_bits_t>(bits));
 
     EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
@@ -190,7 +190,7 @@ serial_ut::test_serial_set_parity_bits_success_extra_bits()
 void
 serial_ut::test_serial_write_character()
 {
-    g_ports[DEFAULT_COM_PORT + LINE_STATUS_REG] = 0xFF;
+    g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
 
     auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write('c');
@@ -199,7 +199,7 @@ serial_ut::test_serial_write_character()
 void
 serial_ut::test_serial_write_string()
 {
-    g_ports[DEFAULT_COM_PORT + LINE_STATUS_REG] = 0xFF;
+    g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
 
     auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write("hello world");

--- a/bfvmm/src/vcpu/src/vcpu.cpp
+++ b/bfvmm/src/vcpu/src/vcpu.cpp
@@ -28,7 +28,7 @@ vcpu::vcpu(uint64_t id, std::shared_ptr<debug_ring> dr) :
     m_is_running(false),
     m_is_initialized(false)
 {
-    if ((id & VCPUID_RESERVED) != 0)
+    if ((id & vcpuid::reserved) != 0)
         throw std::invalid_argument("invalid vcpuid");
 
     if (!m_debug_ring) m_debug_ring = std::make_shared<debug_ring>(id);

--- a/bfvmm/src/vcpu/test/test_vcpu.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu.cpp
@@ -26,7 +26,7 @@
 void
 vcpu_ut::test_vcpu_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_unique<vcpu>(VCPUID_RESERVED, nullptr), std::invalid_argument);
+    EXPECT_EXCEPTION(std::make_unique<vcpu>(vcpuid::reserved, nullptr), std::invalid_argument);
 }
 
 void

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -113,7 +113,7 @@ setup_pt(MockRepository &mocks)
 void
 vcpu_ut::test_vcpu_intel_x64_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_unique<vcpu_intel_x64>(VCPUID_RESERVED), std::invalid_argument);
+    EXPECT_EXCEPTION(std::make_unique<vcpu_intel_x64>(vcpuid::reserved), std::invalid_argument);
 }
 
 void

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_debug.cpp
@@ -25,13 +25,6 @@
 
 #if 0
 
-#define PRINT_FIELD(a,b) \
-    bfdebug << #b << ": "; \
-    if ((a) == true) \
-        bfinfo << view_as_pointer(vmread(b)) << bfendl; \
-    else \
-        bfinfo << "unsupported" << bfendl;
-
 void
 vmcs_intel_x64::dump_vmcs()
 {
@@ -418,10 +411,6 @@ vmcs_intel_x64::print_execution_controls()
     print_vm_exit_control_fields();
     print_vm_entry_control_fields();
 }
-
-#define PRINT_CONTROL(a) \
-    if ((controls & (a)) != 0) \
-        bfdebug << #a << bfendl;
 
 void
 vmcs_intel_x64::print_pin_based_vm_execution_controls()

--- a/include/constants.h
+++ b/include/constants.h
@@ -269,4 +269,49 @@
 #define VMCALL_OUT_BUFFER_SIZE (32 * MAX_PAGE_SIZE)
 #endif
 
+/**
+ * Default Serial COM Port
+ *
+ * Note: See bfvmm/serial/serial_port_intel_x64.h
+ */
+#ifndef DEFAULT_COM_PORT
+#define DEFAULT_COM_PORT com1_port
+#endif
+
+/**
+ * Default Serial Baud Rate
+ *
+ * Note: See bfvmm/serial/serial_port_intel_x64.h
+ */
+#ifndef DEFAULT_BAUD_RATE
+#define DEFAULT_BAUD_RATE baud_rate_115200
+#endif
+
+/**
+ * Default Serial Data Bits
+ *
+ * Note: See bfvmm/serial/serial_port_intel_x64.h
+ */
+#ifndef DEFAULT_DATA_BITS
+#define DEFAULT_DATA_BITS char_length_8
+#endif
+
+/**
+ * Default Serial Stop Bits
+ *
+ * Note: See bfvmm/serial/serial_port_intel_x64.h
+ */
+#ifndef DEFAULT_STOP_BITS
+#define DEFAULT_STOP_BITS stop_bits_1
+#endif
+
+/**
+ * Default Serial Parity Bits
+ *
+ * Note: See bfvmm/serial/serial_port_intel_x64.h
+ */
+#ifndef DEFAULT_PARITY_BITS
+#define DEFAULT_PARITY_BITS parity_none
+#endif
+
 #endif


### PR DESCRIPTION
This patch removes the remaining #defines that are not needed.
There is still a lot of cleanup with respect to aliases and
documentation, but this at least gets rid of the #defines
which is a good first start. Not that this is only for the
VMM. Since other code uses C, there are #defines were C is
used.

Signed-off-by: “Rian <“rianquinn@gmail.com”>