### PR TITLE
GSL Update

### DIFF
--- a/bfvmm/include/memory_manager/memory_manager_x64.h
+++ b/bfvmm/include/memory_manager/memory_manager_x64.h
@@ -337,7 +337,7 @@ public:
     ///
     /// @return memory descriptor list
     ///
-    virtual memory_descriptor_list descriptors() const noexcept;
+    virtual memory_descriptor_list descriptors() const;
 
 private:
 

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64_unittests.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64_unittests.cpp
@@ -28,7 +28,9 @@
 
 void
 exit_handler_intel_x64::handle_vmcall_unittest(vmcall_registers_t &regs)
-{ (void) regs; }
+{
+    (void) regs;
+}
 
 #else
 

--- a/bfvmm/src/intrinsics/src/cpuid_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/cpuid_x64_mock.cpp
@@ -19,6 +19,9 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#undef GSL_THROW_ON_CONTRACT_VIOLATION
+#define GSL_TERMINATE_ON_CONTRACT_VIOLATION
+
 #include <gsl/gsl>
 #include <debug.h>
 

--- a/bfvmm/src/memory_manager/src/memory_manager_x64.cpp
+++ b/bfvmm/src/memory_manager/src/memory_manager_x64.cpp
@@ -261,7 +261,7 @@ memory_manager_x64::remove_md(integer_pointer virt) noexcept
 }
 
 memory_manager_x64::memory_descriptor_list
