### PR TITLE
Clean up miscellaneous vmcs code

### DIFF
--- a/bfvmm/include/intrinsics/x64.h
+++ b/bfvmm/include/intrinsics/x64.h
@@ -4,6 +4,7 @@
 // Copyright (C) 2015 Assured Information Security, Inc.
 // Author: Rian Quinn        <quinnr@ainfosec.com>
 // Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+// Author: Connor Davis      <davisc@ainfosec.com>
 //
 // This library is free software; you can redistribute it and/or
 // modify it under the terms of the GNU Lesser General Public
@@ -22,7 +23,11 @@
 #ifndef X64_H
 #define X64_H
 
+#include <gsl/gsl>
 #include <constants.h>
+#include <type_traits>
+
+#include <intrinsics/cpuid_x64.h>
 
 // *INDENT-OFF*
 
@@ -109,6 +114,24 @@ namespace interrupt
     constexpr const auto simd_floating_point_exception                   = 19U;
     constexpr const auto virtualization_exception                        = 20U;
 }
+
+template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+auto is_address_canonical(T addr)
+{ return ((addr <= 0x00007FFFFFFFFFFFUL) || (addr >= 0xFFFF800000000000UL)); }
+
+template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+auto is_linear_address_valid(T addr)
+{ return is_address_canonical(addr); }
+
+template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+auto is_physical_address_valid(T addr)
+{
+    auto bits = cpuid::addr_size::phys::get();
+    auto mask = (0xFFFFFFFFFFFFFFFFULL >> bits) << bits;
+
+    return ((addr & mask) == 0);
+}
+
 }
 
 // *INDENT-ON*

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
@@ -47,7 +47,8 @@ namespace vm_instruction_error
     inline auto get_if_exists(bool verbose = false) noexcept
     { return get_vmcs_field_if_exists(addr, name, verbose, exists()); }
 
-    inline auto __vm_instruction_error_description(uint64_t error)
+    template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    auto __vm_instruction_error_description(T error)
     {
         switch (error)
         {
@@ -136,8 +137,8 @@ namespace vm_instruction_error
         }
     }
 
-    inline auto
-    vm_instruction_error_description(uint64_t error, bool exists)
+    template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    auto vm_instruction_error_description(T error, bool exists)
     {
         if (!exists)
             throw std::logic_error("vm_instruction_error() failed: vm_instruction_error field doesn't exist");
@@ -145,8 +146,8 @@ namespace vm_instruction_error
         return __vm_instruction_error_description(error);
     }
 
