### PR TITLE
Use new expect functions for unit tests

### DIFF
--- a/bfcrt/test/test_crt.cpp
+++ b/bfcrt/test/test_crt.cpp
@@ -47,7 +47,7 @@ func2()
 void
 crt_ut::test_coveralls()
 {
-    EXPECT_TRUE(register_eh_frame(nullptr, 0) == REGISTER_EH_FRAME_SUCCESS);
+    this->expect_true(register_eh_frame(nullptr, 0) == REGISTER_EH_FRAME_SUCCESS);
     func1();
     func2();
 }
@@ -60,7 +60,7 @@ crt_ut::test_local_init_invalid_arg()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(nullptr) == CRT_FAILURE)
+        this->expect_true(local_init(nullptr) == CRT_FAILURE);
     });
 }
 
@@ -84,7 +84,7 @@ crt_ut::test_local_init_invalid_addr()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == CRT_SUCCESS);
+        this->expect_true(local_init(&info) == CRT_SUCCESS);
     });
 }
 
@@ -110,7 +110,7 @@ crt_ut::test_local_init_invalid_size()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == CRT_SUCCESS);
+        this->expect_true(local_init(&info) == CRT_SUCCESS);
     });
 }
 
@@ -136,7 +136,7 @@ crt_ut::test_local_init_register_eh_frame_failure()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == REGISTER_EH_FRAME_FAILURE);
+        this->expect_true(local_init(&info) == REGISTER_EH_FRAME_FAILURE);
     });
 }
 
@@ -166,7 +166,7 @@ crt_ut::test_local_init_valid_stop_at_size()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == CRT_SUCCESS);
+        this->expect_true(local_init(&info) == CRT_SUCCESS);
     });
 }
 
@@ -196,7 +196,7 @@ crt_ut::test_local_init_valid_stop_at_null()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == CRT_SUCCESS);
+        this->expect_true(local_init(&info) == CRT_SUCCESS);
     });
 }
 
@@ -222,14 +222,14 @@ crt_ut::test_local_init_catch_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_init(&info) == CRT_FAILURE);
+        this->expect_true(local_init(&info) == CRT_FAILURE);
     });
 }
 
 void
 crt_ut::test_local_fini_invalid_arg()
 {
-    EXPECT_TRUE(local_fini(nullptr) == CRT_FAILURE);
+    this->expect_true(local_fini(nullptr) == CRT_FAILURE);
 }
 
 void
@@ -248,7 +248,7 @@ crt_ut::test_local_fini_invalid_addr()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_fini(&info) == CRT_SUCCESS);
+        this->expect_true(local_fini(&info) == CRT_SUCCESS);
     });
 }
 
@@ -270,7 +270,7 @@ crt_ut::test_local_fini_invalid_size()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_fini(&info) == CRT_SUCCESS);
+        this->expect_true(local_fini(&info) == CRT_SUCCESS);
     });
 }
 
@@ -296,7 +296,7 @@ crt_ut::test_local_fini_valid_stop_at_size()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_fini(&info) == CRT_SUCCESS);
+        this->expect_true(local_fini(&info) == CRT_SUCCESS);
     });
 }
 
@@ -322,7 +322,7 @@ crt_ut::test_local_fini_valid_stop_at_null()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_fini(&info) == CRT_SUCCESS);
+        this->expect_true(local_fini(&info) == CRT_SUCCESS);
     });
 }
 
@@ -348,6 +348,6 @@ crt_ut::test_local_fini_catch_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(local_fini(&info) == CRT_FAILURE);
+        this->expect_true(local_fini(&info) == CRT_FAILURE);
     });
 }

--- a/bfdrivers/test/test_common_add_module.cpp
+++ b/bfdrivers/test/test_common_add_module.cpp
@@ -43,13 +43,13 @@ extern "C"
 void
 driver_entry_ut::test_common_add_module_invalid_file()
 {
-    EXPECT_TRUE(common_add_module(nullptr, m_dummy_misc_length) == BF_ERROR_INVALID_ARG);
+    this->expect_true(common_add_module(nullptr, m_dummy_misc_length) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_common_add_module_invalid_file_size()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), 0) == BF_ERROR_INVALID_ARG);
+    this->expect_true(common_add_module(m_dummy_misc.get(), 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
@@ -57,46 +57,46 @@ driver_entry_ut::test_common_add_module_garbage_module()
 {
     auto file = "this is clearly not an ELF file!!!";
 
-    EXPECT_TRUE(common_add_module(file, strlen(file)) == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(common_add_module(file, strlen(file)) == BFELF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_common_add_module_add_when_already_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_LOADED);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_add_module_add_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_RUNNING);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_RUNNING);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_add_module_add_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_vmm_status() == VMM_CORRUPT);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -105,10 +105,10 @@ void
 driver_entry_ut::test_common_add_module_add_too_many()
 {
     for (auto i = 0U; i < MAX_NUM_MODULES; i++)
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+        this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_MAX_MODULES_REACHED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_MAX_MODULES_REACHED);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
@@ -119,7 +119,7 @@ driver_entry_ut::test_common_add_module_get_elf_file_size_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_FAILED_TO_ADD_FILE);
+        this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_FAILED_TO_ADD_FILE);
     });
 }
 
@@ -131,7 +131,7 @@ driver_entry_ut::test_common_add_module_platform_alloc_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_OUT_OF_MEMORY);
+        this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_ERROR_OUT_OF_MEMORY);
     });
 }
 
@@ -143,6 +143,6 @@ driver_entry_ut::test_common_add_module_load_elf_fails()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == -1);
+        this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == -1);
     });
 }

--- a/bfdrivers/test/test_common_dump.cpp
+++ b/bfdrivers/test/test_common_dump.cpp
@@ -31,47 +31,47 @@ debug_ring_resources_t *g_drr;
 void
 driver_entry_ut::test_common_dump_invalid_drr()
 {
-    EXPECT_TRUE(common_dump_vmm(nullptr, 0) == BF_ERROR_INVALID_ARG);
+    this->expect_true(common_dump_vmm(nullptr, 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_common_dump_invalid_vcpuid()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 100000) == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_dump_vmm(&g_drr, 100000) == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_dump_dump_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_dump_vmm(&g_drr, 0) == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_dump_dump_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
+    this->expect_true(common_dump_vmm(&g_drr, 0) == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -79,37 +79,37 @@ driver_entry_ut::test_common_dump_dump_when_corrupt()
 void
 driver_entry_ut::test_common_dump_dump_when_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_get_drr_success.get(), m_dummy_get_drr_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_dump_vmm(&g_drr, 0) == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_dump_get_drr_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_dump_vmm(&g_drr, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_dump_get_drr_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_get_drr_failure.get(), m_dummy_get_drr_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_dump_vmm(&g_drr, 0) == GET_DRR_FAILURE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_get_drr_failure.get(), m_dummy_get_drr_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_dump_vmm(&g_drr, 0) == GET_DRR_FAILURE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }

--- a/bfdrivers/test/test_common_fini.cpp
+++ b/bfdrivers/test/test_common_fini.cpp
@@ -29,58 +29,58 @@
 void
 driver_entry_ut::test_common_fini_unloaded()
 {
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_fini_successful_start()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_successful_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_successful_add_module()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_corrupted()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_vmm_status() == VMM_CORRUPT);
 
     common_reset();
 }
@@ -88,34 +88,34 @@ driver_entry_ut::test_common_fini_corrupted()
 void
 driver_entry_ut::test_common_fini_failed_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_failed_start()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_unload_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -123,23 +123,23 @@ driver_entry_ut::test_common_fini_unload_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_fini() == BF_SUCCESS);
+            this->expect_true(common_fini() == BF_SUCCESS);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_stop_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -147,23 +147,23 @@ driver_entry_ut::test_common_fini_stop_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_fini() == BF_SUCCESS);
+            this->expect_true(common_fini() == BF_SUCCESS);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_fini_reset_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -172,10 +172,10 @@ driver_entry_ut::test_common_fini_reset_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_fini() == BF_SUCCESS);
+            this->expect_true(common_fini() == BF_SUCCESS);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }

--- a/bfdrivers/test/test_common_init.cpp
+++ b/bfdrivers/test/test_common_init.cpp
@@ -25,5 +25,5 @@
 void
 driver_entry_ut::test_common_init()
 {
-    EXPECT_TRUE(common_init() == BF_SUCCESS);
+    this->expect_true(common_init() == BF_SUCCESS);
 }

--- a/bfdrivers/test/test_common_load.cpp
+++ b/bfdrivers/test/test_common_load.cpp
@@ -47,57 +47,57 @@ extern uint64_t g_malloc_fails;
 void
 driver_entry_ut::test_common_load_successful_load()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_LOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_load_load_when_already_loaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_LOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_load_load_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_vmm_status() == VMM_RUNNING);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_vmm_status() == VMM_RUNNING);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_load_load_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
-    EXPECT_TRUE(common_load_vmm() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_vmm_status() == VMM_CORRUPT);
+    this->expect_true(common_load_vmm() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -105,32 +105,32 @@ driver_entry_ut::test_common_load_load_when_corrupt()
 void
 driver_entry_ut::test_common_load_fail_due_to_relocation_error()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_load_fail_due_to_no_modules_added()
 {
-    EXPECT_TRUE(common_load_vmm() == BF_ERROR_NO_MODULES_ADDED);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_load_vmm() == BF_ERROR_NO_MODULES_ADDED);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_fini() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_common_load_add_md_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_failure.get(), m_dummy_add_md_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == MEMORY_MANAGER_FAILURE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_failure.get(), m_dummy_add_md_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == MEMORY_MANAGER_FAILURE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
@@ -141,12 +141,12 @@ driver_entry_ut::test_common_load_tls_platform_alloc_failed()
     auto ___ = gsl::finally([&]
     { g_malloc_fails = 0; });
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_ERROR_OUT_OF_MEMORY);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_ERROR_OUT_OF_MEMORY);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
@@ -157,21 +157,21 @@ driver_entry_ut::test_common_load_stack_platform_alloc_failed()
     auto ___ = gsl::finally([&]
     { g_malloc_fails = 0; });
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_ERROR_OUT_OF_MEMORY);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_ERROR_OUT_OF_MEMORY);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_load_loader_add_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -179,20 +179,20 @@ driver_entry_ut::test_common_load_loader_add_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_load_vmm() == -1);
+            this->expect_true(common_load_vmm() == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_load_resolve_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -200,20 +200,20 @@ driver_entry_ut::test_common_load_resolve_symbol_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_load_vmm() == -1);
+            this->expect_true(common_load_vmm() == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_load_loader_get_info_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -221,20 +221,20 @@ driver_entry_ut::test_common_load_loader_get_info_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_load_vmm() == -1);
+            this->expect_true(common_load_vmm() == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_load_execute_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -242,10 +242,10 @@ driver_entry_ut::test_common_load_execute_symbol_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_load_vmm() == -1);
+            this->expect_true(common_load_vmm() == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 

--- a/bfdrivers/test/test_common_start.cpp
+++ b/bfdrivers/test/test_common_start.cpp
@@ -29,39 +29,39 @@
 void
 driver_entry_ut::test_common_start_start_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_start_start_when_already_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_start_start_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
-    EXPECT_TRUE(common_start_vmm() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
+    this->expect_true(common_start_vmm() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_vmm_status() == VMM_CORRUPT);
 
     common_reset();
 }
@@ -69,34 +69,34 @@ driver_entry_ut::test_common_start_start_when_corrupt()
 void
 driver_entry_ut::test_common_start_start_when_start_vmm_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_start_start_vmm_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_failure.get(), m_dummy_start_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == ENTRY_ERROR_VMM_START_FAILED);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_start_set_affinity_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -104,9 +104,9 @@ driver_entry_ut::test_common_start_set_affinity_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_start_vmm() == -1);
+            this->expect_true(common_start_vmm() == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }

--- a/bfdrivers/test/test_common_stop.cpp
+++ b/bfdrivers/test/test_common_stop.cpp
@@ -28,52 +28,52 @@
 void
 driver_entry_ut::test_common_stop_stop_when_unloaded()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_stop_stop_when_not_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_stop_stop_when_alread_stopped()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_stop_stop_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
-    EXPECT_TRUE(common_stop_vmm() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
+    this->expect_true(common_stop_vmm() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -81,13 +81,13 @@ driver_entry_ut::test_common_stop_stop_when_corrupt()
 void
 driver_entry_ut::test_common_stop_stop_vmm_missing()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -95,14 +95,14 @@ driver_entry_ut::test_common_stop_stop_vmm_missing()
 void
 driver_entry_ut::test_common_stop_stop_vmm_failure()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_stop_vmm() == ENTRY_ERROR_VMM_STOP_FAILED);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -110,12 +110,12 @@ driver_entry_ut::test_common_stop_stop_vmm_failure()
 void
 driver_entry_ut::test_common_stop_set_affinity_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -123,7 +123,7 @@ driver_entry_ut::test_common_stop_set_affinity_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_stop_vmm() == -1);
+            this->expect_true(common_stop_vmm() == -1);
         });
     }
 