-memory_manager_x64::descriptors() const noexcept
+memory_manager_x64::descriptors() const
 {
     memory_descriptor_list list;
     std::lock_guard<std::mutex> guard(g_add_md_mutex);

--- a/bfvmm/src/memory_manager/src/root_page_table_x64.cpp
+++ b/bfvmm/src/memory_manager/src/root_page_table_x64.cpp
@@ -19,6 +19,7 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <debug.h>
 #include <guard_exceptions.h>
 #include <memory_manager/memory_manager_x64.h>
 #include <memory_manager/root_page_table_x64.h>
@@ -141,8 +142,6 @@ root_page_table_x64::map_page(integer_pointer virt, integer_pointer phys, attr_t
 void
 root_page_table_x64::unmap_page(integer_pointer virt) noexcept
 {
-    expects(virt != 0);
-
     guard_exceptions([&]
     { this->remove_page(virt); });
 

--- a/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
@@ -39,13 +39,23 @@ vcpu_intel_x64::vcpu_intel_x64(uint64_t id,
 {
 }
 
+// REMOVE ME
+namespace bfn
+{
+template<class T, class... Args>
+std::shared_ptr<T> make_shared(Args &&... args)
+{
+    return std::shared_ptr<T>(new T{std::forward<Args>(args)...});
+}
+}
+
 void
 vcpu_intel_x64::init(void *attr)
 {
     auto ___ = gsl::on_failure([&]
     { this->fini(); });
 
-    if (!m_state_save) m_state_save = gsl::make_shared<state_save_intel_x64>();
+    if (!m_state_save) m_state_save = bfn::make_shared<state_save_intel_x64>();
     if (!m_vmxon) m_vmxon = std::make_shared<vmxon_intel_x64>();
     if (!m_vmcs) m_vmcs = std::make_shared<vmcs_intel_x64>();
     if (!m_exit_handler) m_exit_handler = std::make_shared<exit_handler_intel_x64>();

--- a/include/gsl/gsl
+++ b/include/gsl/gsl
@@ -19,18 +19,13 @@
 #ifndef GSL_GSL_H
 #define GSL_GSL_H
 
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
-
-// The GSL does not like clang-tidy when other checks are being performed
-// so we disable them here.
-
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
 #pragma GCC system_header
-
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
 
 #include "gsl_assert"  // Ensures/Expects
 #include "gsl_util"    // finally()/narrow()/narrow_cast()...
@@ -42,13 +37,13 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // MSVC 2013 workarounds
 #if _MSC_VER <= 1800
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 // turn off some misguided warnings
 #pragma warning(push)
@@ -66,20 +61,6 @@ namespace gsl
 //
 using std::unique_ptr;
 using std::shared_ptr;
-
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
-
-template<class T, class... Args>
-shared_ptr<T> make_shared(Args&&... args)
-{
-    return std::shared_ptr<T>(new T{std::forward<Args>(args)...});
-}
-
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
 
 template <class T>
 using owner = T;

--- a/include/gsl/gsl_algorithm
+++ b/include/gsl/gsl_algorithm
@@ -1,0 +1,61 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Copyright (c) 2015 Microsoft Corporation. All rights reserved.
+//
+// This code is licensed under the MIT License (MIT).
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#ifndef GSL_ALGORITHM_H
+#define GSL_ALGORITHM_H
+
+#include "span"
+#include <algorithm>
+
+#ifdef _MSC_VER
+
+#pragma warning(push)
+
+// turn off some warnings that are noisy about our Expects statements
+#pragma warning(disable : 4127) // conditional expression is constant
+
+// blanket turn off warnings from CppCoreCheck for now
+// so people aren't annoyed by them when running the tool.
+// more targeted suppressions will be added in a future update to the GSL
+#pragma warning(disable : 26481 26482 26483 26485 26490 26491 26492 26493 26495)
+
+#endif // _MSC_VER
+
+namespace gsl
+{
+
+template <class SrcElementType, std::ptrdiff_t SrcExtent,
+          class DestElementType, std::ptrdiff_t DestExtent>
+void copy(span<SrcElementType, SrcExtent> src, span<DestElementType, DestExtent> dest)
+{
+    static_assert(std::is_assignable<decltype(*dest.data()), decltype(*src.data())>::value,
+                  "Elements of source span can not be assigned to elements of destination span");
+    static_assert(SrcExtent == dynamic_extent || DestExtent == dynamic_extent || (SrcExtent <= DestExtent),
+                  "Source range is longer than target range");
+
+    Expects(dest.size() >= src.size());
+    std::copy_n(src.data(), src.size(), dest.data());
+}
+
+} // namespace gsl
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
+
+#endif // GSL_ALGORITHM_H

--- a/include/gsl/gsl_assert
+++ b/include/gsl/gsl_assert
@@ -38,6 +38,14 @@
 #define GSL_STRINGIFY_DETAIL(x) #x
 #define GSL_STRINGIFY(x) GSL_STRINGIFY_DETAIL(x)
 
+#if defined(__clang__) || defined(__GNUC__)
+#define GSL_LIKELY(x) __builtin_expect (!!(x), 1)
+#define GSL_UNLIKELY(x) __builtin_expect (!!(x), 0)
+#else
+#define GSL_LIKELY(x) (x)
+#define GSL_UNLIKELY(x) (x)
+#endif
+
 //
 // GSL.assert: assertions
 //
@@ -53,19 +61,19 @@ struct fail_fast : public std::runtime_error
 #if defined(GSL_THROW_ON_CONTRACT_VIOLATION)
 
 #define Expects(cond)                                                                              \
-    if (!(cond))                                                                                   \
+    if (GSL_UNLIKELY(!(cond)))                                                                     \
         throw gsl::fail_fast("GSL: Precondition failure at " __FILE__ ": " GSL_STRINGIFY(__LINE__));
 #define Ensures(cond)                                                                              \
-    if (!(cond))                                                                                   \
+    if (GSL_UNLIKELY(!(cond)))                                                                     \
         throw gsl::fail_fast("GSL: Postcondition failure at " __FILE__                             \
                              ": " GSL_STRINGIFY(__LINE__));
 
 #elif defined(GSL_TERMINATE_ON_CONTRACT_VIOLATION)
 
 #define Expects(cond)                                                                              \
-    if (!(cond)) std::terminate();
+    if (GSL_UNLIKELY(!(cond))) std::terminate();
 #define Ensures(cond)                                                                              \
-    if (!(cond)) std::terminate();
+    if (GSL_UNLIKELY(!(cond))) std::terminate();
 
 #elif defined(GSL_UNENFORCED_ON_CONTRACT_VIOLATION)
 
@@ -74,7 +82,13 @@ struct fail_fast : public std::runtime_error
 
 #endif
 
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
 #define expects(cond) Expects(cond)
 #define ensures(cond) Ensures(cond)
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
 
 #endif // GSL_CONTRACTS_H

--- a/include/gsl/gsl_byte
+++ b/include/gsl/gsl_byte
@@ -21,16 +21,21 @@
 
 #ifdef _MSC_VER
 
+#pragma warning(push)
+
+// don't warn about function style casts in byte related operators
+#pragma warning(disable : 26493)
+
 // MSVC 2013 workarounds
 #if _MSC_VER <= 1800
 
 // constexpr is not understood
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 #endif // _MSC_VER <= 1800
 
@@ -45,65 +50,94 @@ enum class byte : unsigned char
 };
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
-constexpr byte& operator<<=(byte& b, IntegerType shift) noexcept
+inline constexpr byte& operator<<=(byte& b, IntegerType shift) noexcept
 {
     return b = byte(static_cast<unsigned char>(b) << shift);
 }
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
-constexpr byte operator<<(byte b, IntegerType shift) noexcept
+inline constexpr byte operator<<(byte b, IntegerType shift) noexcept
 {
     return byte(static_cast<unsigned char>(b) << shift);
 }
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
-constexpr byte& operator>>=(byte& b, IntegerType shift) noexcept
+inline constexpr byte& operator>>=(byte& b, IntegerType shift) noexcept
 {
     return b = byte(static_cast<unsigned char>(b) >> shift);
 }
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
-constexpr byte operator>>(byte b, IntegerType shift) noexcept
+inline constexpr byte operator>>(byte b, IntegerType shift) noexcept
 {
     return byte(static_cast<unsigned char>(b) >> shift);
 }
 
-constexpr byte& operator|=(byte& l, byte r) noexcept
+inline constexpr byte& operator|=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) | static_cast<unsigned char>(r));
 }
 
-constexpr byte operator|(byte l, byte r) noexcept
+inline constexpr byte operator|(byte l, byte r) noexcept
 {
-    return byte(static_cast<unsigned char>(l) + static_cast<unsigned char>(r));
+    return byte(static_cast<unsigned char>(l) | static_cast<unsigned char>(r));
 }
 
-constexpr byte& operator&=(byte& l, byte r) noexcept
+inline constexpr byte& operator&=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) & static_cast<unsigned char>(r));
 }
 