-    inline auto
-    vm_instruction_error_description_if_exists(uint64_t error, bool verbose, bool exists)
+    template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    auto vm_instruction_error_description_if_exists(T error, bool verbose, bool exists)
     {
         if (!exists && verbose)
             bfwarning << "vm_instruction_error() failed: vm_instruction_error field doesn't exist" << '\n';
@@ -254,8 +255,8 @@ namespace exit_reason
         inline auto get_if_exists(bool verbose = false) noexcept
         { return get_bits(get_vmcs_field_if_exists(addr, name, verbose, exists()), mask) >> from; }
 
-        inline auto
-        __basic_exit_reason_description(uint64_t reason)
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto __basic_exit_reason_description(T reason)
         {
             switch (reason)
             {
@@ -444,8 +445,8 @@ namespace exit_reason
             };
         }
 
-        inline auto
-        basic_exit_reason_description(uint64_t reason, bool exists)
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto basic_exit_reason_description(T reason, bool exists)
         {
             if (!exists)
                 throw std::logic_error("basic_exit_reason_description failed: exit_reason field doesn't exist");
@@ -453,8 +454,8 @@ namespace exit_reason
             return __basic_exit_reason_description(reason);
         }
 
-        inline auto
-        basic_exit_reason_description_if_exists(uint64_t reason, bool verbose, bool exists)
+        template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+        auto basic_exit_reason_description_if_exists(T reason, bool verbose, bool exists)
         {
             if (!exists && verbose)
                 bfwarning << "basic_exit_reason_description_if_exists failed: exit_reason field doesn't exist" << '\n';

--- a/bfvmm/include/vmcs/vmcs_intel_x64_64bit_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_64bit_control_fields.h
@@ -34,9 +34,12 @@
 /// Developer's manual.
 ///
 
-inline void
-set_vm_function_control(bool val, uint64_t msr_addr, uint64_t ctls_addr,
-                        const char *name, uint64_t mask, bool field_exists)
+template<class MA, class CA, class M,
+         class = typename std::enable_if<std::is_integral<MA>::value>::type,
+         class = typename std::enable_if<std::is_integral<CA>::value>::type,
+         class = typename std::enable_if<std::is_integral<M>::value>::type>
+auto set_vm_function_control(bool val, MA msr_addr, CA ctls_addr,
+                             const char *name, M mask, bool field_exists)
 {
     if (!field_exists)
     {
@@ -61,10 +64,13 @@ set_vm_function_control(bool val, uint64_t msr_addr, uint64_t ctls_addr,
     }
 }
 
-inline void
-set_vm_function_control_if_allowed(bool val, uint64_t msr_addr, uint64_t ctls_addr,
-                                   const char *name, uint64_t mask,
-                                   bool verbose, bool field_exists) noexcept
+template<class MA, class CA, class M,
+         class = typename std::enable_if<std::is_integral<MA>::value>::type,
+         class = typename std::enable_if<std::is_integral<CA>::value>::type,
+         class = typename std::enable_if<std::is_integral<M>::value>::type>
+auto set_vm_function_control_if_allowed(bool val, MA msr_addr, CA ctls_addr,
+                                        const char *name, M mask,
+                                        bool verbose, bool field_exists) noexcept
 {
     if (!field_exists)
     {

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_controls.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_controls.cpp
@@ -154,10 +154,10 @@ vmcs_intel_x64::check_control_io_bitmap_address_bits()
     if ((addr_b & 0x0000000000000FFF) != 0)
         throw std::logic_error("io bitmap b addr not page aligned");
 
-    if (!is_physical_address_valid(addr_a))
+    if (!x64::is_physical_address_valid(addr_a))
         throw std::logic_error("io bitmap a addr too large");
 
-    if (!is_physical_address_valid(addr_b))
+    if (!x64::is_physical_address_valid(addr_b))
         throw std::logic_error("io bitmap b addr too large");
 }
 
@@ -172,7 +172,7 @@ vmcs_intel_x64::check_control_msr_bitmap_address_bits()
     if ((addr & 0x0000000000000FFF) != 0)
         throw std::logic_error("msr bitmap addr not page aligned");
 
-    if (!is_physical_address_valid(addr))
+    if (!x64::is_physical_address_valid(addr))
         throw std::logic_error("msr bitmap addr too large");
 }
 
@@ -194,7 +194,7 @@ vmcs_intel_x64::check_control_tpr_shadow_and_virtual_apic()
         if ((phys_addr & 0x0000000000000FFFUL) != 0)
             throw std::logic_error("virtual apic addr not 4k aligned");
 
-        if (!is_physical_address_valid(phys_addr))
+        if (!x64::is_physical_address_valid(phys_addr))
             throw std::logic_error("virtual apic addr too large");
 
         if (secondary_ctls_enabled && virtual_interrupt_delivery::is_enabled_if_exists())
@@ -274,7 +274,7 @@ vmcs_intel_x64::check_control_virtual_apic_address_bits()
     if ((phys_addr & 0x0000000000000FFF) != 0)
         throw std::logic_error("apic access addr not 4k aligned");
 
-    if (!is_physical_address_valid(phys_addr))
+    if (!x64::is_physical_address_valid(phys_addr))
         throw std::logic_error("apic access addr too large");
 }
 
@@ -335,7 +335,7 @@ vmcs_intel_x64::check_control_process_posted_interrupt_checks()
         throw std::logic_error("bits 5:0 of the interrupt descriptor addr "
                                "must be 0 if posted interrupts is 1");
 
-    if (!is_physical_address_valid(addr))
+    if (!x64::is_physical_address_valid(addr))
         throw std::logic_error("interrupt descriptor addr too large");
 }
 
@@ -399,7 +399,7 @@ vmcs_intel_x64::check_control_enable_pml_checks()
     if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists())
         throw std::logic_error("ept must be enabled if pml is enabled");
 
-    if (!is_physical_address_valid(pml_addr))
+    if (!x64::is_physical_address_valid(pml_addr))
         throw std::logic_error("pml address must be a valid physical address");
 
     if ((pml_addr & 0x0000000000000FFF) != 0)
@@ -445,7 +445,7 @@ vmcs_intel_x64::check_control_enable_vm_functions()
     if ((eptp_list & 0x0000000000000FFFU) != 0)
         throw std::logic_error("bits 11:0 must be 0 for eptp list address");
 
-    if (!is_physical_address_valid(eptp_list))
+    if (!x64::is_physical_address_valid(eptp_list))
         throw std::logic_error("eptp list address addr too large");
 }
 
@@ -467,10 +467,10 @@ vmcs_intel_x64::check_control_enable_vmcs_shadowing()
     if ((vmcs_vmwrite_bitmap_address & 0x0000000000000FFF) != 0)
         throw std::logic_error("bits 11:0 must be 0 for the vmcs write bitmap address");
 