--- a/bfdrivers/test/test_common_unload.cpp
+++ b/bfdrivers/test/test_common_unload.cpp
@@ -41,34 +41,34 @@ extern "C"
 void
 driver_entry_ut::test_common_unload_unload_when_already_unloaded()
 {
-    EXPECT_TRUE(common_unload_vmm() == BF_SUCCESS);
+    this->expect_true(common_unload_vmm() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_unload_unload_when_running()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_unload_vmm() == BF_ERROR_VMM_INVALID_STATE);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_unload_vmm() == BF_ERROR_VMM_INVALID_STATE);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_common_unload_unload_when_corrupt()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_fini() == BF_ERROR_VMM_CORRUPTED);
-    EXPECT_TRUE(common_vmm_status() == VMM_CORRUPT);
-    EXPECT_TRUE(common_unload_vmm() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_ERROR_VMM_CORRUPTED);
+    this->expect_true(common_vmm_status() == VMM_CORRUPT);
+    this->expect_true(common_unload_vmm() == BF_ERROR_VMM_CORRUPTED);
 
     common_reset();
 }
@@ -76,11 +76,11 @@ driver_entry_ut::test_common_unload_unload_when_corrupt()
 void
 driver_entry_ut::test_common_unload_loader_get_info_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -88,7 +88,7 @@ driver_entry_ut::test_common_unload_loader_get_info_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_unload_vmm() == -1);
+            this->expect_true(common_unload_vmm() == -1);
         });
     }
 
@@ -98,11 +98,11 @@ driver_entry_ut::test_common_unload_loader_get_info_failed()
 void
 driver_entry_ut::test_common_unload_execute_symbol_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_failure.get(), m_dummy_stop_vmm_failure_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -110,7 +110,7 @@ driver_entry_ut::test_common_unload_execute_symbol_failed()
 
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
-            EXPECT_TRUE(common_unload_vmm() == -1);
+            this->expect_true(common_unload_vmm() == -1);
         });
     }
 

--- a/bfdrivers/test/test_helpers.cpp
+++ b/bfdrivers/test/test_helpers.cpp
@@ -48,45 +48,45 @@ extern "C"
 void
 driver_entry_ut::test_helper_common_vmm_status()
 {
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_start_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_RUNNING);
-    EXPECT_TRUE(common_stop_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_LOADED);
-    EXPECT_TRUE(common_unload_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_LOADED);
+    this->expect_true(common_start_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_RUNNING);
+    this->expect_true(common_stop_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_LOADED);
+    this->expect_true(common_unload_vmm() == BF_SUCCESS);
+    this->expect_true(common_vmm_status() == VMM_UNLOADED);
 }
 
 void
 driver_entry_ut::test_helper_get_file_invalid_index()
 {
-    EXPECT_TRUE(get_module(10000) == nullptr);
+    this->expect_true(get_module(10000) == nullptr);
 }
 
 void
 driver_entry_ut::test_helper_get_file_success()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(get_module(0) != nullptr);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(get_module(0) != nullptr);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_symbol_length_null_symbol()
 {
-    EXPECT_TRUE(symbol_length(nullptr) == 0);
+    this->expect_true(symbol_length(nullptr) == 0);
 }
 
 void
 driver_entry_ut::test_helper_symbol_length_success()
 {
-    EXPECT_TRUE(symbol_length("hello world") == 11);
+    this->expect_true(symbol_length("hello world") == 11);
 }
 
 void
@@ -94,13 +94,13 @@ driver_entry_ut::test_helper_resolve_symbol_invalid_name()
 {
     void *sym;
 
-    EXPECT_TRUE(resolve_symbol(nullptr, &sym) == BF_ERROR_INVALID_ARG);
+    this->expect_true(resolve_symbol(nullptr, &sym) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_helper_resolve_symbol_invalid_sym()
 {
-    EXPECT_TRUE(resolve_symbol("sym", nullptr) == BF_ERROR_INVALID_ARG);
+    this->expect_true(resolve_symbol("sym", nullptr) == BF_ERROR_INVALID_ARG);
 }
 
 void
@@ -108,7 +108,7 @@ driver_entry_ut::test_helper_resolve_symbol_no_loaded_modules()
 {
     void *sym;
 
-    EXPECT_TRUE(resolve_symbol("invalid_symbol", &sym) == BF_ERROR_NO_MODULES_ADDED);
+    this->expect_true(resolve_symbol("invalid_symbol", &sym) == BF_ERROR_NO_MODULES_ADDED);
 }
 
 void
@@ -116,73 +116,73 @@ driver_entry_ut::test_helper_resolve_symbol_missing_symbol()
 {
     void *sym;
 
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(resolve_symbol("invalid_symbol", &sym) == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(resolve_symbol("invalid_symbol", &sym) == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_execute_symbol_invalid_arg()
 {
-    EXPECT_TRUE(execute_symbol(nullptr, 0, 0, 0) == BF_ERROR_INVALID_ARG);
+    this->expect_true(execute_symbol(nullptr, 0, 0, 0) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_helper_execute_symbol_missing_symbol()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(execute_symbol("invalid_symbol", 0, 0, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(execute_symbol("invalid_symbol", 0, 0, 0) == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_execute_symbol_sym_failed()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(execute_symbol("sym_that_returns_failure", 0, 0, 0) == -1);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(execute_symbol("sym_that_returns_failure", 0, 0, 0) == -1);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_execute_symbol_sym_success()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
-    EXPECT_TRUE(common_load_vmm() == BF_SUCCESS);
-    EXPECT_TRUE(execute_symbol("sym_that_returns_success", 0, 0, 0) == 0);
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_stop_vmm_success.get(), m_dummy_stop_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_add_md_success.get(), m_dummy_add_md_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_misc.get(), m_dummy_misc_length) == BF_SUCCESS);
+    this->expect_true(common_load_vmm() == BF_SUCCESS);
+    this->expect_true(execute_symbol("sym_that_returns_success", 0, 0, 0) == 0);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_add_md_to_memory_manager_null_module()
 {
-    EXPECT_TRUE(add_md_to_memory_manager(nullptr) == BF_ERROR_INVALID_ARG);
+    this->expect_true(add_md_to_memory_manager(nullptr) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_helper_get_elf_file_size_null_module()
 {
-    EXPECT_TRUE(get_elf_file_size(nullptr) == 0);
+    this->expect_true(get_elf_file_size(nullptr) == 0);
 }
 
 void
 driver_entry_ut::test_helper_get_elf_file_size_get_segment_fails()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -191,23 +191,23 @@ driver_entry_ut::test_helper_get_elf_file_size_get_segment_fails()
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
             auto module = get_module(0);
-            EXPECT_TRUE(get_elf_file_size(module) == 0);
+            this->expect_true(get_elf_file_size(module) == 0);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }
 
 void
 driver_entry_ut::test_helper_load_elf_file_null_module()
 {
-    EXPECT_TRUE(load_elf_file(nullptr) == BF_ERROR_INVALID_ARG);
+    this->expect_true(load_elf_file(nullptr) == BF_ERROR_INVALID_ARG);
 }
 
 void
 driver_entry_ut::test_helper_load_elf_file_get_segment_fails()
 {
-    EXPECT_TRUE(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
+    this->expect_true(common_add_module(m_dummy_start_vmm_success.get(), m_dummy_start_vmm_success_length) == BF_SUCCESS);
 
     {
         MockRepository mocks;
@@ -216,9 +216,9 @@ driver_entry_ut::test_helper_load_elf_file_get_segment_fails()
         RUN_UNITTEST_WITH_MOCKS(mocks, [&]
         {
             auto module = get_module(0);
-            EXPECT_TRUE(load_elf_file(module) == -1);
+            this->expect_true(load_elf_file(module) == -1);
         });
     }
 
-    EXPECT_TRUE(common_fini() == BF_SUCCESS);
+    this->expect_true(common_fini() == BF_SUCCESS);
 }

--- a/bfelf_loader/test/test_file_get_segment.cpp
+++ b/bfelf_loader/test/test_file_get_segment.cpp
@@ -27,7 +27,7 @@ bfelf_loader_ut::test_bfelf_file_get_segment_invalid_ef()
     bfelf_phdr *phdr = nullptr;
 
     auto ret = bfelf_file_get_segment(nullptr, 0, &phdr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -39,10 +39,10 @@ bfelf_loader_ut::test_bfelf_file_get_segment_invalid_index()
     auto test = get_test();
 
     ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_file_get_segment(&ef, 10, &phdr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_INDEX);
+    this->expect_true(ret == BFELF_ERROR_INVALID_INDEX);
 }
 
 void
@@ -53,10 +53,10 @@ bfelf_loader_ut::test_bfelf_file_get_segment_invalid_phdr()
     auto test = get_test();
 
     ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_file_get_segment(&ef, 0, nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -68,8 +68,8 @@ bfelf_loader_ut::test_bfelf_file_get_segment_success()
     auto test = get_test();
 
     ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_file_get_segment(&ef, 0, &phdr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }

--- a/bfelf_loader/test/test_file_init.cpp
+++ b/bfelf_loader/test/test_file_init.cpp
@@ -28,7 +28,7 @@ bfelf_loader_ut::test_bfelf_file_init_success()
     auto test = get_test();
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -38,7 +38,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_file_arg()
     auto test = get_test();
 
     auto ret = bfelf_file_init(nullptr, sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -48,7 +48,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_file_size_arg()
     auto test = get_test();
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), 0, &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -57,7 +57,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_elf_file()
     auto test = get_test();
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -69,7 +69,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_magic_0()
     test.header.e_ident[bfei_mag0] = 0;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SIGNATURE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SIGNATURE);
 }
 
 void
@@ -81,7 +81,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_magic_1()
     test.header.e_ident[bfei_mag1] = 0;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SIGNATURE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SIGNATURE);
 }
 
 void
@@ -93,7 +93,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_magic_2()
     test.header.e_ident[bfei_mag2] = 0;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SIGNATURE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SIGNATURE);
 }
 
 void
@@ -105,7 +105,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_magic_3()
     test.header.e_ident[bfei_mag3] = 0;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SIGNATURE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SIGNATURE);
 }
 
 void
@@ -117,7 +117,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_class()
     test.header.e_ident[bfei_class] = 0x4;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -129,7 +129,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_data()
     test.header.e_ident[bfei_data] = 0x8;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -141,7 +141,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_ident_version()
     test.header.e_ident[bfei_version] = 0x15;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -153,7 +153,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_osabi()
     // test.header.e_ident[bfei_osabi] = 0x16;
 
     // auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    // EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    // this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -165,7 +165,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_abiversion()
     test.header.e_ident[bfei_abiversion] = 0x23;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -177,7 +177,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_type()
     test.header.e_type = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -189,7 +189,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_machine()
     test.header.e_machine = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -201,7 +201,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_version()
     test.header.e_version = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -213,7 +213,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_flags()
     test.header.e_flags = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_UNSUPPORTED_FILE);
+    this->expect_true(ret == BFELF_ERROR_UNSUPPORTED_FILE);
 }
 
 void
@@ -225,7 +225,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_header_size()
     test.header.e_ehsize = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -237,7 +237,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_program_header_size()
     test.header.e_phentsize = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -249,7 +249,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_header_size()
     test.header.e_shentsize = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -261,7 +261,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_program_header_offset()
     test.header.e_phoff = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -273,7 +273,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_header_offset()
     test.header.e_shoff = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -285,7 +285,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_program_header_num()
     test.header.e_phnum = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -297,7 +297,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_header_num()
     test.header.e_shnum = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -309,7 +309,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_header_string_table_index(
     test.header.e_shstrndx = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -321,7 +321,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_file_size()
     test.phdrtab.re_segment1.p_filesz = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SEGMENT);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SEGMENT);
 }
 
 void
@@ -333,7 +333,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_addresses()
     test.phdrtab.re_segment1.p_vaddr = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SEGMENT);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SEGMENT);
 }
 
 void
@@ -345,7 +345,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_alignment()
     test.phdrtab.re_segment1.p_align = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SEGMENT);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SEGMENT);
 }
 
 void
@@ -357,7 +357,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_offset()
     test.phdrtab.re_segment1.p_offset = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SEGMENT);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SEGMENT);
 }
 
 void
@@ -369,7 +369,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_offset()
     test.shdrtab.hashtab.sh_offset = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -381,7 +381,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_size()
     test.shdrtab.hashtab.sh_size = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -393,7 +393,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_name()
     test.shdrtab.hashtab.sh_name = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -405,7 +405,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_link()
     test.shdrtab.hashtab.sh_link = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -418,7 +418,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_address()
     test.phdrtab.re_segment1.p_vaddr = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -431,7 +431,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_segment_size()
     test.phdrtab.re_segment1.p_filesz = 0x275;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -443,7 +443,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_entry()
     test.header.e_entry = 0xDEADBEEF;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -455,7 +455,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_type()
     test.shdrtab.shstrtab.sh_type = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -467,7 +467,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_flags()
     test.shdrtab.shstrtab.sh_flags = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -479,7 +479,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_address_alignment()
     test.shdrtab.shstrtab.sh_addralign = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -491,7 +491,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_section_entry_size()
     test.shdrtab.shstrtab.sh_entsize = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -503,7 +503,7 @@ bfelf_loader_ut::test_bfelf_file_init_missing_dynsym()
     test.shdrtab.dynsym.sh_type = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(ret == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -515,7 +515,7 @@ bfelf_loader_ut::test_bfelf_file_init_too_many_program_segments()
     test.phdrtab.too_many.p_type = bfpt_load;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_LOADER_FULL);