-constexpr byte operator&(byte l, byte r) noexcept
+inline constexpr byte operator&(byte l, byte r) noexcept
 {
     return byte(static_cast<unsigned char>(l) & static_cast<unsigned char>(r));
 }
 
-constexpr byte& operator^=(byte& l, byte r) noexcept
+inline constexpr byte& operator^=(byte& l, byte r) noexcept
 {
     return l = byte(static_cast<unsigned char>(l) ^ static_cast<unsigned char>(r));
 }
 
-constexpr byte operator^(byte l, byte r) noexcept
+inline constexpr byte operator^(byte l, byte r) noexcept
 {
     return byte(static_cast<unsigned char>(l) ^ static_cast<unsigned char>(r));
 }
 
-constexpr byte operator~(byte b) noexcept { return byte(~static_cast<unsigned char>(b)); }
+inline constexpr byte operator~(byte b) noexcept { return byte(~static_cast<unsigned char>(b)); }
 
 template <class IntegerType, class = std::enable_if_t<std::is_integral<IntegerType>::value>>
-constexpr IntegerType to_integer(byte b) noexcept
+inline constexpr IntegerType to_integer(byte b) noexcept
 {
-    return {b};
+    return static_cast<IntegerType>(b);
+}
+
+template<bool E, typename T>
+inline constexpr byte to_byte_impl(T t) noexcept
+{
+    static_assert(
+        E,
+        "gsl::to_byte(t) must be provided an unsigned char, otherwise data loss may occur. "
+        "If you are calling to_byte with an integer contant use: gsl::to_byte<t>() version."
+    );
+    return static_cast<byte>(t);
+}
+template<>
+inline constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept
+{
+     return byte(t);
+}
+
+template<typename T>
+inline constexpr byte to_byte(T t) noexcept
+{
+     return to_byte_impl<std::is_same<T, unsigned char>::value, T>(t);
+}
+
+template <int I>
+inline constexpr byte to_byte() noexcept
+{
+    static_assert(I >= 0 && I <= 255, "gsl::byte only has 8 bits of storage, values must be in range 0-255");
+    return static_cast<byte>(I);
 }
 
 } // namespace gsl
@@ -119,6 +153,8 @@ constexpr IntegerType to_integer(byte b) noexcept
 #pragma pop_macro("noexcept")
 
 #endif // _MSC_VER <= 1800
+
+#pragma warning(pop)
 
 #endif // _MSC_VER
 

--- a/include/gsl/gsl_util
+++ b/include/gsl/gsl_util
@@ -25,21 +25,19 @@
 #include <type_traits>
 #include <utility>
 
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
-
-#include <iostream>
-
-////////////////////////////////////////////////////////////////////////////////
-/// BAREFLANK - proposed API changes to support Bareflank
-////////////////////////////////////////////////////////////////////////////////
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
+#include <guard_exceptions.h>
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
 
 #ifdef _MSC_VER
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
@@ -48,7 +46,7 @@
 #if _MSC_VER <= 1800
 // noexcept is not understood
 #pragma push_macro("noexcept")
-#define noexcept
+#define noexcept /*noexcept*/
 
 // turn off some misguided warnings
 #pragma warning(push)
@@ -63,10 +61,6 @@ namespace gsl
 //
 // GSL.util: utilities
 //
-
-#define concat1(a,b) a ## b
-#define concat2(a,b) concat1(a,b)
-#define ___ concat2(dont_care, __COUNTER__)
 
 // final_act allows you to ensure something gets run at the end of a scope
 template <class F>
@@ -83,82 +77,21 @@ public:
     final_act(const final_act&) = delete;
     final_act& operator=(const final_act&) = delete;
 
-    virtual ~final_act() noexcept
+    ~final_act() noexcept
     {
-        ////////////////////////////////////////////////////////////////////////
-        /// BAREFLANK - proposed API changes to support Bareflank
-        ////////////////////////////////////////////////////////////////////////
-
-        try
-        {
-            if (invoke_) f_();
-        }
-        catch (std::exception &e)
-        {
-            std::cerr << "std::exception caught in ~final_act: " << e.what() << std::endl;
-        }
-        catch (...)
-        {
-            std::cerr << "unknown exception caught in ~final_act!!!" << std::endl;
-        }
-
-        ////////////////////////////////////////////////////////////////////////
-        /// BAREFLANK - proposed API changes to support Bareflank
-        ////////////////////////////////////////////////////////////////////////
-    }
-
-    void dismiss() noexcept
-    {
-        invoke_ = false;
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
+        guard_exceptions([&]
+        { if (invoke_) f_(); });
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
     }
 
 private:
     F f_;
     bool invoke_;
-};
-
-template <class F>
-class final_act_success : public final_act<F>
-{
-public:
-    explicit final_act_success(F &&func) noexcept :
-        final_act<F>(std::move(func))
-    { }
-
-    final_act_success(final_act_success &&other) noexcept :
-        final_act<F>(std::move(other))
-    { }
-
-    final_act_success(const final_act_success &) = delete;
-    final_act_success& operator=(const final_act_success &) = delete;
-
-    ~final_act_success() override
-    {
-        if (std::uncaught_exception())
-            this->dismiss();
-    }
-};
-
-template<class F>
-class final_act_failure : public final_act<F>
-{
-public:
-    explicit final_act_failure(F &&func) noexcept :
-        final_act<F>(std::move(func))
-    { }
-
-    final_act_failure(final_act_failure &&other) noexcept :
-        final_act<F>(std::move(other))
-    { }
-
-    final_act_failure(const final_act_failure &) = delete;
-    final_act_failure& operator=(const final_act_failure &) = delete;
-
-    ~final_act_failure() override
-    {
-        if (!std::uncaught_exception())
-            this->dismiss();
-    }
 };
 
 // finally() - convenience function to generate a final_act