-    if (!is_physical_address_valid(vmcs_vmread_bitmap_address))
+    if (!x64::is_physical_address_valid(vmcs_vmread_bitmap_address))
         throw std::logic_error("vmcs read bitmap address addr too large");
 
-    if (!is_physical_address_valid(vmcs_vmwrite_bitmap_address))
+    if (!x64::is_physical_address_valid(vmcs_vmwrite_bitmap_address))
         throw std::logic_error("vmcs write bitmap address addr too large");
 }
 
@@ -489,7 +489,7 @@ vmcs_intel_x64::check_control_enable_ept_violation_checks()
     if ((vmcs_virt_except_info_address & 0x0000000000000FFF) != 0)
         throw std::logic_error("bits 11:0 must be 0 for the vmcs virt except info address");
 
-    if (!is_physical_address_valid(vmcs_virt_except_info_address))
+    if (!x64::is_physical_address_valid(vmcs_virt_except_info_address))
         throw std::logic_error("vmcs virt except info address addr too large");
 }
 
@@ -536,12 +536,12 @@ vmcs_intel_x64::check_control_exit_msr_store_address()
     if ((msr_store_addr & 0x000000000000000F) != 0)
         throw std::logic_error("bits 3:0 must be 0 for the exit msr store address");
 
-    if (!is_physical_address_valid(msr_store_addr))
+    if (!x64::is_physical_address_valid(msr_store_addr))
         throw std::logic_error("exit msr store addr too large");
 
     auto msr_store_addr_end = msr_store_addr + (msr_store_count * 16) - 1;
 
-    if (!is_physical_address_valid(msr_store_addr_end))
+    if (!x64::is_physical_address_valid(msr_store_addr_end))
         throw std::logic_error("end of exit msr store area too large");
 }
 
@@ -558,12 +558,12 @@ vmcs_intel_x64::check_control_exit_msr_load_address()
     if ((msr_load_addr & 0x000000000000000F) != 0)
         throw std::logic_error("bits 3:0 must be 0 for the exit msr load address");
 
-    if (!is_physical_address_valid(msr_load_addr))
+    if (!x64::is_physical_address_valid(msr_load_addr))
         throw std::logic_error("exit msr load addr too large");
 
     auto msr_load_addr_end = msr_load_addr + (msr_load_count * 16) - 1;
 
-    if (!is_physical_address_valid(msr_load_addr_end))
+    if (!x64::is_physical_address_valid(msr_load_addr_end))
         throw std::logic_error("end of exit msr load area too large");
 }
 
@@ -712,7 +712,7 @@ vmcs_intel_x64::check_control_event_injection_instr_length_checks()
             return;
     }
 
-    if (instruction_length == 0 && !is_supported_event_injection_instr_length_of_0())
+    if (instruction_length == 0 && !msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get())
         throw std::logic_error("instruction length must be greater than zero");
 
     if (instruction_length > 15)
@@ -732,11 +732,11 @@ vmcs_intel_x64::check_control_entry_msr_load_address()
     if ((msr_load_addr & 0x000000000000000F) != 0)
         throw std::logic_error("bits 3:0 must be 0 for the entry msr load address");
 
-    if (!is_physical_address_valid(msr_load_addr))
+    if (!x64::is_physical_address_valid(msr_load_addr))
         throw std::logic_error("entry msr load addr too large");
 
     auto msr_load_addr_end = msr_load_addr + (msr_load_count * 16) - 1;
 
-    if (!is_physical_address_valid(msr_load_addr_end))
+    if (!x64::is_physical_address_valid(msr_load_addr_end))
         throw std::logic_error("end of entry msr load area too large");
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_guest.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_guest.cpp
@@ -1594,7 +1594,7 @@ vmcs_intel_x64::check_guest_hlt_valid_interrupts()
             break;
 
         case interruption_type::other_event:
-            if (vector == MTF_VM_EXIT)
+            if (vector == interrupt::divide_error)
                 return;
 
             break;

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_host.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_host.cpp
@@ -87,21 +87,21 @@ vmcs_intel_x64::check_host_cr4_for_unsupported_bits()
 void
 vmcs_intel_x64::check_host_cr3_for_unsupported_bits()
 {
-    if (!is_physical_address_valid(vmcs::host_cr3::get()))
+    if (!x64::is_physical_address_valid(vmcs::host_cr3::get()))
         throw std::logic_error("host cr3 too large");
 }
 
 void
 vmcs_intel_x64::check_host_ia32_sysenter_esp_canonical_address()
 {
-    if (!is_address_canonical(vmcs::host_ia32_sysenter_esp::get()))
+    if (!x64::is_address_canonical(vmcs::host_ia32_sysenter_esp::get()))
         throw std::logic_error("host sysenter esp must be canonical");
 }
 
 void
 vmcs_intel_x64::check_host_ia32_sysenter_eip_canonical_address()
 {
-    if (!is_address_canonical(vmcs::host_ia32_sysenter_eip::get()))
+    if (!x64::is_address_canonical(vmcs::host_ia32_sysenter_eip::get()))
         throw std::logic_error("host sysenter eip must be canonical");
 }
 