+    this->expect_true(ret == BFELF_ERROR_LOADER_FULL);
 }
 
 void
@@ -527,7 +527,7 @@ bfelf_loader_ut::test_bfelf_file_init_too_many_relocation_tables()
     test.shdrtab.too_many.sh_type = bfsht_rela;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_LOADER_FULL);
+    this->expect_true(ret == BFELF_ERROR_LOADER_FULL);
 }
 
 void
@@ -539,7 +539,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_hash_table_size1()
     test.shdrtab.hashtab.sh_size = 1;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -551,7 +551,7 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_hash_table_size2()
     test.hashtab.nbucket = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }
 
 void
@@ -563,5 +563,5 @@ bfelf_loader_ut::test_bfelf_file_init_invalid_hash_table_size3()
     test.hashtab.nchain = 0xDEAD;
 
     auto ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_SECTION);
+    this->expect_true(ret == BFELF_ERROR_INVALID_SECTION);
 }

--- a/bfelf_loader/test/test_file_num_segments.cpp
+++ b/bfelf_loader/test/test_file_num_segments.cpp
@@ -25,7 +25,7 @@ void
 bfelf_loader_ut::test_bfelf_file_num_segments_invalid_ef()
 {
     auto ret = bfelf_file_num_segments(nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -35,7 +35,7 @@ bfelf_loader_ut::test_bfelf_file_num_segments_uninitalized()
     memset(&ef, 0, sizeof(ef));
 
     auto ret = bfelf_file_num_segments(&ef);
-    EXPECT_TRUE(ret == 0);
+    this->expect_true(ret == 0);
 }
 
 void
@@ -46,8 +46,8 @@ bfelf_loader_ut::test_bfelf_file_num_segments_success()
     auto test = get_test();
 
     ret = bfelf_file_init(reinterpret_cast<char *>(&test), sizeof(test), &ef);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_file_num_segments(&ef);
-    EXPECT_TRUE(ret > 0);
+    this->expect_true(ret > 0);
 }

--- a/bfelf_loader/test/test_file_resolve_symbol.cpp
+++ b/bfelf_loader/test/test_file_resolve_symbol.cpp
@@ -30,7 +30,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_loader()
     e_string_t name = {"foo", 3};
 
     auto ret = bfelf_file_resolve_symbol(nullptr, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -42,7 +42,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_name()
     memset(&ef, 0, sizeof(ef));
 
     auto ret = bfelf_file_resolve_symbol(&ef, nullptr, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -54,7 +54,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_invalid_addr()
     memset(&ef, 0, sizeof(ef));
 
     auto ret = bfelf_file_resolve_symbol(&ef, &name, nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -69,7 +69,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_no_relocation()
     e_string_t name = {"foo", 3};
 
     ret = bfelf_file_resolve_symbol(&ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_OUT_OF_ORDER);
+    this->expect_true(ret == BFELF_ERROR_OUT_OF_ORDER);
 }
 
 void
@@ -98,13 +98,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"fighters", 8};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -133,13 +133,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 0};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -168,13 +168,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 2};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -203,13 +203,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 1000};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -238,13 +238,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_success()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -276,13 +276,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_no_such_symbol_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"fighters", 8};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -314,13 +314,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_zero_length_symbol_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 0};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -352,13 +352,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_invalid_symbol_length_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 2};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -390,13 +390,13 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_length_too_large_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 1000};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -428,11 +428,11 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_success_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_file_resolve_symbol(&dummy_misc_ef, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }

--- a/bfelf_loader/test/test_loader_add.cpp
+++ b/bfelf_loader/test/test_loader_add.cpp
@@ -31,7 +31,7 @@ bfelf_loader_ut::test_bfelf_loader_add_invalid_loader()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_add(nullptr, &dummy_misc_ef, m_dummy_misc_exec.get());
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -41,7 +41,7 @@ bfelf_loader_ut::test_bfelf_loader_add_invalid_elf_file()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_add(&loader, nullptr, m_dummy_misc_exec.get());
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -59,9 +59,9 @@ bfelf_loader_ut::test_bfelf_loader_add_too_many_files()
     for (auto i = 0; i < BFELF_MAX_MODULES; i++)
     {
         ret = bfelf_loader_add(&loader, &dummy_misc_ef, m_dummy_misc_exec.get());
-        EXPECT_TRUE(ret == BFELF_SUCCESS);
+        this->expect_true(ret == BFELF_SUCCESS);
     }
 
     ret = bfelf_loader_add(&loader, &dummy_misc_ef, m_dummy_misc_exec.get());
-    EXPECT_TRUE(ret == BFELF_ERROR_LOADER_FULL);
+    this->expect_true(ret == BFELF_ERROR_LOADER_FULL);
 }

--- a/bfelf_loader/test/test_loader_get_info.cpp
+++ b/bfelf_loader/test/test_loader_get_info.cpp
@@ -51,7 +51,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_invalid_loader()
     section_info_t info;
 
     auto ret = bfelf_loader_get_info(nullptr, &ef, &info);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -63,7 +63,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_invalid_elf_file()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_get_info(&loader, nullptr, &info);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -75,7 +75,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_invalid_info()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_get_info(&loader, &ef, nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -88,7 +88,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_no_relocation()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_get_info(&loader, &ef, &info);
-    EXPECT_TRUE(ret == BFELF_ERROR_OUT_OF_ORDER);
+    this->expect_true(ret == BFELF_ERROR_OUT_OF_ORDER);
 }
 
 void
@@ -117,21 +117,21 @@ bfelf_loader_ut::test_bfelf_loader_get_info_expected_misc_resources()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
 
     ret = bfelf_loader_get_info(&loader, &dummy_misc_ef, &info);
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
-    EXPECT_TRUE(info.ctors_addr != nullptr || info.init_array_addr != nullptr);
-    EXPECT_TRUE(info.ctors_size != 0 || info.init_array_size != 0);
+    this->expect_true(info.ctors_addr != nullptr || info.init_array_addr != nullptr);
+    this->expect_true(info.ctors_size != 0 || info.init_array_size != 0);
 
-    EXPECT_TRUE(info.dtors_addr != nullptr || info.init_array_addr != nullptr);
-    EXPECT_TRUE(info.dtors_size != 0 || info.init_array_size != 0);
+    this->expect_true(info.dtors_addr != nullptr || info.init_array_addr != nullptr);
+    this->expect_true(info.dtors_size != 0 || info.init_array_size != 0);
 
-    EXPECT_TRUE(info.eh_frame_addr != nullptr);
-    EXPECT_TRUE(info.eh_frame_size != 0);
+    this->expect_true(info.eh_frame_addr != nullptr);
+    this->expect_true(info.eh_frame_size != 0);
 }
 
 void
@@ -160,7 +160,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_expected_code_resources()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -168,14 +168,14 @@ bfelf_loader_ut::test_bfelf_loader_get_info_expected_code_resources()
     ret = bfelf_loader_get_info(&loader, &dummy_code_ef, &info);
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
-    EXPECT_TRUE(info.ctors_addr == nullptr);
-    EXPECT_TRUE(info.ctors_size == 0);
+    this->expect_true(info.ctors_addr == nullptr);
+    this->expect_true(info.ctors_size == 0);
 
-    EXPECT_TRUE(info.dtors_addr == nullptr);
-    EXPECT_TRUE(info.dtors_size == 0);
+    this->expect_true(info.dtors_addr == nullptr);
+    this->expect_true(info.dtors_size == 0);
 
-    EXPECT_TRUE(info.eh_frame_addr != nullptr);
-    EXPECT_TRUE(info.eh_frame_size != 0);
+    this->expect_true(info.eh_frame_addr != nullptr);
+    this->expect_true(info.eh_frame_size != 0);
 }
 
 void
@@ -204,7 +204,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_get_section_name_failure_ctors()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -245,7 +245,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_check_section_name_failure_ctors()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -291,7 +291,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_get_section_name_failure_dtors()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -337,7 +337,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_check_section_name_failure_dtors()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -388,7 +388,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_get_section_name_failure_init_array(
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -439,7 +439,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_check_section_name_failure_init_arra
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -495,7 +495,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_get_section_name_failure_fini_array(
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -551,7 +551,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_check_section_name_failure_fini_arra
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -612,7 +612,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_get_section_name_failure_eh_frame()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));
@@ -673,7 +673,7 @@ bfelf_loader_ut::test_bfelf_loader_get_info_check_section_name_failure_eh_frame(
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     section_info_t info;
     memset(&info, 0, sizeof(info));

--- a/bfelf_loader/test/test_loader_relocate.cpp
+++ b/bfelf_loader/test/test_loader_relocate.cpp
@@ -25,7 +25,7 @@ void
 bfelf_loader_ut::test_bfelf_loader_relocate_invalid_loader()
 {
     auto ret = bfelf_loader_relocate(nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -35,7 +35,7 @@ bfelf_loader_ut::test_bfelf_loader_relocate_no_files_added()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -51,13 +51,13 @@ bfelf_loader_ut::test_bfelf_loader_relocate_uninitialized_files()
     memset(&loader, 0, sizeof(loader));
 
     ret = bfelf_loader_add(&loader, &ef1, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_add(&loader, &ef2, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -73,14 +73,14 @@ bfelf_loader_ut::test_bfelf_loader_relocate_twice()
     memset(&loader, 0, sizeof(loader));
 
     ret = bfelf_loader_add(&loader, &ef1, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_add(&loader, &ef2, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }

--- a/bfelf_loader/test/test_loader_resolve_symbol.cpp
+++ b/bfelf_loader/test/test_loader_resolve_symbol.cpp
@@ -46,7 +46,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_loader()
     e_string_t name = {"foo", 3};
 
     auto ret = bfelf_loader_resolve_symbol(nullptr, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -58,7 +58,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_name()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_resolve_symbol(&loader, nullptr, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -70,7 +70,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_invalid_addr()
     memset(&loader, 0, sizeof(loader));
 
     auto ret = bfelf_loader_resolve_symbol(&loader, &name, nullptr);
-    EXPECT_TRUE(ret == BFELF_ERROR_INVALID_ARG);
+    this->expect_true(ret == BFELF_ERROR_INVALID_ARG);
 }
 
 void
@@ -85,7 +85,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_relocation()
     e_string_t name = {"foo", 3};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_OUT_OF_ORDER);
+    this->expect_true(ret == BFELF_ERROR_OUT_OF_ORDER);
 }
 
 void
@@ -97,13 +97,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_no_files_added()
     memset(&loader, 0, sizeof(loader));
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -119,18 +119,18 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_uninitialized_files()
     memset(&loader, 0, sizeof(loader));
 
     ret = bfelf_loader_add(&loader, &ef1, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
     ret = bfelf_loader_add(&loader, &ef2, nullptr);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -159,13 +159,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"fighters", 8};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -194,13 +194,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 0};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -229,13 +229,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 2};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -264,13 +264,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 1000};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -299,13 +299,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -337,13 +337,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_no_such_symbol_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"fighters", 8};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -375,13 +375,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_zero_length_symbol_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 0};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -413,13 +413,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_invalid_symbol_length_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 2};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -451,13 +451,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_length_too_large_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 1000};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
+    this->expect_true(ret == BFELF_ERROR_NO_SUCH_SYMBOL);
 }
 
 void
@@ -489,13 +489,13 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_success_no_hash()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     func_t func;
     e_string_t name = {"foo", 3};
 
     ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 }
 
 void
@@ -524,7 +524,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_real_test()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     {
         section_info_t info;
@@ -555,7 +555,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_real_test()
         ret = bfelf_loader_resolve_symbol(&loader, &name, reinterpret_cast<void **>(&func));
         ASSERT_TRUE(ret == BFELF_SUCCESS);
 
-        EXPECT_TRUE(func(5) == 1005);
+        this->expect_true(func(5) == 1005);
     }
 
     {
@@ -607,7 +607,7 @@ bfelf_loader_ut::test_bfelf_file_resolve_symbol_resolve_fail()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     MockRepository mocks;
     mocks.OnCallFunc(private_resolve_symbol).Return(-1);
@@ -652,7 +652,7 @@ bfelf_loader_ut::test_bfelf_loader_resolve_symbol_resolve_fail()
     ASSERT_TRUE(ret == BFELF_SUCCESS);
 
     ret = bfelf_loader_relocate(&loader);
-    EXPECT_TRUE(ret == BFELF_SUCCESS);
+    this->expect_true(ret == BFELF_SUCCESS);
 
     MockRepository mocks;
     mocks.OnCallFunc(private_resolve_symbol).Return(-1);

--- a/bfelf_loader/test/test_private.cpp
+++ b/bfelf_loader/test/test_private.cpp
@@ -72,7 +72,7 @@ extern "C"
 void
 bfelf_loader_ut::test_private_bfelf_error()
 {
-    EXPECT_TRUE(bfelf_error(0) == "SUCCESS"_s);
+    this->expect_true(bfelf_error(0) == "SUCCESS"_s);
 }
 
 void
@@ -86,7 +86,7 @@ bfelf_loader_ut::test_private_invalid_symbol_index()
     ef.symnum = 1;
     ef.strtab = &strtab;
 
-    EXPECT_TRUE(private_check_symbol(&ef, 2, &name, &sym) == BFELF_ERROR_MISMATCH);
+    this->expect_true(private_check_symbol(&ef, 2, &name, &sym) == BFELF_ERROR_MISMATCH);
 }
 
 void