@@ -173,6 +106,68 @@ inline final_act<F> finally(F&& f) noexcept
 {
     return final_act<F>(std::forward<F>(f));
 }
+
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
+
+// final_act_success allows you to ensure something gets run at the end of a scope on failure
+template <class F>
+class final_act_success
+{
+public:
+    explicit final_act_success(F f) noexcept : f_(std::move(f)), invoke_(true) {}
+
+    final_act_success(final_act_success&& other) noexcept : f_(std::move(other.f_)), invoke_(other.invoke_)
+    {
+        other.invoke_ = false;
+    }
+
+    final_act_success(const final_act_success&) = delete;
+    final_act_success& operator=(const final_act_success&) = delete;
+
+    ~final_act_success() noexcept
+    {
+        if (std::uncaught_exception())
+            return;
+
+        guard_exceptions([&]
+        { if (invoke_) f_(); });
+    }
+
+private:
+    F f_;
+    bool invoke_;
+};
+
+// final_act_failure allows you to ensure something gets run at the end of a scope on failure
+template <class F>
+class final_act_failure
+{
+public:
+    explicit final_act_failure(F f) noexcept : f_(std::move(f)), invoke_(true) {}
+
+    final_act_failure(final_act_failure&& other) noexcept : f_(std::move(other.f_)), invoke_(other.invoke_)
+    {
+        other.invoke_ = false;
+    }
+
+    final_act_failure(const final_act_failure&) = delete;
+    final_act_failure& operator=(const final_act_failure&) = delete;
+
+    ~final_act_failure() noexcept
+    {
+        if (!std::uncaught_exception())
+            return;
+
+        guard_exceptions([&]
+        { if (invoke_) f_(); });
+    }
+
+private:
+    F f_;
+    bool invoke_;
+};
 
 // on_success() - convenience function to generate a final_act_success
 template <class F>
@@ -200,12 +195,28 @@ inline final_act_failure<F> on_failure(F&& f) noexcept
     return final_act_failure<F>(std::forward<F>(f));
 }
 
+#define concat1(a,b) a ## b
+#define concat2(a,b) concat1(a,b)
+#define ___ concat2(dont_care, __COUNTER__)
+
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
+
 // narrow_cast(): a searchable way to do narrowing casts of values
+#if _MSC_VER <= 1800
+template <class T, class U>
+inline constexpr T narrow_cast(U u) noexcept
+{
+    return static_cast<T>(u);
+}
+#else
 template <class T, class U>
 inline constexpr T narrow_cast(U&& u) noexcept
 {
     return static_cast<T>(std::forward<U>(u));
 }
+#endif
 
 struct narrowing_error : public std::exception
 {
@@ -234,40 +245,63 @@ inline T narrow(U u)
 //
 // at() - Bounds-checked way of accessing static arrays, std::array, std::vector
 //
-template <class T, size_t N>
-constexpr T& at(T (&arr)[N], size_t index)
+
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
+
+template <class T, size_t N, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+constexpr T& at(T (&arr)[N], I index)
 {
-    Expects(index < N);
-    return arr[index];
+    Expects(index >= 0 && index < narrow_cast<I>(N));
+    return arr[static_cast<size_t>(index)];
 }
 
-template <class T, size_t N>
-constexpr T& at(std::array<T, N>& arr, size_t index)
+template <class T, size_t N, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+const constexpr T& at(const T (&arr)[N], I index)
 {
-    Expects(index < N);
-    return arr[index];
+    Expects(index >= 0 && index < narrow_cast<I>(N));
+    return arr[static_cast<size_t>(index)];
 }
 
-template <class T, size_t N>
-constexpr const T& at(const std::array<T, N>& arr, size_t index)
+template <class T, size_t N, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+constexpr T& at(std::array<T, N>& arr, I index)
 {
-    Expects(index < N);
-    return arr[index];
+    Expects(index >= 0 && index < narrow_cast<I>(N));
+    return arr[static_cast<size_t>(index)];
 }
 
-template <class Cont>
-constexpr typename Cont::value_type& at(Cont& cont, size_t index)
+template <class T, size_t N, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+const constexpr T& at(const std::array<T, N>& arr, I index)
 {
-    Expects(index < cont.size());
-    return cont[index];
+    Expects(index >= 0 && index < narrow_cast<I>(N));
+    return arr[static_cast<size_t>(index)];
 }
 
-template <class T>
-constexpr const T& at(std::initializer_list<T> cont, size_t index)
+template <class Cont, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+constexpr typename Cont::value_type& at(Cont& cont, I index)
 {
-    Expects(index < cont.size());
+    Expects(index >= 0 && index < narrow_cast<I>(cont.size()));
+    return cont[static_cast<typename Cont::size_type>(index)];
+}
+
+template <class Cont, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+const constexpr typename Cont::value_type& at(const Cont& cont, I index)
+{
+    Expects(index >= 0 && index < narrow_cast<I>(cont.size()));
+    return cont[static_cast<typename Cont::size_type>(index)];
+}
+
+template <class T, class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
+constexpr const T& at(std::initializer_list<T> cont, I index)
+{
+    Expects(index >= 0 && index < narrow_cast<I>(cont.size()));
     return *(cont.begin() + index);
 }
+
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
 
 } // namespace gsl
 