@@ -296,35 +296,35 @@ vmcs_intel_x64::check_host_ss_not_equal_zero()
 void
 vmcs_intel_x64::check_host_fs_canonical_base_address()
 {
-    if (!is_address_canonical(vmcs::host_fs_base::get()))
+    if (!x64::is_address_canonical(vmcs::host_fs_base::get()))
         throw std::logic_error("host fs base must be canonical");
 }
 
 void
 vmcs_intel_x64::check_host_gs_canonical_base_address()
 {
-    if (!is_address_canonical(vmcs::host_gs_base::get()))
+    if (!x64::is_address_canonical(vmcs::host_gs_base::get()))
         throw std::logic_error("host gs base must be canonical");
 }
 
 void
 vmcs_intel_x64::check_host_gdtr_canonical_base_address()
 {
-    if (!is_address_canonical(vmcs::host_gdtr_base::get()))
+    if (!x64::is_address_canonical(vmcs::host_gdtr_base::get()))
         throw std::logic_error("host gdtr base must be canonical");
 }
 
 void
 vmcs_intel_x64::check_host_idtr_canonical_base_address()
 {
-    if (!is_address_canonical(vmcs::host_idtr_base::get()))
+    if (!x64::is_address_canonical(vmcs::host_idtr_base::get()))
         throw std::logic_error("host idtr base must be canonical");
 }
 
 void
 vmcs_intel_x64::check_host_tr_canonical_base_address()
 {
-    if (!is_address_canonical(vmcs::host_tr_base::get()))
+    if (!x64::is_address_canonical(vmcs::host_tr_base::get()))
         throw std::logic_error("host tr base must be canonical");
 }
 
@@ -385,6 +385,6 @@ vmcs_intel_x64::check_host_host_address_space_enabled()
     if (vmcs::host_cr4::physical_address_extensions::is_disabled())
         throw std::logic_error("cr4 pae must be enabled if host addr space is enabled");
 
-    if (!is_address_canonical(vmcs::host_rip::get()))
+    if (!x64::is_address_canonical(vmcs::host_rip::get()))
         throw std::logic_error("host rip must be canonical");
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_check_misc.cpp
@@ -28,33 +28,6 @@ using namespace x64;
 using namespace intel_x64;
 
 bool
-vmcs_intel_x64::is_address_canonical(uint64_t addr)
-{
-    return ((addr <= 0x00007FFFFFFFFFFF) || (addr >= 0xFFFF800000000000));
-}
-
-bool
-vmcs_intel_x64::is_linear_address_valid(uint64_t addr)
-{
-    return is_address_canonical(addr);
-}
-
-bool
-vmcs_intel_x64::is_physical_address_valid(uint64_t addr)
-{
-    auto bits = cpuid::addr_size::phys::get();
-    auto mask = (0xFFFFFFFFFFFFFFFFULL >> bits) << bits;
-
-    return ((addr & mask) == 0);
-}
-
-bool
-vmcs_intel_x64::is_supported_event_injection_instr_length_of_0() const
-{
-    return msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::get();
-}
-
-bool
 vmcs_intel_x64::check_pat(uint64_t pat)
 {
     switch (pat)

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
@@ -689,7 +689,8 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
     {
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::enable_ept::mask);
         vmcs::ept_pointer::memory_type::set(vmcs::ept_pointer::memory_type::uncacheable);
-        g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~(IA32_VMX_EPT_VPID_CAP_UC | IA32_VMX_EPT_VPID_CAP_WB);
+        g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = ~(msrs::ia32_vmx_ept_vpid_cap::memory_type_uncacheable_supported::mask |
+        msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::mask);
     };
     path.throws_exception = true;
     path.exception = std::shared_ptr<std::exception>(new std::logic_error("hardware does not support ept memory type: uncachable"));
@@ -707,7 +708,7 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
 
     path.setup = [&]
     {
-        g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = IA32_VMX_EPT_VPID_CAP_WB;
+        g_msrs[msrs::ia32_vmx_ept_vpid_cap::addr] = msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::mask;
         vmcs::ept_pointer::memory_type::set(vmcs::ept_pointer::memory_type::write_back);
         vmcs::ept_pointer::page_walk_length_minus_one::set(0U);
     };


### PR DESCRIPTION
This patch removes instances of uint64_t in the vmcs
namespaces and the rest of the #defines in vmcs_intel_x64.h.