@@ -110,7 +110,7 @@ bfelf_loader_ut::test_private_corrupt_symbol_table()
     strtab.sh_size = 5;
     strtab.sh_offset = 0;
 
-    EXPECT_TRUE(private_check_symbol(&ef, 0, &name, &sym) == BFELF_ERROR_MISMATCH);
+    this->expect_true(private_check_symbol(&ef, 0, &name, &sym) == BFELF_ERROR_MISMATCH);
 }
 
 void
@@ -125,7 +125,7 @@ bfelf_loader_ut::test_private_relocate_invalid_index()
 
     ef.strtab = &strtab;
 
-    EXPECT_TRUE(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_INVALID_INDEX);
+    this->expect_true(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_INVALID_INDEX);
 }
 
 void
@@ -152,7 +152,7 @@ bfelf_loader_ut::test_private_relocate_invalid_name()
     gsl::at(symtab, 0).st_name = 0xFFFFF;
     gsl::at(symtab, 0).st_value = 0x0;
 
-    EXPECT_TRUE(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -182,7 +182,7 @@ bfelf_loader_ut::test_private_relocate_invalid_relocation()
     gsl::at(symtab, 0).st_name = 0xFFFFF;
     gsl::at(symtab, 0).st_value = 0x1;
 
-    EXPECT_TRUE(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_UNSUPPORTED_RELA);
+    this->expect_true(private_relocate_symbol(&loader, &ef, &rela) == BFELF_ERROR_UNSUPPORTED_RELA);
 }
 
 void
@@ -207,7 +207,7 @@ bfelf_loader_ut::test_private_get_section_invalid_name()
 
     shstrtab.sh_size = 0;
 
-    EXPECT_TRUE(private_get_section_by_name(&ef, &name, &shdr) == BFELF_ERROR_INVALID_FILE);
+    this->expect_true(private_get_section_by_name(&ef, &name, &shdr) == BFELF_ERROR_INVALID_FILE);
 }
 
 void
@@ -231,7 +231,7 @@ bfelf_loader_ut::test_private_symbol_table_sections_invalid_dynsym()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(private_symbol_table_sections(&ef) == -1);
+        this->expect_true(private_symbol_table_sections(&ef) == -1);
     });
 }
 
@@ -256,7 +256,7 @@ bfelf_loader_ut::test_private_symbol_table_sections_invalid_hash()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(private_symbol_table_sections(&ef) == -1);
+        this->expect_true(private_symbol_table_sections(&ef) == -1);
     });
 }
 
@@ -280,7 +280,7 @@ bfelf_loader_ut::test_private_string_table_sections_invalid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(private_get_string_table_sections(&ef) == -1);
+        this->expect_true(private_get_string_table_sections(&ef) == -1);
     });
 }
 
@@ -300,7 +300,7 @@ bfelf_loader_ut::test_private_get_relocation_tables_invalid_type()
 
     gsl::at(shdrtab, 0).sh_type = bfsht_rel;
 
-    EXPECT_TRUE(private_get_relocation_tables(&ef) == BFELF_ERROR_UNSUPPORTED_RELA);
+    this->expect_true(private_get_relocation_tables(&ef) == BFELF_ERROR_UNSUPPORTED_RELA);
 }
 
 void
@@ -325,7 +325,7 @@ bfelf_loader_ut::test_private_get_relocation_tables_invalid_section()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_TRUE(private_get_relocation_tables(&ef) == -1);
+        this->expect_true(private_get_relocation_tables(&ef) == -1);
     });
 }
 
@@ -334,5 +334,5 @@ bfelf_loader_ut::test_private_hash()
 {
     const char name[2] = {static_cast<char>(-1), static_cast<char>(0)};
 
-    EXPECT_TRUE(private_hash(static_cast<const char *>(name)) != 0);
+    this->expect_true(private_hash(static_cast<const char *>(name)) != 0);
 }

--- a/bfunwind/test/test_try_catch.cpp
+++ b/bfunwind/test/test_try_catch.cpp
@@ -115,7 +115,7 @@ bfunwind_ut::test_catch_all()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -131,12 +131,12 @@ bfunwind_ut::test_catch_bool()
     catch (bool val)
     {
         caught = true;
-        EXPECT_TRUE(val);
+        this->expect_true(val);
     }
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -152,12 +152,12 @@ bfunwind_ut::test_catch_int()
     catch (int val)
     {
         caught = true;
-        EXPECT_TRUE(val == 5);
+        this->expect_true(val == 5);
     }
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -173,12 +173,12 @@ bfunwind_ut::test_catch_cstr()
     catch (const char *val)
     {
         caught = true;
-        EXPECT_TRUE(strcmp(val, "1234") == 0);
+        this->expect_true(strcmp(val, "1234") == 0);
     }
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -194,12 +194,12 @@ bfunwind_ut::test_catch_string()
     catch (std::string &val)
     {
         caught = true;
-        EXPECT_TRUE(val.compare("1234") == 0);
+        this->expect_true(val.compare("1234") == 0);
     }
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -219,7 +219,7 @@ bfunwind_ut::test_catch_exception()
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -239,7 +239,7 @@ bfunwind_ut::test_catch_custom_exception()
     catch (...)
     {}
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -256,7 +256,7 @@ bfunwind_ut::test_catch_multiple_catches_per_function()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
     caught = false;
 
     try
@@ -268,7 +268,7 @@ bfunwind_ut::test_catch_multiple_catches_per_function()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
     caught = false;
 
     try
@@ -280,7 +280,7 @@ bfunwind_ut::test_catch_multiple_catches_per_function()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -304,8 +304,8 @@ bfunwind_ut::test_catch_raii()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
-    EXPECT_TRUE(g_raii_count == 5);
+    this->expect_true(caught);
+    this->expect_true(g_raii_count == 5);
 }
 
 void
@@ -323,7 +323,7 @@ bfunwind_ut::test_catch_throw_from_stream()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
+    this->expect_true(caught);
 }
 
 void
@@ -350,8 +350,8 @@ bfunwind_ut::test_catch_nested_throw_in_catch()
         caught2 = true;
     }
 
-    EXPECT_TRUE(caught1);
-    EXPECT_TRUE(caught2);
+    this->expect_true(caught1);
+    this->expect_true(caught2);
 }
 
 void
@@ -378,8 +378,8 @@ bfunwind_ut::test_catch_nested_throw_outside_catch()
         caught2 = true;
     }
 
-    EXPECT_TRUE(caught1);
-    EXPECT_TRUE(caught2);
+    this->expect_true(caught1);
+    this->expect_true(caught2);
 }
 
 void
@@ -404,8 +404,8 @@ bfunwind_ut::test_catch_nested_throw_uncaught()
         caught2 = true;
     }
 
-    EXPECT_FALSE(caught1);
-    EXPECT_TRUE(caught2);
+    this->expect_false(caught1);
+    this->expect_true(caught2);
 }
 
 void
@@ -431,8 +431,8 @@ bfunwind_ut::test_catch_nested_throw_rethrow()
         caught2 = true;
     }
 
-    EXPECT_TRUE(caught1);
-    EXPECT_TRUE(caught2);
+    this->expect_true(caught1);
+    this->expect_true(caught2);
 }
 
 void
@@ -457,14 +457,14 @@ bfunwind_ut::test_catch_throw_with_lots_of_register_mods()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
-    EXPECT_TRUE(r01 == 1);
-    EXPECT_TRUE(r02 == 2);
-    EXPECT_TRUE(r03 == 3);
-    EXPECT_TRUE(r04 == 4);
-    EXPECT_TRUE(r05 == 5);
-    EXPECT_TRUE(r06 == 6);
-    EXPECT_TRUE(r07 == 7);
+    this->expect_true(caught);
+    this->expect_true(r01 == 1);
+    this->expect_true(r02 == 2);
+    this->expect_true(r03 == 3);
+    this->expect_true(r04 == 4);
+    this->expect_true(r05 == 5);
+    this->expect_true(r06 == 6);
+    this->expect_true(r07 == 7);
 
     caught = false;
 
@@ -485,12 +485,12 @@ bfunwind_ut::test_catch_throw_with_lots_of_register_mods()
         caught = true;
     }
 
-    EXPECT_TRUE(caught);
-    EXPECT_TRUE(r11 == 1);
-    EXPECT_TRUE(r12 == 2);
-    EXPECT_TRUE(r13 == 3);
-    EXPECT_TRUE(r14 == 4);
-    EXPECT_TRUE(r15 == 5);
-    EXPECT_TRUE(r16 == 6);
-    EXPECT_TRUE(r17 == 7);
+    this->expect_true(caught);
+    this->expect_true(r11 == 1);
+    this->expect_true(r12 == 2);
+    this->expect_true(r13 == 3);
+    this->expect_true(r14 == 4);
+    this->expect_true(r15 == 5);
+    this->expect_true(r16 == 6);
+    this->expect_true(r17 == 7);
 }

--- a/bfvmm/src/debug_ring/test/test_debug_ring.cpp
+++ b/bfvmm/src/debug_ring/test/test_debug_ring.cpp
@@ -65,13 +65,13 @@ init_wb(uint64_t num, char val = 'A')
 void
 debug_ring_ut::test_get_drr_invalid_drr()
 {
-    EXPECT_TRUE(get_drr(0, nullptr) == GET_DRR_FAILURE);
+    this->expect_true(get_drr(0, nullptr) == GET_DRR_FAILURE);
 }
 
 void
 debug_ring_ut::test_get_drr_invalid_vcpuid()
 {
-    EXPECT_TRUE(get_drr(0x1000, &drr) == GET_DRR_FAILURE);
+    this->expect_true(get_drr(0x1000, &drr) == GET_DRR_FAILURE);
 }
 
 void
@@ -88,13 +88,13 @@ debug_ring_ut::test_write_out_of_memory()
     out_of_memory = true;
     debug_ring dr(0);
     out_of_memory = false;
-    EXPECT_NO_EXCEPTION(dr.write("hello"));
+    this->expect_no_exception([&] { dr.write("hello"); });
 }
 
 void
 debug_ring_ut::test_read_with_invalid_drr()
 {
-    EXPECT_TRUE(debug_ring_read(nullptr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
+    this->expect_true(debug_ring_read(nullptr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
 }
 
 void
@@ -103,7 +103,7 @@ debug_ring_ut::test_read_with_null_string()
     debug_ring dr(0);
     get_drr(0, &drr);
 
-    EXPECT_TRUE(debug_ring_read(drr, nullptr, DEBUG_RING_SIZE) == 0);
+    this->expect_true(debug_ring_read(drr, nullptr, DEBUG_RING_SIZE) == 0);
 }
 
 void
@@ -112,7 +112,7 @@ debug_ring_ut::test_read_with_zero_length()
     debug_ring dr(0);
     get_drr(0, &drr);
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), 0) == 0);
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), 0) == 0);
 }
 
 void
@@ -123,7 +123,7 @@ debug_ring_ut::test_write_with_zero_length()
 
     auto zero_len_wb = "";
 
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(zero_len_wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(zero_len_wb)); });
 }
 
 void
@@ -134,7 +134,7 @@ debug_ring_ut::test_write_string_to_dr_that_is_larger_than_dr()
 
     init_wb(DEBUG_RING_SIZE);
 
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 }
 
 void
@@ -145,7 +145,7 @@ debug_ring_ut::test_write_string_to_dr_that_is_much_larger_than_dr()
 
     init_wb(DEBUG_RING_SIZE + 50);
 
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 }
 
 void
@@ -156,8 +156,8 @@ debug_ring_ut::test_write_one_small_string_to_dr()
 
     auto small_wb = "01234";
 
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(small_wb)));
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 5);
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(small_wb)); });
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 5);
 }
 
 void
@@ -168,9 +168,9 @@ debug_ring_ut::test_fill_dr()
 
     init_wb(DEBUG_RING_SIZE - 1);
 
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == DEBUG_RING_SIZE);
-    EXPECT_TRUE(rb[DEBUG_RING_SIZE - 1] == '\0');
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == DEBUG_RING_SIZE);
+    this->expect_true(rb[DEBUG_RING_SIZE - 1] == '\0');
 }
 
 void