--- a/include/gsl/span
+++ b/include/gsl/span
@@ -45,7 +45,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr
+#define constexpr /*constexpr*/
 
 // VS 2013 workarounds
 #if _MSC_VER <= 1800
@@ -57,7 +57,7 @@
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 #endif
 
 #pragma push_macro("alignof")
@@ -78,7 +78,7 @@
 #pragma push_macro("noexcept")
 #endif
 
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
@@ -124,23 +124,6 @@ namespace details
     {
     };
 
-    template <class From, class To>
-    struct is_allowed_pointer_conversion
-        : public std::integral_constant<bool, std::is_pointer<From>::value &&
-                                                  std::is_pointer<To>::value &&
-                                                  std::is_convertible<From, To>::value>
-    {
-    };
-
-    template <class From, class To>
-    struct is_allowed_integral_conversion
-        : public std::integral_constant<
-              bool, std::is_integral<From>::value && std::is_integral<To>::value &&
-                        sizeof(From) == sizeof(To) && alignof(From) == alignof(To) &&
-                        std::is_convertible<From, To>::value>
-    {
-    };
-
     template <std::ptrdiff_t From, std::ptrdiff_t To>
     struct is_allowed_extent_conversion
         : public std::integral_constant<bool, From == To || From == gsl::dynamic_extent ||
@@ -150,20 +133,7 @@ namespace details
 
     template <class From, class To>
     struct is_allowed_element_type_conversion
-        : public std::integral_constant<bool, std::is_same<From, std::remove_cv_t<To>>::value ||
-                                                  is_allowed_pointer_conversion<From, To>::value ||
-                                                  is_allowed_integral_conversion<From, To>::value>
-    {
-    };
-
-    template <class From>
-    struct is_allowed_element_type_conversion<From, byte>
-        : public std::integral_constant<bool, !std::is_const<From>::value>
-    {
-    };
-
-    template <class From>
-    struct is_allowed_element_type_conversion<From, const byte> : public std::true_type
+        : public std::integral_constant<bool, std::is_convertible<From (*)[], To (*)[]>::value>
     {
     };
 
@@ -194,6 +164,8 @@ namespace details
         {
         }
 
+        constexpr span_iterator<Span, IsConst>& operator=(const span_iterator<Span, IsConst>&) noexcept = default;
+
         constexpr reference operator*() const
         {
             Expects(span_);
@@ -206,7 +178,7 @@ namespace details
             return &((*span_)[index_]);
         }
 
-        constexpr span_iterator& operator++() noexcept
+        constexpr span_iterator& operator++()
         {
             Expects(span_ && index_ >= 0 && index_ < span_->length());
             ++index_;
@@ -220,7 +192,7 @@ namespace details
             return ret;
         }
 
-        constexpr span_iterator& operator--() noexcept
+        constexpr span_iterator& operator--()
         {
             Expects(span_ && index_ > 0 && index_ <= span_->length());
             --index_;
@@ -240,7 +212,7 @@ namespace details
             return ret += n;
         }
 
