### PR TITLE
AppVeyor Cleanup

### DIFF
--- a/Makefile.bf
+++ b/Makefile.bf
@@ -58,18 +58,21 @@ endif
 # Subdirs
 ################################################################################
 
-PARENT_SUBDIRS += bfc
-PARENT_SUBDIRS += bfcxx
-PARENT_SUBDIRS += bfcrt
-PARENT_SUBDIRS += bfunwind
-PARENT_SUBDIRS += bfdrivers
-PARENT_SUBDIRS += bfelf_loader
+ifneq ($(APPVEYOR), true)
+	PARENT_SUBDIRS += bfc
+	PARENT_SUBDIRS += bfcxx
+	PARENT_SUBDIRS += bfcrt
+	PARENT_SUBDIRS += bfunwind
+	PARENT_SUBDIRS += bfdrivers
+	PARENT_SUBDIRS += bfelf_loader
+	PARENT_SUBDIRS += bfvmm
+	PARENT_SUBDIRS += $(wildcard %HYPER_ABS%/src_*/)
+	PARENT_SUBDIRS += $(wildcard %HYPER_ABS%/hypervisor_*/)
+	PARENT_SUBDIRS += $(wildcard %BUILD_ABS%/makefiles/src_*/)
+	PARENT_SUBDIRS += $(wildcard %BUILD_ABS%/makefiles/hypervisor_*/)
+endif
+
 PARENT_SUBDIRS += bfm
-PARENT_SUBDIRS += bfvmm
-PARENT_SUBDIRS += $(wildcard %HYPER_ABS%/src_*/)
-PARENT_SUBDIRS += $(wildcard %HYPER_ABS%/hypervisor_*/)
-PARENT_SUBDIRS += $(wildcard %BUILD_ABS%/makefiles/src_*/)
-PARENT_SUBDIRS += $(wildcard %BUILD_ABS%/makefiles/hypervisor_*/)
 
 ################################################################################
 # Common
@@ -81,10 +84,13 @@ include %HYPER_ABS%/common/common_subdir.mk
 # Custom Targets
 ################################################################################
 
+.PHONY: linux_build
 .PHONY: linux_load
 .PHONY: linux_unload
+.PHONY: windows_build
 .PHONY: windows_load
 .PHONY: windows_unload
+.PHONY: driver_build
 .PHONY: driver_load
 .PHONY: driver_unload
 .PHONY: load
@@ -101,6 +107,7 @@ include %HYPER_ABS%/common/common_subdir.mk
 .PHONY: doxygen
 .PHONY: doxygen_clean
 .PHONY: test
+.PHONY: tidy
 
 ifeq ($(shell uname -s), Linux)
     SUDO:=sudo
@@ -108,20 +115,32 @@ else
     SUDO:=
 endif
 
+windows_build: force
+	@%BUILD_ABS%/build_scripts/build_driver.sh
+
 windows_load: force
 	@%BUILD_ABS%/build_scripts/build_driver.sh
+	@%BUILD_ABS%/build_scripts/load_driver.sh
 
 windows_unload: force
 	@%BUILD_ABS%/build_scripts/clean_driver.sh
 
+linux_build: force
+	@%BUILD_ABS%/build_scripts/build_driver.sh
+
 linux_load: force
 	@%BUILD_ABS%/build_scripts/build_driver.sh
+	@%BUILD_ABS%/build_scripts/load_driver.sh
 
 linux_unload: force
 	@%BUILD_ABS%/build_scripts/clean_driver.sh
 
+driver_build:
+	@%BUILD_ABS%/build_scripts/build_driver.sh
+
 driver_load:
 	@%BUILD_ABS%/build_scripts/build_driver.sh
+	@%BUILD_ABS%/build_scripts/load_driver.sh
 
 driver_unload: force
 	@%BUILD_ABS%/build_scripts/clean_driver.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,12 +7,14 @@ environment:
         CYG_MIRROR: http://cygwin.mirror.constant.com
         CYG_CACHE: C:\cygwin64\var\cache\setup
         CYG_BASH: C:\cygwin64\bin\bash
+        CYG_EWDK: C:\cygdrive\c\ewdk
 
 #
 # Cache Cygwin files to speed up build
 #
 cache:
     - '%CYG_CACHE%'
+    - '%CYG_EWDK%'
 
 #
 # Do a shallow clone of the repo to speed up build
@@ -33,11 +35,9 @@ install:
 #
 build_script:
     - 'echo Building...'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./tools/scripts/setup_cygwin.sh -d --no_ewdk --no-configure"'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./configure --compiler clang_38"'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; ./configure --compiler clang_39"'
-    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; make -j2"'
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; APPVEYOR=true ./tools/scripts/setup_cygwin.sh"'
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; APPVEYOR=true make -j2"'
+    - '%CYG_BASH% -lc "cd $APPVEYOR_BUILD_FOLDER; APPVEYOR=true make driver_build"'
 
 #
 # Only build the master branch

--- a/bfdrivers/src/arch/windows/README.md
+++ b/bfdrivers/src/arch/windows/README.md
@@ -44,7 +44,7 @@ lot of time to complete, so please be patient.
 cd ~/
 mkdir build
 cd ~/hypervisor