@@ -180,13 +180,13 @@ debug_ring_ut::test_overcommit_dr()
     get_drr(0, &drr);
 
     init_wb(DEBUG_RING_SIZE - 10, 'A');
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 
     init_wb(100, 'B');
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 100);
-    EXPECT_TRUE(rb[0] == 'B');
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 100);
+    this->expect_true(rb[0] == 'B');
 }
 
 void
@@ -196,16 +196,16 @@ debug_ring_ut::test_overcommit_dr_more_than_once()
     get_drr(0, &drr);
 
     init_wb(DEBUG_RING_SIZE - 150, 'A');
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 
     init_wb(DEBUG_RING_SIZE - 150, 'B');
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 
     init_wb(DEBUG_RING_SIZE - 150, 'C');
-    EXPECT_NO_EXCEPTION(dr.write(static_cast<const char *>(wb)));
+    this->expect_no_exception([&] { dr.write(static_cast<const char *>(wb)); });
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == DEBUG_RING_SIZE - 150);
-    EXPECT_TRUE(rb[0] == 'C');
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == DEBUG_RING_SIZE - 150);
+    this->expect_true(rb[0] == 'C');
 }
 
 void
@@ -214,7 +214,7 @@ debug_ring_ut::test_read_with_empty_dr()
     debug_ring dr(0);
     get_drr(0, &drr);
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
 }
 
 void
@@ -235,6 +235,6 @@ debug_ring_ut::acceptance_test_stress()
     auto num = DEBUG_RING_SIZE / (strlen(static_cast<const char *>(small_wb)) + 1);
     auto total = num * strlen(static_cast<const char *>(small_wb));
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == total);
-    EXPECT_TRUE(rb[0] == '0');
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == total);
+    this->expect_true(rb[0] == '0');
 }

--- a/bfvmm/src/entry/test/test_entry.cpp
+++ b/bfvmm/src/entry/test/test_entry.cpp
@@ -40,7 +40,7 @@ entry_ut::test_start_vmm_success()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(start_vmm(0));
+        this->expect_no_exception([&] { start_vmm(0); });
     });
 }
 
@@ -58,7 +58,7 @@ entry_ut::test_start_vmm_throws_general_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(start_vmm(0));
+        this->expect_no_exception([&] { start_vmm(0); });
     });
 }
 
@@ -76,7 +76,7 @@ entry_ut::test_start_vmm_throws_standard_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(start_vmm(0));
+        this->expect_no_exception([&] { start_vmm(0); });
     });
 }
 
@@ -94,7 +94,7 @@ entry_ut::test_start_vmm_throws_bad_alloc()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(start_vmm(0));
+        this->expect_no_exception([&] { start_vmm(0); });
     });
 }
 
@@ -112,7 +112,7 @@ entry_ut::test_start_vmm_throws_any_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(start_vmm(0));
+        this->expect_no_exception([&] { start_vmm(0); });
     });
 }
 
@@ -130,7 +130,7 @@ entry_ut::test_stop_vmm_success()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(stop_vmm(0));
+        this->expect_no_exception([&] { stop_vmm(0); });
     });
 }
 
@@ -148,7 +148,7 @@ entry_ut::test_stop_vmm_throws_general_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(stop_vmm(0));
+        this->expect_no_exception([&] { stop_vmm(0); });
     });
 }
 
@@ -166,7 +166,7 @@ entry_ut::test_stop_vmm_throws_standard_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(stop_vmm(0));
+        this->expect_no_exception([&] { stop_vmm(0); });
     });
 }
 
@@ -184,7 +184,7 @@ entry_ut::test_stop_vmm_throws_bad_alloc()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(stop_vmm(0));
+        this->expect_no_exception([&] { stop_vmm(0); });
     });
 }
 
@@ -202,6 +202,6 @@ entry_ut::test_stop_vmm_throws_any_exception()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(stop_vmm(0));
+        this->expect_no_exception([&] { stop_vmm(0); });
     });
 }

--- a/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
+++ b/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
@@ -40,26 +40,26 @@ __outb(uint16_t port, uint8_t val) noexcept
 void
 serial_ut::test_serial_null_intrinsics()
 {
-    EXPECT_NO_EXCEPTION(std::make_unique<serial_port_intel_x64>());
+    this->expect_no_exception([&] { std::make_shared<serial_port_intel_x64>(); });
 }
 
 void
 serial_ut::test_serial_success()
 {
-    EXPECT_TRUE(serial_port_intel_x64::instance()->port() == serial_intel_x64::DEFAULT_COM_PORT);
-    EXPECT_TRUE(serial_port_intel_x64::instance()->baud_rate() == serial_port_intel_x64::DEFAULT_BAUD_RATE);
-    EXPECT_TRUE(serial_port_intel_x64::instance()->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE(serial_port_intel_x64::instance()->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE(serial_port_intel_x64::instance()->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true(serial_port_intel_x64::instance()->port() == serial_intel_x64::DEFAULT_COM_PORT);
+    this->expect_true(serial_port_intel_x64::instance()->baud_rate() == serial_port_intel_x64::DEFAULT_BAUD_RATE);
+    this->expect_true(serial_port_intel_x64::instance()->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true(serial_port_intel_x64::instance()->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true(serial_port_intel_x64::instance()->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_lo_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_hi_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_enable_fifos) != 0);
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_recieve_fifo) != 0);
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_transmit_fifo) != 0);
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_data_mask) == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_stop_mask) == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_parity_mask) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_lo_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_hi_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_enable_fifos) != 0);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_recieve_fifo) != 0);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_transmit_fifo) != 0);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_data_mask) == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_stop_mask) == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_parity_mask) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void
@@ -68,41 +68,41 @@ serial_ut::test_serial_set_baud_rate_success()
     auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_50);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_50);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_50);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_75);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_75);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_75);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_110);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_110);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_110);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_150);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_150);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_150);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_300);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_300);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_300);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_600);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_600);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_600);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_1200);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_1200);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_1200);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_1800);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_1800);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_1800);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_2000);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_2000);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_2000);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_2400);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_2400);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_2400);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_3600);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_3600);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_3600);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_4800);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_4800);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_4800);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_7200);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_7200);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_7200);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_9600);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_9600);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_9600);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_19200);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_19200);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_19200);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_38400);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_38400);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_38400);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_57600);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_57600);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_57600);
     serial->set_baud_rate(serial_port_intel_x64::baud_rate_115200);
-    EXPECT_TRUE(serial->baud_rate() == serial_port_intel_x64::baud_rate_115200);
+    this->expect_true(serial->baud_rate() == serial_port_intel_x64::baud_rate_115200);
 }
 
 void
@@ -111,13 +111,13 @@ serial_ut::test_serial_set_data_bits_success()
     auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_data_bits(serial_port_intel_x64::char_length_5);
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::char_length_5);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::char_length_5);
     serial->set_data_bits(serial_port_intel_x64::char_length_6);
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::char_length_6);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::char_length_6);
     serial->set_data_bits(serial_port_intel_x64::char_length_7);
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::char_length_7);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::char_length_7);
     serial->set_data_bits(serial_port_intel_x64::char_length_8);
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::char_length_8);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::char_length_8);
 }
 
 void
@@ -128,9 +128,9 @@ serial_ut::test_serial_set_data_bits_success_extra_bits()
     auto bits = serial_port_intel_x64::DEFAULT_DATA_BITS | ~serial_intel_x64::line_control_data_mask;
     serial->set_data_bits(static_cast<serial_port_intel_x64::data_bits_t>(bits));
 
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void
@@ -139,9 +139,9 @@ serial_ut::test_serial_set_stop_bits_success()
     auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_stop_bits(serial_port_intel_x64::stop_bits_1);
-    EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::stop_bits_1);
+    this->expect_true(serial->stop_bits() == serial_port_intel_x64::stop_bits_1);
     serial->set_stop_bits(serial_port_intel_x64::stop_bits_2);
-    EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::stop_bits_2);
+    this->expect_true(serial->stop_bits() == serial_port_intel_x64::stop_bits_2);
 }
 
 void
@@ -152,9 +152,9 @@ serial_ut::test_serial_set_stop_bits_success_extra_bits()
     auto bits = serial_port_intel_x64::DEFAULT_STOP_BITS | ~serial_intel_x64::line_control_stop_mask;
     serial->set_stop_bits(static_cast<serial_port_intel_x64::stop_bits_t>(bits));
 
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void
@@ -163,15 +163,15 @@ serial_ut::test_serial_set_parity_bits_success()
     auto serial = std::make_unique<serial_port_intel_x64>();
 
     serial->set_parity_bits(serial_port_intel_x64::parity_none);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_none);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::parity_none);
     serial->set_parity_bits(serial_port_intel_x64::parity_odd);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_odd);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::parity_odd);
     serial->set_parity_bits(serial_port_intel_x64::parity_even);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_even);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::parity_even);
     serial->set_parity_bits(serial_port_intel_x64::parity_mark);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_mark);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::parity_mark);
     serial->set_parity_bits(serial_port_intel_x64::parity_space);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::parity_space);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::parity_space);
 }
 
 void
@@ -182,9 +182,9 @@ serial_ut::test_serial_set_parity_bits_success_extra_bits()
     auto bits = serial_port_intel_x64::DEFAULT_PARITY_BITS | ~serial_intel_x64::line_control_parity_mask;
     serial->set_parity_bits(static_cast<serial_port_intel_x64::parity_bits_t>(bits));
 
-    EXPECT_TRUE(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    EXPECT_TRUE(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    EXPECT_TRUE(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true(serial->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true(serial->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true(serial->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void

--- a/bfvmm/src/vcpu/test/test_vcpu.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu.cpp
@@ -26,13 +26,13 @@
 void
 vcpu_ut::test_vcpu_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_unique<vcpu>(vcpuid::reserved, nullptr), std::invalid_argument);
+    this->expect_exception([&] { std::make_shared<vcpu>(vcpuid::reserved, nullptr); }, ""_ut_iae);
 }
 
 void
 vcpu_ut::test_vcpu_null_debug_ring()
 {
-    EXPECT_NO_EXCEPTION(std::make_unique<vcpu>(0, nullptr));
+    this->expect_no_exception([&] { std::make_shared<vcpu>(0, nullptr); });
 }
 
 void
@@ -40,7 +40,7 @@ vcpu_ut::test_vcpu_valid()
 {
     auto dr = std::shared_ptr<debug_ring>(nullptr);
 
-    EXPECT_NO_EXCEPTION(std::make_unique<vcpu>(0, dr));
+    this->expect_no_exception([&] { std::make_shared<vcpu>(0, dr); });
 }
 
 void
@@ -53,7 +53,7 @@ vcpu_ut::test_vcpu_write_empty_string()
     vc->write("");
     get_drr(0, &drr);
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 0);
 }
 
 void
@@ -66,7 +66,7 @@ vcpu_ut::test_vcpu_write_hello_world()
     vc->write("hello world");
     get_drr(0, &drr);
 
-    EXPECT_TRUE(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 11);
+    this->expect_true(debug_ring_read(drr, static_cast<char *>(rb), DEBUG_RING_SIZE) == 11);
 }
 
 void
@@ -74,9 +74,9 @@ vcpu_ut::test_vcpu_init_null_attr()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_initialized());
     vc->init(nullptr);
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_initialized());
 }
 
 void
@@ -85,9 +85,9 @@ vcpu_ut::test_vcpu_init_valid_attr()
     int i = 0;
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_initialized());
     vc->init(&i);
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_initialized());
 }
 
 void
@@ -97,9 +97,9 @@ vcpu_ut::test_vcpu_fini_null_attr()
 
     vc->init();
 
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_initialized());
     vc->fini(nullptr);
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -110,9 +110,9 @@ vcpu_ut::test_vcpu_fini_valid_attr()
 
     vc->init();
 
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_initialized());
     vc->fini(&i);
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -120,11 +120,11 @@ vcpu_ut::test_vcpu_fini_without_init_without_run()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_false(vc->is_initialized());
     vc->fini();
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -134,11 +134,11 @@ vcpu_ut::test_vcpu_fini_with_init_without_run()
 
     vc->init();
 
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_true(vc->is_initialized());
     vc->fini();
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -148,11 +148,11 @@ vcpu_ut::test_vcpu_fini_without_init_with_run()
 
     vc->run();
 
-    EXPECT_TRUE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_true(vc->is_running());
+    this->expect_false(vc->is_initialized());
     vc->fini();
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -163,11 +163,11 @@ vcpu_ut::test_vcpu_fini_with_init_with_run()
     vc->init();
     vc->run();
 
-    EXPECT_TRUE(vc->is_running());
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_running());
+    this->expect_true(vc->is_initialized());
     vc->fini();
-    EXPECT_FALSE(vc->is_running());
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_running());
+    this->expect_false(vc->is_initialized());
 }
 
 void
@@ -175,9 +175,9 @@ vcpu_ut::test_vcpu_run_null_attr()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->run(nullptr);
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
 }
 
 void
@@ -186,9 +186,9 @@ vcpu_ut::test_vcpu_run_valid_attr()
     int i = 0;
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->run(&i);
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
 }
 
 void