-        constexpr span_iterator& operator+=(difference_type n) noexcept
+        constexpr span_iterator& operator+=(difference_type n)
         {
             Expects(span_ && (index_ + n) >= 0 && (index_ + n) <= span_->length());
             index_ += n;
@@ -255,7 +227,7 @@ namespace details
 
         constexpr span_iterator& operator-=(difference_type n) noexcept { return *this += -n; }
 
-        constexpr difference_type operator-(const span_iterator& rhs) const noexcept
+        constexpr difference_type operator-(const span_iterator& rhs) const
         {
             Expects(span_ == rhs.span_);
             return index_ - rhs.index_;
@@ -275,7 +247,7 @@ namespace details
             return !(lhs == rhs);
         }
 
-        constexpr friend bool operator<(const span_iterator& lhs, const span_iterator& rhs) noexcept
+        constexpr friend bool operator<(const span_iterator& lhs, const span_iterator& rhs)
         {
             Expects(lhs.span_ == rhs.span_);
             return lhs.index_ < rhs.index_;
@@ -336,7 +308,7 @@ namespace details
         constexpr extent_type() noexcept {}
 
         template <index_type Other>
-        constexpr extent_type(extent_type<Other> ext) noexcept
+        constexpr extent_type(extent_type<Other> ext)
         {
             static_assert(Other == Ext || Other == dynamic_extent,
                           "Mismatch between fixed-size extent and size of initializing data.");
@@ -429,7 +401,7 @@ public:
                   std::is_convertible<typename Container::pointer, pointer>::value &&
                   std::is_convertible<typename Container::pointer,
                                       decltype(std::declval<Container>().data())>::value>>
-    constexpr span(Container& cont) : span(cont.data(), cont.size())
+    constexpr span(Container& cont) : span(cont.data(), narrow<index_type>(cont.size()))
     {
     }
 
@@ -439,7 +411,7 @@ public:
                   std::is_convertible<typename Container::pointer, pointer>::value &&
                   std::is_convertible<typename Container::pointer,
                                       decltype(std::declval<Container>().data())>::value>>
-    constexpr span(const Container& cont) : span(cont.data(), cont.size())
+    constexpr span(const Container& cont) : span(cont.data(), narrow<index_type>(cont.size()))
     {
     }
 
@@ -456,8 +428,7 @@ public:
             details::is_allowed_extent_conversion<OtherExtent, Extent>::value &&
             details::is_allowed_element_type_conversion<OtherElementType, element_type>::value>>
     constexpr span(const span<OtherElementType, OtherExtent>& other)
-        : storage_(reinterpret_cast<pointer>(other.data()),
-                   details::extent_type<OtherExtent>(other.size()))
+        : storage_(other.data(), details::extent_type<OtherExtent>(other.size()))
     {
     }
 
@@ -467,8 +438,7 @@ public:
             details::is_allowed_extent_conversion<OtherExtent, Extent>::value &&
             details::is_allowed_element_type_conversion<OtherElementType, element_type>::value>>
     constexpr span(span<OtherElementType, OtherExtent>&& other)
-        : storage_(reinterpret_cast<pointer>(other.data()),
-                   details::extent_type<OtherExtent>(other.size()))
+        : storage_(other.data(), details::extent_type<OtherExtent>(other.size()))
     {
     }
 
@@ -531,7 +501,7 @@ public:
     constexpr index_type length() const noexcept { return size(); }
     constexpr index_type size() const noexcept { return storage_.size(); }
     constexpr index_type length_bytes() const noexcept { return size_bytes(); }
-    constexpr index_type size_bytes() const noexcept { return size() * sizeof(element_type); }
+    constexpr index_type size_bytes() const noexcept { return size() * narrow_cast<index_type>(sizeof(element_type)); }
     constexpr bool empty() const noexcept { return size() == 0; }
 
     // [span.elem], span element access
@@ -540,45 +510,17 @@ public:
         Expects(idx >= 0 && idx < storage_.size());
         return data()[idx];
     }
+
+// ----------------------------------------------------------------------------
+// bareflank: start
+// ----------------------------------------------------------------------------
+    template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    constexpr reference at(T idx) const { return this->operator[](narrow_cast<index_type>(idx)); }
+// ----------------------------------------------------------------------------
+// bareflank: end
+// ----------------------------------------------------------------------------
     constexpr reference operator()(index_type idx) const { return this->operator[](idx); }
     constexpr pointer data() const noexcept { return storage_.data(); }
-
-    ////////////////////////////////////////////////////////////////////////////
-    /// BAREFLANK - proposed API changes to support Bareflank
-    ////////////////////////////////////////////////////////////////////////////
-
-    // We added this for sanity, and consistency. Instead of using [], which
-    // not allowed in the STL anymore, we use .at to be consistent with the STL,
-    // and we provide an implementation that accepts both signed and unsigned
-    // indexes to prevent from having to maintain separate signed / unsigned
-    // index types in the same code.
-    template<class I, class = typename std::enable_if<std::is_integral<I>::value>::type>
-    constexpr reference at(I idx) const
-    {
-        auto _idx = narrow_cast<index_type>(idx);
-        Expects(_idx >= 0 && _idx < storage_.size());
-        return data()[_idx];
-    }
-
-    // There isn't a fast way of doing a reverse lookup. It is possible to
-    // use std::find_if by looping though each element, and comparing the
-    // reference of each element to the pointer, but this is linear in time.
-    // The following is a simple patch to perform the reverse lookup.
-
-    constexpr bool contains(pointer ptr) const
-    {
-        return ptr >= data() && ptr < data() + size();
-    }
-
-    constexpr index_type index_from_ptr(pointer ptr) const
-    {
-        Expects(ptr >= data() && ptr < data() + size());
-        return ptr - data();
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    /// BAREFLANK - proposed API changes to support Bareflank
-    ////////////////////////////////////////////////////////////////////////////
 
     // [span.iter], span iterator support
     iterator begin() const noexcept { return {this, 0}; }
@@ -702,12 +644,12 @@ as_writeable_bytes(span<ElementType, Extent> s) noexcept
 //
 template <class ElementType>
 span<ElementType>
-make_span(ElementType *ptr, typename span<ElementType>::index_type count)
+make_span(ElementType* ptr, typename span<ElementType>::index_type count)
 { return span<ElementType>(ptr, count); }
 
 template <class ElementType>
 span<ElementType>
-make_span(ElementType *firstElem, ElementType *lastElem)
+make_span(ElementType* firstElem, ElementType* lastElem)
 { return span<ElementType>(firstElem, lastElem); }
 
 template <class ElementType, size_t N>
@@ -727,8 +669,22 @@ make_span(const Container &cont)
 
 template <class Ptr>
 span<typename Ptr::element_type>
-make_span(Ptr &ptr, typename span<typename Ptr::element_type>::index_type &&count)
-{ return span<typename Ptr::element_type>(ptr, count); }
+make_span(Ptr& cont, std::ptrdiff_t count)
+{ return span<typename Ptr::element_type>(cont, count); }
+
+template <class Ptr>
+span<typename Ptr::element_type>
+make_span(Ptr& cont)
+{ return span<typename Ptr::element_type>(cont); }
+
+
+// Specialization of gsl::at for span
+template <class ElementType, std::ptrdiff_t Extent>
+constexpr ElementType& at(const span<ElementType, Extent>& s, std::ptrdiff_t index)
+{
+    // No bounds checking here because it is done in span::operator[] called below
+    return s[index];
+}
 
 } // namespace gsl
 

--- a/include/gsl/string_span
+++ b/include/gsl/string_span
@@ -30,7 +30,7 @@
 
 // No MSVC does constexpr fully yet
 #pragma push_macro("constexpr")
-#define constexpr /* nothing */
+#define constexpr /*constexpr*/
 
 #pragma warning(push)
 
@@ -50,15 +50,11 @@
 // noexcept is not understood
 #ifndef GSL_THROW_ON_CONTRACT_VIOLATION
 #pragma push_macro("noexcept")
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 #endif
 
 #endif // _MSC_VER <= 1800
 #endif // _MSC_VER
-
-#ifndef __CYGWIN__
-#define GSL_PLATFORM_HAS_STRNLEN
-#endif
 
 // In order to test the library, we need it to throw exceptions that we can catch
 #ifdef GSL_THROW_ON_CONTRACT_VIOLATION
@@ -67,7 +63,7 @@
 #pragma push_macro("noexcept")
 #endif
 
-#define noexcept /* nothing */
+#define noexcept /*noexcept*/
 
 #endif // GSL_THROW_ON_CONTRACT_VIOLATION
 
@@ -101,40 +97,32 @@ using wzstring = basic_zstring<wchar_t, Extent>;
 
 namespace details
 {
-    inline std::size_t string_length(const char *str, std::size_t n)
+    inline std::ptrdiff_t string_length(const char *str, std::ptrdiff_t n)
     {
-#ifdef GSL_PLATFORM_HAS_STRNLEN
-        return strnlen(str, n);
-#else
-        if (str == nullptr || n == 0)
+        if (str == nullptr || n <= 0)
             return 0;
 
-        std::size_t len = 0;
         span<const char> str_span{str, n};
 
+        std::ptrdiff_t len = 0;
         while (len < n && str_span[len])
             len++;
 
         return len;
-#endif
     }
 
-    inline std::size_t wstring_length(const wchar_t *str, std::size_t n)
+    inline std::ptrdiff_t wstring_length(const wchar_t *str, std::ptrdiff_t n)
     {
-#ifdef GSL_PLATFORM_HAS_STRNLEN
-        return wcsnlen(str, n);
-#else
-        if (str == nullptr || n == 0)
+        if (str == nullptr || n <= 0)
             return 0;
 
-        std::size_t len = 0;
         span<const wchar_t> str_span{str, n};
 
+        std::ptrdiff_t len = 0;
         while (len < n && str_span[len])
             len++;
 
         return len;
-#endif
     }
 }
 
@@ -170,30 +158,30 @@ inline span<T, dynamic_extent> ensure_z(T* const& sz, std::ptrdiff_t max = PTRDI
 // overloads to share an implementation
 inline span<char, dynamic_extent> ensure_z(char* const& sz, std::ptrdiff_t max)
 {
-    auto len = details::string_length(sz, narrow_cast<size_t>(max));
+    auto len = details::string_length(sz, max);
     Ensures(sz[len] == 0);
-    return {sz, static_cast<std::ptrdiff_t>(len)};
+    return {sz, len};
 }
 
 inline span<const char, dynamic_extent> ensure_z(const char* const& sz, std::ptrdiff_t max)
 {
-    auto len = details::string_length(sz, narrow_cast<size_t>(max));
+    auto len = details::string_length(sz, max);
     Ensures(sz[len] == 0);
-    return {sz, static_cast<std::ptrdiff_t>(len)};
+    return {sz, len};
 }
 
 inline span<wchar_t, dynamic_extent> ensure_z(wchar_t* const& sz, std::ptrdiff_t max)
 {
-    auto len = details::wstring_length(sz, narrow_cast<size_t>(max));
+    auto len = details::wstring_length(sz, max);
     Ensures(sz[len] == 0);
-    return {sz, static_cast<std::ptrdiff_t>(len)};
+    return {sz, len};
 }
 
 inline span<const wchar_t, dynamic_extent> ensure_z(const wchar_t* const& sz, std::ptrdiff_t max)
 {
-    auto len = details::wstring_length(sz, narrow_cast<size_t>(max));
+    auto len = details::wstring_length(sz, max);
     Ensures(sz[len] == 0);
-    return {sz, static_cast<std::ptrdiff_t>(len)};
+    return {sz, len};
 }
 
 template <typename T, size_t N>
@@ -239,7 +227,7 @@ namespace details
     {
         std::ptrdiff_t operator()(char* const ptr, std::ptrdiff_t length) noexcept
         {
-            return narrow_cast<std::ptrdiff_t>(details::string_length(ptr, narrow_cast<size_t>(length)));
+            return details::string_length(ptr, length);
         }
     };
 
@@ -248,7 +236,7 @@ namespace details
     {
         std::ptrdiff_t operator()(wchar_t* const ptr, std::ptrdiff_t length) noexcept
         {
-            return narrow_cast<std::ptrdiff_t>(details::wstring_length(ptr, narrow_cast<size_t>(length)));
+            return details::wstring_length(ptr, length);
         }
     };
 
@@ -257,7 +245,7 @@ namespace details
     {
         std::ptrdiff_t operator()(const char* const ptr, std::ptrdiff_t length) noexcept
         {
-            return narrow_cast<std::ptrdiff_t>(details::string_length(ptr, narrow_cast<size_t>(length)));
+            return details::string_length(ptr, length);
         }
     };
 
@@ -266,7 +254,7 @@ namespace details
     {
         std::ptrdiff_t operator()(const wchar_t* const ptr, std::ptrdiff_t length) noexcept
         {
-            return narrow_cast<std::ptrdiff_t>(details::wstring_length(ptr, narrow_cast<size_t>(length)));
+            return details::wstring_length(ptr, length);
         }
     };
 }
@@ -343,7 +331,7 @@ public:
     // Container signature should work for basic_string after C++17 version exists
     template <class Traits, class Allocator>
     constexpr basic_string_span(std::basic_string<element_type, Traits, Allocator>& str)
-        : span_(&str[0], str.length())
+        : span_(&str[0], narrow_cast<std::ptrdiff_t>(str.length()))
     {
     }
 
@@ -504,6 +492,16 @@ inline std::wstring to_string(wstring_span<> view)
 
 #endif
 
+template <typename CharT,
+	  typename Traits = typename std::char_traits<CharT>,
+	  typename Allocator = std::allocator<CharT>,
+	  typename gCharT,
+	  std::ptrdiff_t Extent>
+std::basic_string<CharT, Traits, Allocator> to_basic_string(basic_string_span<gCharT, Extent> view)
+{
+  return {view.data(), static_cast<size_t>(view.length())};
+}
+
 // zero-terminated string span, used to convert
 // zero-terminated spans to legacy strings
 template <typename CharT, std::ptrdiff_t Extent = dynamic_extent>
@@ -556,7 +554,8 @@ public:
 
     constexpr string_span_type as_string_span() const noexcept
     {
-        return span_.first(span_.size() - 1);
+        auto sz = span_.size();
+        return span_.first(sz <= 0 ? 0 : sz - 1);
     }
 
     constexpr string_span_type ensure_z() const noexcept { return gsl::ensure_z(span_); }

--- a/include/guard_exceptions.h
+++ b/include/guard_exceptions.h
@@ -22,8 +22,7 @@
 #ifndef GUARD_EXCEPTIONS_H
 #define GUARD_EXCEPTIONS_H
 
-#include <debug.h>
-#include <exception.h>
+#include <iostream>
 #include <error_codes.h>
 
 template<class T, class E> E
@@ -35,32 +34,24 @@ guard_exceptions(E error_code, T func)
 
         return SUCCESS;
     }
-    catch (bfn::general_exception &ge)
-    {
-        bfinfo << bfendl;
-        bferror << "----------------------------------------" << bfendl;
-        bferror << "- General Exception Caught             -" << bfendl;
-        bferror << "----------------------------------------" << bfendl;
-        bferror << ge << bfendl;
-    }
     catch (std::bad_alloc &e)
     {
         return BF_BAD_ALLOC;
     }
     catch (std::exception &e)
     {
-        bfinfo << bfendl;
-        bferror << "----------------------------------------" << bfendl;
-        bferror << "- Standard Exception Caught            -" << bfendl;
-        bferror << "----------------------------------------" << bfendl;
-        bferror << e.what() << bfendl;
+        std::cout << '\n';
+        std::cerr << "----------------------------------------" << '\n';
+        std::cerr << "- Standard Exception Caught            -" << '\n';
+        std::cerr << "----------------------------------------" << '\n';
+        std::cerr << e.what() << '\n';
     }
     catch (...)
     {
-        bfinfo << bfendl;
-        bferror << "----------------------------------------" << bfendl;
-        bferror << "- Unknown Exception Caught             -" << bfendl;
-        bferror << "----------------------------------------" << bfendl;
+        std::cout << '\n';
+        std::cerr << "----------------------------------------" << '\n';
+        std::cerr << "- Unknown Exception Caught             -" << '\n';
+        std::cerr << "----------------------------------------" << '\n';
     }
 
     return error_code;

--- a/tools/scripts/fetch_clang.sh
+++ b/tools/scripts/fetch_clang.sh
@@ -37,7 +37,7 @@ else
 fi
 
 if [[ -z "$CUSTOM_CLANG_BRANCH" ]]; then
-    clang_branch=$CLANG_RELEASE
+    clang_branch=$LLVM_RELEASE
 else
     clang_branch=$CUSTOM_CLANG_BRANCH
 fi


### PR DESCRIPTION
This updates the GSL to the latest and greatest, and cleans up our
patches to provide a more clear picture as to what we are
changing.

For whatever reason, updating the GSL causes GCC 6.2 to flag
several new bugs in the code that prevented the code from
compiling as well as passing the unit tests, so I also cleaned
up these newly discovered issues.

Signed-off-by: “Rian <“rianquinn@gmail.com”>