-./tools/scripts/setup_cygwin.sh -l -o ../build/
+./tools/scripts/setup_cygwin.sh --local-compilers --out-of-tree ../build/
 ```
 
 Once you have a cross compiler setup, you need to build the main source code.
@@ -125,7 +125,7 @@ cd ~/
 git clone https://github.com/Bareflank/hypervisor.git
 cd ~/hypervisor
 
-./tools/scripts/setup_ubuntu.sh --no-configure
+./tools/scripts/setup_cygwin.sh --local-compilers --no-configure
 
 cd ~/
 mkdir build

--- a/configure
+++ b/configure
@@ -571,6 +571,7 @@ copy_scripts() {
     copy_script "build_libcxxabi.sh"
     copy_script "build_libbfc.sh"
     copy_script "build_driver.sh"
+    copy_script "load_driver.sh"
     copy_script "clean_driver.sh"
     copy_script "fetch_newlib.sh"
     copy_script "fetch_libcxx.sh"

--- a/tools/scripts/build_driver.sh
+++ b/tools/scripts/build_driver.sh
@@ -30,10 +30,6 @@ CYGWIN_NT-6.3)
     HYPER_ABS_PATH=`cygpath -w $HYPER_ABS`
     BUILD_ABS_PATH=`cygpath -w $BUILD_ABS`
     cmd.exe /c $SCRIPT_PATH $HYPER_ABS_PATH $BUILD_ABS_PATH WindowsV6.3
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine root
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine trustedpublisher
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon remove "ROOT\bareflank"
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon install `cygpath -w $BUILD_ABS/outdir/bareflank/bareflank.inf` "ROOT\bareflank"
     ;;
 
 CYGWIN_NT-10.0)
@@ -43,18 +39,12 @@ CYGWIN_NT-10.0)
     HYPER_ABS_PATH=`cygpath -w $HYPER_ABS`
     BUILD_ABS_PATH=`cygpath -w $BUILD_ABS`
     cmd.exe /c $SCRIPT_PATH $HYPER_ABS_PATH $BUILD_ABS_PATH Windows10
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine root
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine trustedpublisher
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon remove "ROOT\bareflank"
-    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon install `cygpath -w $BUILD_ABS/outdir/bareflank/bareflank.inf` "ROOT\bareflank"
     ;;
 
 Linux)
     cd $HYPER_ABS/bfdrivers/src/arch/linux
-    sudo make unload
     make clean
     make
-    sudo make load
     ;;
 *)
     echo "OS not supported"

--- a/tools/scripts/load_driver.sh
+++ b/tools/scripts/load_driver.sh
@@ -1,0 +1,48 @@
+#!/bin/bash -e
+#
+# Bareflank Hypervisor
+#
+# Copyright (C) 2015 Assured Information Security, Inc.
+# Author: Rian Quinn        <quinnr@ainfosec.com>
+# Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+%ENV_SOURCE%
+
+case $(uname -s) in
+CYGWIN_NT-6.3)
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine root
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine trustedpublisher
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon remove "ROOT\bareflank"
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon install `cygpath -w $BUILD_ABS/outdir/bareflank/bareflank.inf` "ROOT\bareflank"
+    ;;
+
+CYGWIN_NT-10.0)
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine root
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/bin/x64/certmgr /add `cygpath -w $BUILD_ABS/outdir/bareflank.cer` /s /r localMachine trustedpublisher
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon remove "ROOT\bareflank"
+    /cygdrive/c/ewdk/Program\ Files/Windows\ Kits/10/Tools/x64/devcon install `cygpath -w $BUILD_ABS/outdir/bareflank/bareflank.inf` "ROOT\bareflank"
+    ;;
+
+Linux)
+    cd $HYPER_ABS/bfdrivers/src/arch/linux
+    sudo make unload
+    sudo make load
+    ;;
+*)
+    echo "OS not supported"
+    exit 1
+esac

--- a/tools/scripts/setup_common.sh
+++ b/tools/scripts/setup_common.sh
@@ -25,7 +25,14 @@
 # ------------------------------------------------------------------------------
 
 check_distro() {
-    case $( grep ^ID= /etc/os-release | cut -d'=' -f 2 ) in
+
+    if [[ -f /etc/os-release ]]; then
+        distro=`grep ^ID= /etc/os-release | cut -d'=' -f 2`
+    else
+        distro=`uname -o`
+    fi
+
+    case $distro in
     $1)
         ;;
     *)
@@ -57,10 +64,10 @@ option_help() {
     echo -e "Sets up the system to compile / use Bareflank"
     echo -e ""
     echo -e "       --help                       show this help menu"
-    echo -e "       --local_compilers            setup local cross compilers"
+    echo -e "       --local-compilers            setup local cross compilers"
     echo -e "       --no-configure               skip the configure step"
     echo -e "       --compiler <dirname>         directory of cross compiler"
-    echo -e "       --out_of_tree <dirname>      setup out of tree build"
+    echo -e "       --out-of-tree <dirname>      setup out of tree build"
     echo -e ""
 }
 
@@ -80,8 +87,12 @@ parse_arguments() {
             exit 0
             ;;
 
-        "--local_compilers")
+        "--local-compilers")
             local="true"
+            ;;
+
+        "--no-configure")
+            noconfigure="true"
             ;;
 
         "--compiler")
@@ -89,11 +100,7 @@ parse_arguments() {
             compiler="--compiler $1"
             ;;
 
-        "--no-configure")
-            noconfigure="true"
-            ;;
-
-        "--out_of_tree")
+        "--out-of-tree")
             shift
             build_dir=$1
             mkdir -p $build_dir


### PR DESCRIPTION
This patch fixes a lot of issues with AppVeyor. Specifically, it doesn't
attempt to compile the VMM as that is being tested by Travis CI, and is
not specific to Windows. Instead, it focuses on the Windows specific
components being the driver and BFM. This also cleans up the setup
script for cygwin

Signed-off-by: “Rian <“rianquinn@gmail.com”>