@@ -196,9 +196,9 @@ vcpu_ut::test_vcpu_run_without_init()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->run();
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
 }
 
 void
@@ -208,9 +208,9 @@ vcpu_ut::test_vcpu_run_with_init()
 
     vc->init();
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->run();
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
 }
 
 void
@@ -218,9 +218,9 @@ vcpu_ut::test_vcpu_hlt_null_attr()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->hlt(nullptr);
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
 }
 
 void
@@ -229,9 +229,9 @@ vcpu_ut::test_vcpu_hlt_valid_attr()
     int i = 0;
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->hlt(&i);
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
 }
 
 void
@@ -239,9 +239,9 @@ vcpu_ut::test_vcpu_hlt_without_run()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
     vc->hlt();
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
 }
 
 void
@@ -251,9 +251,9 @@ vcpu_ut::test_vcpu_hlt_with_run()
 
     vc->run();
 
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
     vc->hlt();
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
 }
 
 void
@@ -261,7 +261,7 @@ vcpu_ut::test_vcpu_id()
 {
     auto vc = std::make_unique<vcpu>(1);
 
-    EXPECT_TRUE(vc->id() == 1);
+    this->expect_true(vc->id() == 1);
 }
 
 void
@@ -269,7 +269,7 @@ vcpu_ut::test_vcpu_is_bootstrap_vcpu()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_TRUE(vc->is_bootstrap_vcpu());
+    this->expect_true(vc->is_bootstrap_vcpu());
 }
 
 void
@@ -277,7 +277,7 @@ vcpu_ut::test_vcpu_is_not_bootstrap_vcpu()
 {
     auto vc = std::make_unique<vcpu>(1);
 
-    EXPECT_FALSE(vc->is_bootstrap_vcpu());
+    this->expect_false(vc->is_bootstrap_vcpu());
 }
 
 void
@@ -285,7 +285,7 @@ vcpu_ut::test_vcpu_is_host_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(1);
 
-    EXPECT_TRUE(vc->is_host_vm_vcpu());
+    this->expect_true(vc->is_host_vm_vcpu());
 }
 
 void
@@ -293,7 +293,7 @@ vcpu_ut::test_vcpu_is_not_host_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(0x0000000100000000);
 
-    EXPECT_FALSE(vc->is_host_vm_vcpu());
+    this->expect_false(vc->is_host_vm_vcpu());
 }
 
 void
@@ -301,7 +301,7 @@ vcpu_ut::test_vcpu_is_guest_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(0x0000000100000000);
 
-    EXPECT_TRUE(vc->is_guest_vm_vcpu());
+    this->expect_true(vc->is_guest_vm_vcpu());
 }
 
 void
@@ -309,7 +309,7 @@ vcpu_ut::test_vcpu_is_not_guest_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(1);
 
-    EXPECT_FALSE(vc->is_guest_vm_vcpu());
+    this->expect_false(vc->is_guest_vm_vcpu());
 }
 
 void
@@ -318,7 +318,7 @@ vcpu_ut::test_vcpu_is_running_vm_vcpu()
     auto vc = std::make_unique<vcpu>(0);
 
     vc->run();
-    EXPECT_TRUE(vc->is_running());
+    this->expect_true(vc->is_running());
 }
 
 void
@@ -326,7 +326,7 @@ vcpu_ut::test_vcpu_is_not_running_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_running());
+    this->expect_false(vc->is_running());
 }
 
 void
@@ -335,7 +335,7 @@ vcpu_ut::test_vcpu_is_initialized_vm_vcpu()
     auto vc = std::make_unique<vcpu>(0);
 
     vc->init();
-    EXPECT_TRUE(vc->is_initialized());
+    this->expect_true(vc->is_initialized());
 }
 
 void
@@ -343,5 +343,5 @@ vcpu_ut::test_vcpu_is_not_initialized_vm_vcpu()
 {
     auto vc = std::make_unique<vcpu>(0);
 
-    EXPECT_FALSE(vc->is_initialized());
+    this->expect_false(vc->is_initialized());
 }

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -113,7 +113,7 @@ setup_pt(MockRepository &mocks)
 void
 vcpu_ut::test_vcpu_intel_x64_invalid_id()
 {
-    EXPECT_EXCEPTION(std::make_unique<vcpu_intel_x64>(vcpuid::reserved), std::invalid_argument);
+    this->expect_exception([&] { std::make_unique<vcpu_intel_x64>(vcpuid::reserved); }, ""_ut_iae);
 }
 
 void
@@ -129,7 +129,7 @@ vcpu_ut::test_vcpu_intel_x64_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs));
+        this->expect_no_exception([&] { std::make_shared<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs); });
     });
 }
 
@@ -221,7 +221,7 @@ vcpu_ut::test_vcpu_intel_x64_init_vmcs_throws()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
-        EXPECT_EXCEPTION(vc->init(), std::logic_error);
+        this->expect_exception([&] { vc->init(); }, ""_ut_lee);
     });
 }
 
@@ -443,7 +443,7 @@ vcpu_ut::test_vcpu_intel_x64_run_no_init()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
-        EXPECT_EXCEPTION(vc->run(), std::runtime_error);
+        this->expect_exception([&] { vc->run(); }, ""_ut_ree);
     });
 }
 
@@ -476,7 +476,7 @@ vcpu_ut::test_vcpu_intel_x64_run_vmxon_throws()
     {
         auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
-        EXPECT_EXCEPTION(vc->run(), std::runtime_error);
+        this->expect_exception([&] { vc->run(); }, ""_ut_ree);
     });
 }
 
@@ -509,7 +509,7 @@ vcpu_ut::test_vcpu_intel_x64_run_vmcs_throws()
     {
         auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
-        EXPECT_EXCEPTION(vc->run(), std::runtime_error);
+        this->expect_exception([&] { vc->run(); }, ""_ut_ree);
     });
 }
 
@@ -676,6 +676,6 @@ vcpu_ut::test_vcpu_intel_x64_hlt_vmxon_throws()
         auto vc = std::make_unique<vcpu_intel_x64>(0, dr, on, cs, eh, vs, gs);
         vc->init();
         vc->run();
-        EXPECT_EXCEPTION(vc->hlt(), std::runtime_error);
+        this->expect_exception([&] { vc->hlt(); }, ""_ut_ree);
     });
 }

--- a/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_manager.cpp
@@ -37,7 +37,7 @@ vcpu_ut::test_vcpu_manager_create_valid()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(g_vcm->create_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->create_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -55,8 +55,8 @@ vcpu_ut::test_vcpu_manager_create_valid_twice_overwrites()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(g_vcm->create_vcpu(0));
-        EXPECT_NO_EXCEPTION(g_vcm->create_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->create_vcpu(0); });
+        this->expect_no_exception([&] { g_vcm->create_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -66,14 +66,14 @@ vcpu_ut::test_vcpu_manager_create_valid_twice_overwrites()
 void
 vcpu_ut::test_vcpu_manager_create_make_vcpu_returns_null()
 {
-    EXPECT_EXCEPTION(g_vcm->create_vcpu(0), std::runtime_error);
+    this->expect_exception([&] { g_vcm->create_vcpu(0); }, ""_ut_ree);
 }
 
 void
 vcpu_ut::test_vcpu_manager_create_make_vcpu_throws()
 {
     make_vcpu_throws = true;
-    EXPECT_EXCEPTION(g_vcm->create_vcpu(0), std::runtime_error);
+    this->expect_exception([&] { g_vcm->create_vcpu(0); }, ""_ut_ree);
     make_vcpu_throws = false;
 }
 
@@ -88,7 +88,7 @@ vcpu_ut::test_vcpu_manager_create_init_throws()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_EXCEPTION(g_vcm->create_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->create_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -107,7 +107,7 @@ vcpu_ut::test_vcpu_manager_delete_valid()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->delete_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->delete_vcpu(0); });
     });
 
     g_vcpu = nullptr;
@@ -125,8 +125,8 @@ vcpu_ut::test_vcpu_manager_delete_valid_twice()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->delete_vcpu(0));
-        EXPECT_NO_EXCEPTION(g_vcm->delete_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->delete_vcpu(0); });
+        this->expect_no_exception([&] { g_vcm->delete_vcpu(0); });
     });
 
     g_vcpu = nullptr;
@@ -143,7 +143,7 @@ vcpu_ut::test_vcpu_manager_delete_no_create()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(g_vcm->delete_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->delete_vcpu(0); });
     });
 
     g_vcpu = nullptr;
@@ -161,7 +161,7 @@ vcpu_ut::test_vcpu_manager_delete_fini_throws()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_EXCEPTION(g_vcm->delete_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->delete_vcpu(0); }, ""_ut_ree);
     });
 
     g_vcpu = nullptr;
@@ -183,7 +183,7 @@ vcpu_ut::test_vcpu_manager_run_valid()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->run_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->run_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -206,8 +206,8 @@ vcpu_ut::test_vcpu_manager_run_valid_twice()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->run_vcpu(0));
-        EXPECT_NO_EXCEPTION(g_vcm->run_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->run_vcpu(0); });
+        this->expect_no_exception([&] { g_vcm->run_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -230,7 +230,7 @@ vcpu_ut::test_vcpu_manager_run_run_throws()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_EXCEPTION(g_vcm->run_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->run_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -253,7 +253,7 @@ vcpu_ut::test_vcpu_manager_run_hlt_throws()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_EXCEPTION(g_vcm->run_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->run_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -276,7 +276,7 @@ vcpu_ut::test_vcpu_manager_run_is_guest_vm_vcpu_throws()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_EXCEPTION(g_vcm->run_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->run_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -298,7 +298,7 @@ vcpu_ut::test_vcpu_manager_run_no_create()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_EXCEPTION(g_vcm->run_vcpu(0), std::invalid_argument);
+        this->expect_exception([&] { g_vcm->run_vcpu(0); }, ""_ut_iae);
     });
 
     g_vcpu = nullptr;
@@ -320,7 +320,7 @@ vcpu_ut::test_vcpu_manager_run_is_running()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_EXCEPTION(g_vcm->run_vcpu(0), std::logic_error);
+        this->expect_exception([&] { g_vcm->run_vcpu(0); }, ""_ut_lee);
         g_vcm->delete_vcpu(0);
     });
 
@@ -343,7 +343,7 @@ vcpu_ut::test_vcpu_manager_run_is_guest_vm()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         g_vcm->create_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->run_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->run_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -370,7 +370,7 @@ vcpu_ut::test_vcpu_manager_hlt_valid()
 
         mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -397,8 +397,8 @@ vcpu_ut::test_vcpu_manager_hlt_valid_twice()
 
         mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -425,7 +425,7 @@ vcpu_ut::test_vcpu_manager_hlt_hlt_throws()
 
         mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
-        EXPECT_EXCEPTION(g_vcm->hlt_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->hlt_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -453,7 +453,7 @@ vcpu_ut::test_vcpu_manager_hlt_is_guest_vm_vcpu_throws()
         mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
         mocks.OnCall(g_vcpu, vcpu::is_guest_vm_vcpu).Throw(std::runtime_error("error"));
 
-        EXPECT_EXCEPTION(g_vcm->hlt_vcpu(0), std::runtime_error);
+        this->expect_exception([&] { g_vcm->hlt_vcpu(0); }, ""_ut_ree);
         g_vcm->delete_vcpu(0);
     });
 
@@ -475,7 +475,7 @@ vcpu_ut::test_vcpu_manager_hlt_no_create()
 
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
     });
 
     g_vcpu = nullptr;
@@ -498,7 +498,7 @@ vcpu_ut::test_vcpu_manager_hlt_is_running()
     {
         g_vcm->create_vcpu(0);
         g_vcm->run_vcpu(0);
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 
@@ -525,7 +525,7 @@ vcpu_ut::test_vcpu_manager_hlt_is_guest_vm()
 
         mocks.OnCall(g_vcpu, vcpu::is_running).Return(true);
 
-        EXPECT_NO_EXCEPTION(g_vcm->hlt_vcpu(0));
+        this->expect_no_exception([&] { g_vcm->hlt_vcpu(0); });
         g_vcm->delete_vcpu(0);
     });
 

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -108,12 +108,14 @@ protected:
                             const std::vector<struct control_flow_path> &cfg,
                             R(vmcs_intel_x64::*mf)(Args...), Args &&... args)
     {
-        for (const auto &path : cfg)
+        for (int i = 0; static_cast<size_t>(i) < cfg.size(); i++)
         {
             MockRepository mocks;
             auto mm = mocks.Mock<memory_manager_x64>();
 
             setup_mock(mocks, mm);
+
+            auto path = cfg[static_cast<size_t>(i)];
             path.setup();
 
             RUN_UNITTEST_WITH_MOCKS(mocks, [&]
@@ -122,9 +124,9 @@ protected:
                 auto func = std::bind(std::forward<decltype(mf)>(mf), &vmcs, std::forward<Args>(args)...);
 
                 if (path.throws_exception)
-                    this->expect_exception_with_args(std::forward<decltype(func)>(func), path.exception, fut, line);
+                    this->expect_exception_with_args(func, path.exception, fut, line, i);
                 else
-                    this->expect_no_exception_with_args(std::forward<decltype(func)>(func), fut, line);
+                    this->expect_no_exception_with_args(func, fut, line, i);
             });
         }
     }

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_controls.cpp
@@ -160,8 +160,7 @@ vmcs_ut::test_check_control_ctls_reserved_properly_set()
     RUN_UNITTEST_WITH_MOCKS(mocks, [&]
     {
         vmcs_intel_x64 vmcs{};
-
-        EXPECT_NO_EXCEPTION(vmcs.check_control_ctls_reserved_properly_set(msr_addr, ctls, name));
+        this->expect_no_exception([&]{ vmcs.check_control_ctls_reserved_properly_set(msr_addr, ctls, name); });
     });
 }
 
@@ -174,11 +173,11 @@ setup_check_control_pin_based_ctls_reserved_properly_set_paths(std::vector<struc
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_pinbased_ctls::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid pin_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::pin_based_vm_execution_controls::set(1UL); };
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid pin_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -191,11 +190,11 @@ setup_check_control_proc_based_ctls_reserved_properly_set_paths(std::vector<stru
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid primary_processor_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::primary_processor_based_vm_execution_controls::set(1UL); };
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid primary_processor_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -204,7 +203,7 @@ setup_check_control_proc_based_ctls2_reserved_properly_set_paths(std::vector<str
 {
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = ~(msrs::ia32_vmx_true_procbased_ctls::activate_secondary_controls::mask << 32); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("secondary controls field doesn't exist"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -217,7 +216,7 @@ setup_check_control_proc_based_ctls2_reserved_properly_set_paths(std::vector<str
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_procbased_ctls2::addr] |= 1; vmcs::secondary_processor_based_vm_execution_controls::set(0UL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid secondary_processor_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -236,7 +235,7 @@ setup_check_control_proc_based_ctls2_reserved_properly_set_paths(std::vector<str
 
     path.setup = [&] { vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::enable(); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid secondary_processor_based_vm_execution_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -249,7 +248,7 @@ setup_check_control_cr3_count_less_than_4_paths(std::vector<struct control_flow_
 
     path.setup = [&] { vmcs::cr3_target_count::set(5UL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("cr3 target count > 4"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -262,22 +261,22 @@ setup_check_control_io_bitmap_address_bits_paths(std::vector<struct control_flow
 
     path.setup = [&] { enable_proc_ctl(vmcs::primary_processor_based_vm_execution_controls::use_io_bitmaps::mask); vmcs::address_of_io_bitmap_a::set(0x1U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("io bitmap a addr not page aligned"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_io_bitmap_a::set(0xff00000000000000U); vmcs::address_of_io_bitmap_b::set(0x1U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("io bitmap b addr not page aligned"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_io_bitmap_b::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("io bitmap a addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_io_bitmap_a::set(0x1000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("io bitmap b addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_io_bitmap_b::set(0x1000U); };
@@ -303,12 +302,12 @@ setup_check_control_msr_bitmap_address_bits_paths(std::vector<struct control_flo
         vmcs::address_of_msr_bitmaps::set(0x1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("msr bitmap addr not page aligned"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_msr_bitmaps::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("msr bitmap addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::address_of_msr_bitmaps::set(0x1000U); };
@@ -328,17 +327,17 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         vmcs::virtual_apic_address::set(0U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual apic physical addr is NULL"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::virtual_apic_address::set(1U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual apic addr not 4k aligned"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::virtual_apic_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual apic addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -347,7 +346,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("tpr_shadow is enabled, but virtual interrupt delivery is enabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -357,7 +356,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         vmcs::tpr_threshold::set(0xffffffffffffffffUL);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 31:4 of the tpr threshold must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -366,7 +365,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("tpr_shadow is enabled, but virtual apic is enabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -375,7 +374,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         g_phys_to_virt_return_nullptr = true;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual apic virtual addr is NULL"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_phys_to_virt_return_nullptr = false; };
@@ -384,7 +383,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
 
     path.setup = [&] { vmcs::tpr_threshold::set(0xfUL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid TPR threshold"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     // control paths when tpr shadow is disabled
@@ -402,7 +401,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtualize_x2apic_mode::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtualize_x2apic_mode must be disabled if tpr shadow is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -411,7 +410,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::apic_register_virtualization::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("apic_register_virtualization must be disabled if tpr shadow is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -420,7 +419,7 @@ setup_check_control_tpr_shadow_and_virtual_apic_paths(std::vector<struct control
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual interrupt delivery must be disabled if tpr shadow is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::mask); };
@@ -441,7 +440,7 @@ setup_check_control_nmi_exiting_and_virtual_nmi_paths(std::vector<struct control
         enable_pin_ctl(vmcs::pin_based_vm_execution_controls::virtual_nmis::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual NMI must be 0 if NMI exiting is 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_pin_ctl(vmcs::pin_based_vm_execution_controls::virtual_nmis::mask); };
@@ -462,7 +461,7 @@ setup_check_control_virtual_nmi_and_nmi_window_paths(std::vector<struct control_
         enable_proc_ctl(vmcs::primary_processor_based_vm_execution_controls::nmi_window_exiting::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("NMI window exiting must be 0 if virtual NMI is 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_proc_ctl(vmcs::primary_processor_based_vm_execution_controls::nmi_window_exiting::mask); };
@@ -493,17 +492,17 @@ setup_check_control_virtual_apic_address_bits_paths(std::vector<struct control_f
         vmcs::apic_access_address::set(0U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("apic access physical addr is NULL"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::apic_access_address::set(1U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("apic access addr not 4k aligned"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::apic_access_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("apic access addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::apic_access_address::set(0x1000U); };
@@ -532,7 +531,7 @@ setup_check_control_x2apic_mode_and_virtual_apic_access_paths(std::vector<struct
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("apic accesses must be 0 if x2 apic mode is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtualize_x2apic_mode::mask); };
@@ -561,7 +560,7 @@ setup_check_control_virtual_interrupt_and_external_interrupt_paths(std::vector<s
         disable_pin_ctl(vmcs::pin_based_vm_execution_controls::external_interrupt_exiting::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("external interrupt exiting must be 1 if virtual interrupt delivery is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { enable_pin_ctl(vmcs::pin_based_vm_execution_controls::external_interrupt_exiting::mask); };
@@ -586,7 +585,7 @@ setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct con
         disable_proc_ctl(vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual interrupt delivery must be 1 if posted interrupts is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -595,7 +594,7 @@ setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct con
         disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("virtual interrupt delivery must be 1 if posted interrupts is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -604,7 +603,7 @@ setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct con
         disable_exit_ctl(vmcs::vm_exit_controls::acknowledge_interrupt_on_exit::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("ack interrupt on exit must be 1 if posted interrupts is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -613,7 +612,7 @@ setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct con
         g_vmcs_fields[vmcs::posted_interrupt_notification_vector::addr] = 0x100;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 15:8 of the notification vector must be 0 if posted interrupts is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -622,12 +621,12 @@ setup_check_control_process_posted_interrupt_checks_paths(std::vector<struct con
         vmcs::posted_interrupt_descriptor_address::set(1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 5:0 of the interrupt descriptor addr must be 0 if posted interrupts is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::posted_interrupt_descriptor_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt descriptor addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::posted_interrupt_descriptor_address::set(0x1000U); };
@@ -656,7 +655,7 @@ setup_check_control_vpid_checks_paths(std::vector<struct control_flow_path> &cfg
         g_vmcs_fields[vmcs::virtual_processor_identifier::addr] = 0;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("vpid cannot equal 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::virtual_processor_identifier::addr] = 1; };
@@ -693,17 +692,17 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
         msrs::ia32_vmx_ept_vpid_cap::memory_type_write_back_supported::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("hardware does not support ept memory type: uncachable"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::ept_pointer::memory_type::set(vmcs::ept_pointer::memory_type::write_back); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("hardware does not support ept memory type: write-back"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::ept_pointer::memory_type::set(3U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("unknown eptp memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -713,7 +712,7 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
         vmcs::ept_pointer::page_walk_length_minus_one::set(0U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("the ept walk-through length must be 1 less than 4, i.e. 3"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -722,7 +721,7 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
         vmcs::ept_pointer::accessed_and_dirty_flags::enable();
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("hardware does not support dirty / accessed flags for ept"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -731,7 +730,7 @@ setup_check_control_enable_ept_checks_paths(std::vector<struct control_flow_path
         vmcs::ept_pointer::reserved::set(0xFF0U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:7 and 63:48 of the eptp must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -756,7 +755,7 @@ setup_check_control_enable_pml_checks_paths(std::vector<struct control_flow_path
         disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::enable_ept::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("ept must be enabled if pml is enabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -765,12 +764,12 @@ setup_check_control_enable_pml_checks_paths(std::vector<struct control_flow_path
         vmcs::pml_address::set(0xff00000000000000U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pml address must be a valid physical address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::pml_address::set(1U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:0 of the pml address must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::pml_address::set(0x1000U); };
@@ -799,7 +798,7 @@ setup_check_control_unrestricted_guests_paths(std::vector<struct control_flow_pa
         disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::enable_ept::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("enable ept must be 1 if unrestricted guest is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::enable_ept::mask); };
@@ -837,7 +836,7 @@ setup_check_control_enable_vm_functions_paths(std::vector<struct control_flow_pa
         g_msrs[msrs::ia32_vmx_vmfunc::addr] = 0;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("unsupported vm function control bit set"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_function_controls::set(0U); };
@@ -853,7 +852,7 @@ setup_check_control_enable_vm_functions_paths(std::vector<struct control_flow_pa
         disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::enable_ept::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("enable ept must be 1 if eptp switching is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -862,12 +861,12 @@ setup_check_control_enable_vm_functions_paths(std::vector<struct control_flow_pa
         vmcs::eptp_list_address::set_if_exists(1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:0 must be 0 for eptp list address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::eptp_list_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("eptp list address addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::eptp_list_address::set(0x1000U); };
@@ -896,7 +895,7 @@ setup_check_control_enable_vmcs_shadowing_paths(std::vector<struct control_flow_
         vmcs::vmread_bitmap_address::set(1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:0 must be 0 for the vmcs read bitmap address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -905,17 +904,17 @@ setup_check_control_enable_vmcs_shadowing_paths(std::vector<struct control_flow_
         vmcs::vmwrite_bitmap_address::set(1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:0 must be 0 for the vmcs write bitmap address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vmwrite_bitmap_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("vmcs read bitmap address addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vmread_bitmap_address::set(0x1000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("vmcs write bitmap address addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vmwrite_bitmap_address::set(0x1000U); };
@@ -944,12 +943,12 @@ setup_check_control_enable_ept_violation_checks_paths(std::vector<struct control
         vmcs::virtualization_exception_information_address::set(1U);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 11:0 must be 0 for the vmcs virt except info address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::virtualization_exception_information_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("vmcs virt except info address addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::virtualization_exception_information_address::set(0x1000U); };
@@ -966,7 +965,7 @@ setup_check_control_vm_exit_ctls_reserved_properly_set_paths(std::vector<struct 
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid vm_exit_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_exit_ctls::addr] = 0xffffffff00000000UL; };
@@ -987,7 +986,7 @@ setup_check_control_activate_and_save_preemption_timer_must_be_0_paths(std::vect
         enable_exit_ctl(vmcs::vm_exit_controls::save_vmx_preemption_timer_value::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("save vmx preemption timer must be 0 if activate vmx preemption timer is 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::save_vmx_preemption_timer_value::mask); };
@@ -1004,17 +1003,17 @@ setup_check_control_exit_msr_store_address_paths(std::vector<struct control_flow
 
     path.setup = [&] { vmcs::vm_exit_msr_store_count::set(16UL); vmcs::vm_exit_msr_store_address::set(0xfU); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 3:0 must be 0 for the exit msr store address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_store_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("exit msr store addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_store_address::set(0xfffffff0U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("end of exit msr store area too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_store_address::set(0x10U); };
@@ -1031,17 +1030,17 @@ setup_check_control_exit_msr_load_address_paths(std::vector<struct control_flow_
 
     path.setup = [&] { vmcs::vm_exit_msr_load_count::set(16UL); vmcs::vm_exit_msr_load_address::set(0xfU); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 3:0 must be 0 for the exit msr load address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_load_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("exit msr load addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_load_address::set(0xfffffff0U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("end of exit msr load area too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_exit_msr_load_address::set(0x10U); };
@@ -1058,7 +1057,7 @@ setup_check_control_vm_entry_ctls_reserved_properly_set_paths(std::vector<struct
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid vm_entry_controls"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_true_entry_ctls::addr] = 0xffffffff00000000; };
@@ -1077,7 +1076,7 @@ setup_check_control_event_injection_type_vector_checks_paths(std::vector<struct 
 
     path.setup = [&] { valid_bit::enable(); interruption_type::set(interruption_type::reserved); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field type of 1 is reserved"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -1086,17 +1085,17 @@ setup_check_control_event_injection_type_vector_checks_paths(std::vector<struct 
         g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = 0;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field type of 7 is reserved on this hardware"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { interruption_type::set(interruption_type::non_maskable_interrupt); vector::set(0xFFUL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field vector must be 2 if the type field is 2 (NMI)"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { interruption_type::set(interruption_type::hardware_exception); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field vector must be 0->31 if the type field is 3 (HE)"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&]
@@ -1105,7 +1104,7 @@ setup_check_control_event_injection_type_vector_checks_paths(std::vector<struct 
         g_msrs[msrs::ia32_vmx_true_procbased_ctls::addr] = msrs::ia32_vmx_true_procbased_ctls::monitor_trap_flag::mask << 32;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field vector must be 0 if the type field is 7 (other)"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vector::set(0UL); };
@@ -1130,19 +1129,17 @@ setup_check_control_event_injection_delivery_ec_checks_paths(std::vector<struct 
         enable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::unrestricted_guest::mask);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("unrestricted guest must be 0 or PE must be enabled in cr0"
-                     "if deliver error code bit is set"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_proc_ctl2(vmcs::secondary_processor_based_vm_execution_controls::unrestricted_guest::mask); interruption_type::set(interruption_type::non_maskable_interrupt); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("interrupt information field type must be 3 if deliver error code bit is set"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { interruption_type::set(interruption_type::hardware_exception); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("vector must indicate exception that would normally deliver"
-                     "an error code if deliver error code bit is set"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vector::set(0x8UL); };
@@ -1151,7 +1148,7 @@ setup_check_control_event_injection_delivery_ec_checks_paths(std::vector<struct 
 
     path.setup = [&] { deliver_error_code_bit::disable(); };
     path.throws_exception = true;
-    path.exception = std::make_shared<std::logic_error>("deliver_error_code_bit must be 1");
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -1170,7 +1167,7 @@ setup_check_control_event_injection_reserved_bits_checks_paths(std::vector<struc
 
     path.setup = [&] { reserved::set(1UL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("reserved bits of the interrupt info field must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -1189,8 +1186,7 @@ setup_check_control_event_injection_ec_checks_paths(std::vector<struct control_f
 
     path.setup = [&] { deliver_error_code_bit::enable(); vmcs::vm_entry_exception_error_code::set(0x8000UL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 31:15 of the exception error code field must be 0"
-                     " if deliver error code bit is set in the interrupt info field"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_exception_error_code::set(0UL); };
@@ -1222,12 +1218,12 @@ setup_check_control_event_injection_instr_length_checks_paths(std::vector<struct
         g_msrs[msrs::ia32_vmx_misc::addr] = 0;
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("instruction length must be greater than zero"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_instruction_length::set(16UL); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("instruction length must be in the range of 0-15 if type is 4, 5, 6"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_instruction_length::set(1UL); };
@@ -1244,17 +1240,17 @@ setup_check_control_entry_msr_load_address_paths(std::vector<struct control_flow
 
     path.setup = [&] { vmcs::vm_entry_msr_load_count::set(16UL); vmcs::vm_entry_msr_load_address::set(0xfU); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("bits 3:0 must be 0 for the entry msr load address"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_msr_load_address::set(0xff00000000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("entry msr load addr too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_msr_load_address::set(0xfffffff0U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("end of entry msr load area too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::vm_entry_msr_load_address::set(0x10U); };

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_host.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_check_host.cpp
@@ -125,7 +125,7 @@ setup_check_host_cr0_for_unsupported_bits_paths(std::vector<struct control_flow_
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_cr0_fixed0::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid cr0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -138,7 +138,7 @@ setup_check_host_cr4_for_unsupported_bits_paths(std::vector<struct control_flow_
 
     path.setup = [&] { g_msrs[msrs::ia32_vmx_cr4_fixed0::addr] = 1; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("invalid cr4"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -147,7 +147,7 @@ setup_check_host_cr3_for_unsupported_bits_paths(std::vector<struct control_flow_
 {
     path.setup = [&] { g_vmcs_fields[vmcs::host_cr3::addr] = 0xff00000000000000; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host cr3 too large"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cr3::addr] = 0x1000; };
@@ -164,7 +164,7 @@ setup_check_host_ia32_sysenter_esp_canonical_address_paths(std::vector<struct co
 
     path.setup = [&] { vmcs::host_ia32_sysenter_esp::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host sysenter esp must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -177,7 +177,7 @@ setup_check_host_ia32_sysenter_eip_canonical_address_paths(std::vector<struct co
 
     path.setup = [&] {  vmcs::host_ia32_sysenter_eip::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host sysenter eip must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -198,7 +198,7 @@ setup_check_host_verify_load_ia32_perf_global_ctrl_paths(std::vector<struct cont
         vmcs::host_ia32_perf_global_ctrl::set(0xcU);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("perf global ctrl msr reserved bits must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_perf_global_ctrl::set(0x0U); };
@@ -223,42 +223,42 @@ setup_check_host_verify_load_ia32_pat_paths(std::vector<struct control_flow_path
         vmcs::host_ia32_pat::set(2ULL);
     };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat0 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 8); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat1 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 16); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat2 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 24); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat3 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 32); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat4 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 40); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat5 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 48); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat6 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(2ULL << 56); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("pat7 has an invalid memory type"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_ia32_pat::set(0U); };
@@ -279,17 +279,17 @@ setup_check_host_verify_load_ia32_efer_paths(std::vector<struct control_flow_pat
 
     path.setup = [&] { enable_exit_ctl(vmcs::vm_exit_controls::load_ia32_efer::mask); g_vmcs_fields[vmcs::host_ia32_efer::addr] = 0xe; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("ia32 efer msr reserved buts must be 0 if load ia32 efer entry is enabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); g_vmcs_fields[vmcs::host_ia32_efer::addr] = msrs::ia32_efer::lma::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host addr space is 0, but efer.lma is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { enable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); g_vmcs_fields[vmcs::host_ia32_efer::addr] = 0; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host addr space is 1, but efer.lma is 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ia32_efer::addr] = msrs::ia32_efer::lma::mask; g_vmcs_fields[vmcs::host_cr0::addr] = 0; };
@@ -298,12 +298,12 @@ setup_check_host_verify_load_ia32_efer_paths(std::vector<struct control_flow_pat
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cr0::addr] = cr0::paging::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("efer.lme is 0, but efer.lma is 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); g_vmcs_fields[vmcs::host_ia32_efer::addr] = msrs::ia32_efer::lme::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("efer.lme is 1, but efer.lma is 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ia32_efer::addr] = 0; };
@@ -321,12 +321,12 @@ setup_check_host_es_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_es_selector::addr] = segment_register::es::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host es ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_es_selector::addr] = segment_register::es::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host es rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -339,12 +339,12 @@ setup_check_host_cs_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cs_selector::addr] = segment_register::cs::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host cs ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cs_selector::addr] = segment_register::cs::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host cs rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -357,12 +357,12 @@ setup_check_host_ss_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ss_selector::addr] = segment_register::ss::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host ss ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ss_selector::addr] = segment_register::ss::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host ss rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -375,12 +375,12 @@ setup_check_host_ds_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ds_selector::addr] = segment_register::ds::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host ds ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ds_selector::addr] = segment_register::ds::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host ds rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -393,12 +393,12 @@ setup_check_host_fs_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_fs_selector::addr] = segment_register::fs::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host fs ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_fs_selector::addr] = segment_register::fs::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host fs rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -411,12 +411,12 @@ setup_check_host_gs_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_gs_selector::addr] = segment_register::gs::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host gs ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_gs_selector::addr] = segment_register::gs::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host gs rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -429,12 +429,12 @@ setup_check_host_tr_selector_rpl_ti_equal_zero_paths(std::vector<struct control_
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_tr_selector::addr] = segment_register::tr::ti::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host tr ti flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_tr_selector::addr] = segment_register::tr::rpl::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host tr rpl flag must be 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -447,7 +447,7 @@ setup_check_host_cs_not_equal_zero_paths(std::vector<struct control_flow_path> &
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cs_selector::addr] = 0; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host cs cannot equal 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -460,7 +460,7 @@ setup_check_host_tr_not_equal_zero_paths(std::vector<struct control_flow_path> &
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_tr_selector::addr] = 0; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host tr cannot equal 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -473,7 +473,7 @@ setup_check_host_ss_not_equal_zero_paths(std::vector<struct control_flow_path> &
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); g_vmcs_fields[vmcs::host_ss_selector::addr] = 0; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host ss cannot equal 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_ss_selector::addr] = 1; };
@@ -490,7 +490,7 @@ setup_check_host_fs_canonical_base_address_paths(std::vector<struct control_flow
 
     path.setup = [&] { vmcs::host_fs_base::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host fs base must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -503,7 +503,7 @@ setup_check_host_gs_canonical_base_address_paths(std::vector<struct control_flow
 
     path.setup = [&] {  vmcs::host_gs_base::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host gs base must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -516,7 +516,7 @@ setup_check_host_gdtr_canonical_base_address_paths(std::vector<struct control_fl
 
     path.setup = [&] { vmcs::host_gdtr_base::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host gdtr base must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -529,7 +529,7 @@ setup_check_host_idtr_canonical_base_address_paths(std::vector<struct control_fl
 
     path.setup = [&] { vmcs::host_idtr_base::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host idtr base must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -542,7 +542,7 @@ setup_check_host_tr_canonical_base_address_paths(std::vector<struct control_flow
 
     path.setup = [&] { vmcs::host_tr_base::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host tr base must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 }
 
@@ -555,12 +555,12 @@ setup_check_host_if_outside_ia32e_mode_paths(std::vector<struct control_flow_pat
 
     path.setup = [&] { g_msrs[msrs::ia32_efer::addr] = 0; enable_entry_ctl(vmcs::vm_entry_controls::ia_32e_mode_guest::mask); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("ia 32e mode must be 0 if efer.lma == 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_entry_ctl(vmcs::vm_entry_controls::ia_32e_mode_guest::mask); enable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host addr space must be 0 if efer.lma == 0"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); };
@@ -577,7 +577,7 @@ setup_check_host_vmcs_host_address_space_size_is_set_paths(std::vector<struct co
 
     path.setup = [&] { g_msrs[msrs::ia32_efer::addr] = msrs::ia32_efer::lma::mask; disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host addr space must be 1 if efer.lma == 1"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { enable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); };
@@ -594,17 +594,17 @@ setup_check_host_host_address_space_disabled_paths(std::vector<struct control_fl
 
     path.setup = [&] { disable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); enable_entry_ctl(vmcs::vm_entry_controls::ia_32e_mode_guest::mask); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("ia 32e mode must be disabled if host addr space is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { disable_entry_ctl(vmcs::vm_entry_controls::ia_32e_mode_guest::mask); g_vmcs_fields[vmcs::host_cr4::addr] = cr4::pcid_enable_bit::mask; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("cr4 pcide must be disabled if host addr space is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cr4::addr] = 0; vmcs::host_rip::set(0xf000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("rip bits 63:32 must be 0 if host addr space is disabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_rip::set(0U); };
@@ -621,12 +621,12 @@ setup_check_host_host_address_space_enabled_paths(std::vector<struct control_flo
 
     path.setup = [&] { enable_exit_ctl(vmcs::vm_exit_controls::host_address_space_size::mask); g_vmcs_fields[vmcs::host_cr4::addr] = 0; };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("cr4 pae must be enabled if host addr space is enabled"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { g_vmcs_fields[vmcs::host_cr4::addr] = cr4::physical_address_extensions::mask; vmcs::host_rip::set(0x800000000000U); };
     path.throws_exception = true;
-    path.exception = std::shared_ptr<std::exception>(new std::logic_error("host rip must be canonical"));
+    path.exception = ""_ut_lee;
     cfg.push_back(path);
 
     path.setup = [&] { vmcs::host_rip::set(0U); };

--- a/include/mainpage.h
+++ b/include/mainpage.h
@@ -236,10 +236,10 @@
 ///
 /// @ref unittest <br>
 /// @ref bfn::mock_shared <br>
-/// @ref EXPECT_TRUE <br>
-/// @ref EXPECT_FALSE <br>
-/// @ref EXPECT_EXCEPTION <br>
-/// @ref EXPECT_NO_EXCEPTION <br>
+/// @ref expect_true <br>
+/// @ref expect_false <br>
+/// @ref expect_exception <br>
+/// @ref expect_no_exception <br>
 /// @ref ASSERT_TRUE <br>
 /// @ref ASSERT_FALSE <br>
 /// @ref ASSERT_EXCEPTION <br>


### PR DESCRIPTION
This commit replaces each occurence of EXPECT_TRUE,
EXPECT_FALSE, EXPECT_EXCEPTION, and EXPECT_NO_EXCEPTION
in the Bareflank tree with their snake-case counterparts
introduced in (#209).

Also, expect_exception_with_args and expect_no_exception_with_args
now take a default path_id argument that is printed along with
__LINE__ and __FUNC__ info when a test fails within the
run_vmcs_with_args loop. The user can then easily identify which
path caused the failure by refering to the appropriate setup function.