### PR TITLE
VMCS Cleanup

### DIFF
--- a/bfvmm/include/intrinsics/crs_intel_x64.h
+++ b/bfvmm/include/intrinsics/crs_intel_x64.h
@@ -40,6 +40,8 @@ namespace intel_x64
 {
 namespace cr0
 {
+    using value_type = uint64_t;
+
     inline auto get() noexcept
     { return __read_cr0(); }
 
@@ -220,6 +222,8 @@ namespace cr0
 
 namespace cr3
 {
+    using value_type = uint64_t;
+
     inline auto get() noexcept
     { return __read_cr3(); }
 
@@ -229,6 +233,8 @@ namespace cr3
 
 namespace cr4
 {
+    using value_type = uint64_t;
+
     inline auto get() noexcept
     { return __read_cr4(); }
 
@@ -533,4 +539,3 @@ namespace cr4
 // *INDENT-ON*
 
 #endif
-

--- a/bfvmm/include/intrinsics/debug_x64.h
+++ b/bfvmm/include/intrinsics/debug_x64.h
@@ -31,6 +31,8 @@ namespace x64
 {
 namespace dr7
 {
+    using value_type = uint64_t;
+
     inline auto get() noexcept
     { return __read_dr7(); }
 

--- a/bfvmm/include/intrinsics/idt_x64.h
+++ b/bfvmm/include/intrinsics/idt_x64.h
@@ -28,6 +28,8 @@
 #include <algorithm>
 #include <exception>
 
+#include <guard_exceptions.h>
+
 // -----------------------------------------------------------------------------
 // Interrupt Descriptor Table Register
 // -----------------------------------------------------------------------------
@@ -164,10 +166,13 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    idt_x64()
+    idt_x64() noexcept
     {
-        m_idt_reg.base = x64::idt::base::get();
-        m_idt_reg.limit = x64::idt::limit::get();
+        guard_exceptions([&]
+        {
+            m_idt_reg.base = x64::idt::base::get();
+            m_idt_reg.limit = x64::idt::limit::get();
+        });
     }
 
     /// Constructor
@@ -180,13 +185,14 @@ public:
     ///
     /// @param size number of entries in the IDT
     ///
-    idt_x64(size_type size) :
+    idt_x64(size_type size) noexcept :
         m_idt(size)
     {
-        expects(size != 0);
-
-        m_idt_reg.base = m_idt.data();
-        m_idt_reg.limit = gsl::narrow<size_type>((size << 3) - 1);
+        guard_exceptions([&]
+        {
+            m_idt_reg.base = m_idt.data();
+            m_idt_reg.limit = gsl::narrow_cast<size_type>((size << 3) - 1);
+        });
     }
 
     /// Destructor

--- a/bfvmm/include/intrinsics/rflags_x64.h
+++ b/bfvmm/include/intrinsics/rflags_x64.h
@@ -36,6 +36,8 @@ namespace x64
 {
 namespace rflags
 {
+    using value_type = uint64_t;
+
     inline auto get() noexcept
     { return __read_rflags(); }
 

--- a/bfvmm/include/intrinsics/srs_x64.h
+++ b/bfvmm/include/intrinsics/srs_x64.h
@@ -58,7 +58,7 @@ namespace x64
 namespace segment_register
 {
 
-using segment_register_type = uint16_t;
+using type = uint16_t;
 
 namespace es
 {
@@ -66,7 +66,7 @@ namespace es
     { return __read_es(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_es(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_es(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -75,10 +75,10 @@ namespace es
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_es(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_es(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_es(gsl::narrow_cast<segment_register_type>(set_bits(__read_es(), mask, val << from))); }
+        void set(T val) noexcept { __write_es(gsl::narrow_cast<type>(set_bits(__read_es(), mask, val << from))); }
     }
 
     namespace ti
@@ -88,10 +88,10 @@ namespace es
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_es(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_es(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_es(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_es(), from) : clear_bit(__read_es(), from))); }
+        { __write_es(gsl::narrow_cast<type>(val ? set_bit(__read_es(), from) : clear_bit(__read_es(), from))); }
     }
 
     namespace index
@@ -101,10 +101,10 @@ namespace es
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_es(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_es(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_es(gsl::narrow_cast<segment_register_type>(set_bits(__read_es(), mask, val << from))); }
+        void set(T val) noexcept { __write_es(gsl::narrow_cast<type>(set_bits(__read_es(), mask, val << from))); }
     }
 }
 
@@ -114,7 +114,7 @@ namespace cs
     { return __read_cs(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_cs(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_cs(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -123,10 +123,10 @@ namespace cs
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_cs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_cs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_cs(gsl::narrow_cast<segment_register_type>(set_bits(__read_cs(), mask, val << from))); }
+        void set(T val) noexcept { __write_cs(gsl::narrow_cast<type>(set_bits(__read_cs(), mask, val << from))); }
     }
 
     namespace ti
@@ -136,10 +136,10 @@ namespace cs
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_cs(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_cs(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_cs(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_cs(), from) : clear_bit(__read_cs(), from))); }
+        { __write_cs(gsl::narrow_cast<type>(val ? set_bit(__read_cs(), from) : clear_bit(__read_cs(), from))); }
     }
 
     namespace index
@@ -149,10 +149,10 @@ namespace cs
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_cs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_cs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_cs(gsl::narrow_cast<segment_register_type>(set_bits(__read_cs(), mask, val << from))); }
+        void set(T val) noexcept { __write_cs(gsl::narrow_cast<type>(set_bits(__read_cs(), mask, val << from))); }
     }
 }
 
@@ -162,7 +162,7 @@ namespace ss
     { return __read_ss(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_ss(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_ss(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -171,10 +171,10 @@ namespace ss
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ss(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ss(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ss(gsl::narrow_cast<segment_register_type>(set_bits(__read_ss(), mask, val << from))); }
+        void set(T val) noexcept { __write_ss(gsl::narrow_cast<type>(set_bits(__read_ss(), mask, val << from))); }
     }
 
     namespace ti
@@ -184,10 +184,10 @@ namespace ss
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_ss(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_ss(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_ss(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_ss(), from) : clear_bit(__read_ss(), from))); }
+        { __write_ss(gsl::narrow_cast<type>(val ? set_bit(__read_ss(), from) : clear_bit(__read_ss(), from))); }
     }
 
     namespace index
@@ -197,10 +197,10 @@ namespace ss
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ss(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ss(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ss(gsl::narrow_cast<segment_register_type>(set_bits(__read_ss(), mask, val << from))); }
+        void set(T val) noexcept { __write_ss(gsl::narrow_cast<type>(set_bits(__read_ss(), mask, val << from))); }
     }
 }
 
@@ -210,7 +210,7 @@ namespace ds
     { return __read_ds(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_ds(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_ds(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -219,10 +219,10 @@ namespace ds
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ds(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ds(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ds(gsl::narrow_cast<segment_register_type>(set_bits(__read_ds(), mask, val << from))); }
+        void set(T val) noexcept { __write_ds(gsl::narrow_cast<type>(set_bits(__read_ds(), mask, val << from))); }
     }
 
     namespace ti
@@ -232,10 +232,10 @@ namespace ds
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_ds(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_ds(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_ds(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_ds(), from) : clear_bit(__read_ds(), from))); }
+        { __write_ds(gsl::narrow_cast<type>(val ? set_bit(__read_ds(), from) : clear_bit(__read_ds(), from))); }
     }
 
     namespace index
@@ -245,10 +245,10 @@ namespace ds
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ds(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ds(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ds(gsl::narrow_cast<segment_register_type>(set_bits(__read_ds(), mask, val << from))); }
+        void set(T val) noexcept { __write_ds(gsl::narrow_cast<type>(set_bits(__read_ds(), mask, val << from))); }
     }
 }
 
@@ -258,7 +258,7 @@ namespace fs
     { return __read_fs(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_fs(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_fs(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -267,10 +267,10 @@ namespace fs
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_fs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_fs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_fs(gsl::narrow_cast<segment_register_type>(set_bits(__read_fs(), mask, val << from))); }
+        void set(T val) noexcept { __write_fs(gsl::narrow_cast<type>(set_bits(__read_fs(), mask, val << from))); }
     }
 
     namespace ti
@@ -280,10 +280,10 @@ namespace fs
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_fs(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_fs(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_fs(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_fs(), from) : clear_bit(__read_fs(), from))); }
+        { __write_fs(gsl::narrow_cast<type>(val ? set_bit(__read_fs(), from) : clear_bit(__read_fs(), from))); }
     }
 
     namespace index
@@ -293,10 +293,10 @@ namespace fs
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_fs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_fs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_fs(gsl::narrow_cast<segment_register_type>(set_bits(__read_fs(), mask, val << from))); }
+        void set(T val) noexcept { __write_fs(gsl::narrow_cast<type>(set_bits(__read_fs(), mask, val << from))); }
     }
 }
 
@@ -306,7 +306,7 @@ namespace gs
     { return __read_gs(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_gs(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_gs(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -315,10 +315,10 @@ namespace gs
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_gs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_gs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_gs(gsl::narrow_cast<segment_register_type>(set_bits(__read_gs(), mask, val << from))); }
+        void set(T val) noexcept { __write_gs(gsl::narrow_cast<type>(set_bits(__read_gs(), mask, val << from))); }
     }
 
     namespace ti
@@ -328,10 +328,10 @@ namespace gs
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_gs(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_gs(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_gs(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_gs(), from) : clear_bit(__read_gs(), from))); }
+        { __write_gs(gsl::narrow_cast<type>(val ? set_bit(__read_gs(), from) : clear_bit(__read_gs(), from))); }
     }
 
     namespace index
@@ -341,10 +341,10 @@ namespace gs
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_gs(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_gs(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_gs(gsl::narrow_cast<segment_register_type>(set_bits(__read_gs(), mask, val << from))); }
+        void set(T val) noexcept { __write_gs(gsl::narrow_cast<type>(set_bits(__read_gs(), mask, val << from))); }
     }
 }
 
@@ -354,7 +354,7 @@ namespace ldtr
     { return __read_ldtr(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -363,10 +363,10 @@ namespace ldtr
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ldtr(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ldtr(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<segment_register_type>(set_bits(__read_ldtr(), mask, val << from))); }
+        void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<type>(set_bits(__read_ldtr(), mask, val << from))); }
     }
 
     namespace ti
@@ -376,10 +376,10 @@ namespace ldtr
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_ldtr(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_ldtr(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_ldtr(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_ldtr(), from) : clear_bit(__read_ldtr(), from))); }
+        { __write_ldtr(gsl::narrow_cast<type>(val ? set_bit(__read_ldtr(), from) : clear_bit(__read_ldtr(), from))); }
     }
 
     namespace index
@@ -389,10 +389,10 @@ namespace ldtr
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_ldtr(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_ldtr(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<segment_register_type>(set_bits(__read_ldtr(), mask, val << from))); }
+        void set(T val) noexcept { __write_ldtr(gsl::narrow_cast<type>(set_bits(__read_ldtr(), mask, val << from))); }
     }
 }
 
@@ -402,7 +402,7 @@ namespace tr
     { return __read_tr(); }
 
     template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-    void set(T val) noexcept { __write_tr(gsl::narrow_cast<segment_register_type>(val)); }
+    void set(T val) noexcept { __write_tr(gsl::narrow_cast<type>(val)); }
 
     namespace rpl
     {
@@ -411,10 +411,10 @@ namespace tr
         constexpr const auto name = "rpl";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_tr(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_tr(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_tr(gsl::narrow_cast<segment_register_type>(set_bits(__read_tr(), mask, val << from))); }
+        void set(T val) noexcept { __write_tr(gsl::narrow_cast<type>(set_bits(__read_tr(), mask, val << from))); }
     }
 
     namespace ti
@@ -424,10 +424,10 @@ namespace tr
         constexpr const auto name = "ti";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bit(__read_tr(), from)); }
+        { return gsl::narrow_cast<type>(get_bit(__read_tr(), from)); }
 
         inline void set(bool val) noexcept
-        { __write_tr(gsl::narrow_cast<segment_register_type>(val ? set_bit(__read_tr(), from) : clear_bit(__read_tr(), from))); }
+        { __write_tr(gsl::narrow_cast<type>(val ? set_bit(__read_tr(), from) : clear_bit(__read_tr(), from))); }
     }
 
     namespace index
@@ -437,10 +437,10 @@ namespace tr
         constexpr const auto name = "index";
 
         inline auto get() noexcept
-        { return gsl::narrow_cast<segment_register_type>(get_bits(__read_tr(), mask) >> from); }
+        { return gsl::narrow_cast<type>(get_bits(__read_tr(), mask) >> from); }
 
         template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
-        void set(T val) noexcept { __write_tr(gsl::narrow_cast<segment_register_type>(set_bits(__read_tr(), mask, val << from))); }
+        void set(T val) noexcept { __write_tr(gsl::narrow_cast<type>(set_bits(__read_tr(), mask, val << from))); }
     }
 }
 }

--- a/bfvmm/include/intrinsics/tss_x64.h
+++ b/bfvmm/include/intrinsics/tss_x64.h
@@ -56,7 +56,7 @@ struct tss_x64
     uint16_t reserved6;
     uint16_t iomap;
 
-    tss_x64() :
+    tss_x64() noexcept :
         reserved1(0),
         rsp0_lower(0),
         rsp0_upper(0),

--- a/bfvmm/include/vmcs/vmcs_intel_x64_16bit_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_16bit_control_fields.h
@@ -28,9 +28,9 @@
 
 /// Intel x86_64 VMCS 16-Bit Control Fields
 ///
-/// This provides the namespace for 16-bit control fields of the VMCS.
-/// See Appendix B.1.1, Vol. 3 of the Intel Software Developer's Manual
-/// for details.
+/// The following provides the interface for the 16-bit control VMCS
+/// fields as defined in Appendix B.1.1, Vol. 3 of the Intel Software Developer's
+/// Manual.
 ///
 
 // *INDENT-OFF*

--- a/bfvmm/include/vmcs/vmcs_intel_x64_16bit_host_state_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_16bit_host_state_fields.h
@@ -27,7 +27,7 @@
 
 /// Intel x86_64 VMCS 16-Bit Host-State Fields
 ///
-/// The following provides the interface for the 16-bit guest-state VMCS
+/// The following provides the interface for the 16-bit host-state VMCS
 /// fields as defined in Appendix B.1.3, Vol. 3 of the Intel Software Developer's
 /// Manual.
 ///

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_control_fields.h
@@ -26,11 +26,11 @@
 #include <vmcs/vmcs_intel_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
 
-/// Intel x86_64 VMCS 32-Bit Control Fields
+/// Intel x86_64 VMCS 32-bit Control Fields
 ///
-/// The following provides the interface for the 32-bit VMCS control
-/// fields as defined in Appendix B.3.1, Vol. 3 of the Intel Software
-/// Developer's manual.
+/// The following provides the interface for the 32-bit control VMCS
+/// fields as defined in Appendix B.3.1, Vol. 3 of the Intel Software Developer's
+/// Manual.
 ///
 
 // *INDENT-OFF*

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_guest_state_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_guest_state_fields.h
@@ -32,6 +32,13 @@
 #include <intrinsics/vmx_intel_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
 
+/// Intel x86_64 VMCS 32-bit Guest-State Fields
+///
+/// The following provides the interface for the 32-bit guest-state VMCS
+/// fields as defined in Appendix B.3.3, Vol. 3 of the Intel Software Developer's
+/// Manual.
+///
+
 // *INDENT-OFF*
 
 namespace intel_x64

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_host_state_field.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_host_state_field.h
@@ -24,10 +24,11 @@
 
 #include <vmcs/vmcs_intel_x64.h>
 
-/// Intel x86_64 VMCS 32-Bit Host-State Field
+/// Intel x86_64 VMCS 32-bit Host-State Data Fields
 ///
-/// The following provides the interface to the 32-bit vmcs host state field
-/// define in Appendix B.3.4, Vol. 3 of the Intel Software Developer's manual.
+/// The following provides the interface for the 32-bit host-state VMCS
+/// fields as defined in Appendix B.3.4, Vol. 3 of the Intel Software Developer's
+/// Manual.
 ///
 
 // *INDENT-OFF*

--- a/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_32bit_read_only_data_fields.h
@@ -26,6 +26,13 @@
 #include <bitmanip.h>
 #include <vmcs/vmcs_intel_x64.h>
 
+/// Intel x86_64 VMCS 32-bit Read-Only Data Fields
+///
+/// The following provides the interface for the 32-bit read-only data VMCS
+/// fields as defined in Appendix B.3.2, Vol. 3 of the Intel Software Developer's
+/// Manual.
+///
+
 // *INDENT-OFF*
 
 namespace intel_x64

--- a/bfvmm/include/vmcs/vmcs_intel_x64_64bit_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_64bit_control_fields.h
@@ -26,11 +26,11 @@
 #include <vmcs/vmcs_intel_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
 
-/// Intel x86_64 VMCS 64-Bit Control Fields
+/// Intel x86_64 VMCS 64-bit Control Fields
 ///
-/// The following provides the interface for the 64-bit VMCS control
-/// fields as defined in Appendix B.2.1, Vol. 3 of the Intel Software
-/// Developer's manual.
+/// The following provides the interface for the 64-bit control VMCS
+/// fields as defined in Appendix B.2.1, Vol. 3 of the Intel Software Developer's
+/// Manual.
 ///
 
 template<class MA, class CA, class M,

--- a/bfvmm/include/vmcs/vmcs_intel_x64_64bit_guest_state_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_64bit_guest_state_fields.h
@@ -30,6 +30,13 @@
 #include <intrinsics/msrs_intel_x64.h>
 #include <intrinsics/cpuid_x64.h>
 
+/// Intel x86_64 VMCS 64-bit Guest-State Fields
+///
+/// The following provides the interface for the 64-bit guest-state VMCS
+/// fields as defined in Appendix B.2.3, Vol. 3 of the Intel Software Developer's
+/// Manual.
+///
+
 // *INDENT-OFF*
 
 namespace intel_x64

--- a/bfvmm/include/vmcs/vmcs_intel_x64_64bit_read_only_data_field.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_64bit_read_only_data_field.h
@@ -27,6 +27,13 @@
 #include <vmcs/vmcs_intel_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
 
+/// Intel x86_64 VMCS 64-bit Read-Only Data Fields
+///
+/// The following provides the interface for the 64-bit read-only data VMCS
+/// fields as defined in Appendix B.2.2, Vol. 3 of the Intel Software Developer's
+/// Manual.
+///
+
 // *INDENT-OFF*
 
 namespace intel_x64

--- a/bfvmm/include/vmcs/vmcs_intel_x64_check.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_check.h
@@ -274,6 +274,7 @@ auto control_reserved_properly_set(MA msr_addr, C ctls, const char *ctls_name)
     auto allowed0 = (msrs::get(msr_addr) & 0x00000000FFFFFFFFUL);
     auto allowed1 = ((msrs::get(msr_addr) >> 32) & 0x00000000FFFFFFFFUL);
     auto allowed1_failed = false;
+
     ctls &= 0x00000000FFFFFFFFUL;
 
     if ((allowed0 & ctls) != allowed0)

--- a/bfvmm/include/vmcs/vmcs_intel_x64_helpers.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_helpers.h
@@ -1,0 +1,167 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+// Author: Connor Davis      <davisc@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef VMCS_INTEL_X64_HELPERS_H
+#define VMCS_INTEL_X64_HELPERS_H
+
+#include <type_traits>
+#include <intrinsics/vmx_intel_x64.h>
+#include <intrinsics/msrs_intel_x64.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vmcs
+{
+
+using field_type = uint64_t;
+using value_type = uint64_t;
+
+template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+auto get_vmcs_field(T addr, const char *name, bool exists)
+{
+    if (!exists)
+        throw std::logic_error("get_vmcs_field failed: "_s + name + " field doesn't exist");
+
+    return intel_x64::vm::read(addr, name);
+}
+
+template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+auto get_vmcs_field_if_exists(T addr, const char *name, bool verbose, bool exists)
+{
+    if (exists)
+        return intel_x64::vm::read(addr, name);
+
+    if (!exists && verbose)
+        bfwarning << "get_vmcs_field_if_exists failed: " << name << " field doesn't exist" << bfendl;
+
+    return 0UL;
+}
+
+template <class V, class A,
+          class = typename std::enable_if<std::is_integral<V>::value>::type,
+          class = typename std::enable_if<std::is_integral<A>::value>::type>
+auto set_vmcs_field(V val, A addr, const char *name, bool exists)
+{
+    if (!exists)
+        throw std::logic_error("set_vmcs_field failed: "_s + name + " field doesn't exist");
+
+    intel_x64::vm::write(addr, val, name);
+}
+
+template <class V, class A,
+          class = typename std::enable_if<std::is_integral<V>::value>::type,
+          class = typename std::enable_if<std::is_integral<A>::value>::type>
+auto set_vmcs_field_if_exists(V val, A addr, const char *name, bool verbose, bool exists) noexcept
+{
+    if (exists)
+        intel_x64::vm::write(addr, val, name);
+
+    if (!exists && verbose)
+        bfwarning << "set_vmcs_field failed: " << name << " field doesn't exist" << bfendl;
+}
+
+template <class MA, class CA, class M,
+          class = typename std::enable_if<std::is_integral<MA>::value>::type,
+          class = typename std::enable_if<std::is_integral<CA>::value>::type,
+          class = typename std::enable_if<std::is_integral<M>::value>::type>
+auto set_vm_control(bool val, MA msr_addr, CA ctls_addr, const char *name, M mask, bool field_exists)
+{
+    if (!field_exists)
+        throw std::logic_error("set_vm_control failed: "_s + name + " control doesn't exist");
+
+    if (!val)
+    {
+        auto is_allowed0 = (intel_x64::msrs::get(msr_addr) & mask) == 0;
+
+        if (!is_allowed0)
+            throw std::logic_error("set_vm_control failed: "_s + name + " control is not allowed to be cleared to 0");
+
+        intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) & ~mask), name);
+    }
+    else
+    {
+        auto is_allowed1 = (intel_x64::msrs::get(msr_addr) & (mask << 32)) != 0;
+
+        if (!is_allowed1)
+            throw std::logic_error("set_vm_control failed: "_s + name + " control is not allowed to be set to 1");
+
+        intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) | mask), name);
+    }
+}
+
+template <class MA, class CA, class M,
+          class = typename std::enable_if<std::is_integral<MA>::value>::type,
+          class = typename std::enable_if<std::is_integral<CA>::value>::type,
+          class = typename std::enable_if<std::is_integral<M>::value>::type>
+auto set_vm_control_if_allowed(bool val, MA msr_addr, CA ctls_addr, const char *name,
+                               M mask, bool verbose, bool field_exists) noexcept
+{
+    if (!field_exists)
+    {
+        bfwarning << "set_vm_control_if_allowed failed: " << name << " control doesn't exist" << bfendl;
+        return;
+    }
+
+    if (!val)
+    {
+        auto is_allowed0 = (intel_x64::msrs::get(msr_addr) & mask) == 0;
+
+        if (is_allowed0)
+        {
+            intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) & ~mask), name);
+        }
+        else
+        {
+            if (verbose)
+            {
+                bfwarning << "set_vm_control_if_allowed failed: " << name
+                          << "control is not allowed to be cleared to 0" << bfendl;
+            }
+        }
+    }
+    else
+    {
+        auto is_allowed1 = (intel_x64::msrs::get(msr_addr) & (mask << 32)) != 0;
+
+        if (is_allowed1)
+        {
+            intel_x64::vm::write(ctls_addr, (intel_x64::vm::read(ctls_addr, name) | mask), name);
+        }
+        else
+        {
+            if (verbose)
+            {
+                bfwarning << "set_vm_control_if_allowed failed: " << name
+                          << "control is not allowed to be set to 1" << bfendl;
+            }
+        }
+    }
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfvmm/include/vmcs/vmcs_intel_x64_host_vm_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_host_vm_state.h
@@ -27,9 +27,6 @@
 #include <debug.h>
 #include <vmcs/vmcs_intel_x64_state.h>
 
-#include <intrinsics/gdt_x64.h>
-#include <intrinsics/idt_x64.h>
-
 /// VMCS Host VM State
 ///
 /// Define's the Host VM's CPU state. The Host VM runs the Host OS that
@@ -44,113 +41,113 @@ public:
     vmcs_intel_x64_host_vm_state();
     ~vmcs_intel_x64_host_vm_state() override = default;
 
-    uint16_t es() const override
+    x64::segment_register::type es() const override
     { return m_es; }
-    uint16_t cs() const override
+    x64::segment_register::type cs() const override
     { return m_cs; }
-    uint16_t ss() const override
+    x64::segment_register::type ss() const override
     { return m_ss; }
-    uint16_t ds() const override
+    x64::segment_register::type ds() const override
     { return m_ds; }
-    uint16_t fs() const override
+    x64::segment_register::type fs() const override
     { return m_fs; }
-    uint16_t gs() const override
+    x64::segment_register::type gs() const override
     { return m_gs; }
-    uint16_t ldtr() const override
+    x64::segment_register::type ldtr() const override
     { return m_ldtr; }
-    uint16_t tr() const override
+    x64::segment_register::type tr() const override
     { return m_tr; }
 
-    uint64_t cr0() const override
+    intel_x64::cr0::value_type cr0() const override
     { return m_cr0; }
-    uint64_t cr3() const override
+    intel_x64::cr3::value_type cr3() const override
     { return m_cr3; }
-    uint64_t cr4() const override
+    intel_x64::cr4::value_type cr4() const override
     { return m_cr4; }
-    uint64_t dr7() const override
+    x64::dr7::value_type dr7() const override
     { return m_dr7; }
 
-    uint64_t rflags() const override
+    x64::rflags::value_type rflags() const override
     { return m_rflags; }
 
-    uint64_t gdt_base() const override
+    gdt_x64::integer_pointer gdt_base() const override
     { return m_gdt.base(); }
-    uint64_t idt_base() const override
+    idt_x64::integer_pointer idt_base() const override
     { return m_idt.base(); }
 
-    uint16_t gdt_limit() const override
+    gdt_x64::size_type gdt_limit() const override
     { return m_gdt.limit(); }
-    uint16_t idt_limit() const override
+    idt_x64::size_type idt_limit() const override
     { return m_idt.limit(); }
 
-    uint32_t es_limit() const override
+    gdt_x64::limit_type es_limit() const override
     { return m_es_index != 0 ? m_gdt.limit(m_es_index) : 0; }
-    uint32_t cs_limit() const override
+    gdt_x64::limit_type cs_limit() const override
     { return m_cs_index != 0 ? m_gdt.limit(m_cs_index) : 0; }
-    uint32_t ss_limit() const override
+    gdt_x64::limit_type ss_limit() const override
     { return m_ss_index != 0 ? m_gdt.limit(m_ss_index) : 0; }
-    uint32_t ds_limit() const override
+    gdt_x64::limit_type ds_limit() const override
     { return m_ds_index != 0 ? m_gdt.limit(m_ds_index) : 0; }
-    uint32_t fs_limit() const override
+    gdt_x64::limit_type fs_limit() const override
     { return m_fs_index != 0 ? m_gdt.limit(m_fs_index) : 0; }
-    uint32_t gs_limit() const override
+    gdt_x64::limit_type gs_limit() const override
     { return m_gs_index != 0 ? m_gdt.limit(m_gs_index) : 0; }
-    uint32_t ldtr_limit() const override
+    gdt_x64::limit_type ldtr_limit() const override
     { return m_ldtr_index != 0 ? m_gdt.limit(m_ldtr_index) : 0; }
-    uint32_t tr_limit() const override
+    gdt_x64::limit_type tr_limit() const override
     { return m_tr_index != 0 ? m_gdt.limit(m_tr_index) : 0; }
 
-    uint32_t es_access_rights() const override
+    gdt_x64::access_rights_type es_access_rights() const override
     { return m_es_index != 0 ? m_gdt.access_rights(m_es_index) : x64::access_rights::unusable; }
-    uint32_t cs_access_rights() const override
+    gdt_x64::access_rights_type cs_access_rights() const override
     { return m_cs_index != 0 ? m_gdt.access_rights(m_cs_index) : x64::access_rights::unusable; }
-    uint32_t ss_access_rights() const override
+    gdt_x64::access_rights_type ss_access_rights() const override
     { return m_ss_index != 0 ? m_gdt.access_rights(m_ss_index) : x64::access_rights::unusable; }
-    uint32_t ds_access_rights() const override
+    gdt_x64::access_rights_type ds_access_rights() const override
     { return m_ds_index != 0 ? m_gdt.access_rights(m_ds_index) : x64::access_rights::unusable; }
-    uint32_t fs_access_rights() const override
+    gdt_x64::access_rights_type fs_access_rights() const override
     { return m_fs_index != 0 ? m_gdt.access_rights(m_fs_index) : x64::access_rights::unusable; }
-    uint32_t gs_access_rights() const override
+    gdt_x64::access_rights_type gs_access_rights() const override
     { return m_gs_index != 0 ? m_gdt.access_rights(m_gs_index) : x64::access_rights::unusable; }
-    uint32_t ldtr_access_rights() const override
+    gdt_x64::access_rights_type ldtr_access_rights() const override
     { return m_ldtr_index != 0 ? m_gdt.access_rights(m_ldtr_index) : x64::access_rights::unusable; }
-    uint32_t tr_access_rights() const override
+    gdt_x64::access_rights_type tr_access_rights() const override
     { return m_tr_index != 0 ? m_gdt.access_rights(m_tr_index) : x64::access_rights::unusable; }
 
-    uint64_t es_base() const override
+    gdt_x64::base_type es_base() const override
     { return m_es_index != 0 ? m_gdt.base(m_es_index) : 0; }
-    uint64_t cs_base() const override
+    gdt_x64::base_type cs_base() const override
     { return m_cs_index != 0 ? m_gdt.base(m_cs_index) : 0; }
-    uint64_t ss_base() const override
+    gdt_x64::base_type ss_base() const override
     { return m_ss_index != 0 ? m_gdt.base(m_ss_index) : 0; }
-    uint64_t ds_base() const override
+    gdt_x64::base_type ds_base() const override
     { return m_ds_index != 0 ? m_gdt.base(m_ds_index) : 0; }
-    uint64_t fs_base() const override
+    gdt_x64::base_type fs_base() const override
     { return m_fs_index != 0 ? m_gdt.base(m_fs_index) : 0; }
-    uint64_t gs_base() const override
+    gdt_x64::base_type gs_base() const override
     { return m_gs_index != 0 ? m_gdt.base(m_gs_index) : 0; }
-    uint64_t ldtr_base() const override
+    gdt_x64::base_type ldtr_base() const override
     { return m_ldtr_index != 0 ? m_gdt.base(m_ldtr_index) : 0; }
-    uint64_t tr_base() const override
+    gdt_x64::base_type tr_base() const override
     { return m_tr_index != 0 ? m_gdt.base(m_tr_index) : 0; }
 
-    uint64_t ia32_debugctl_msr() const override
+    intel_x64::msrs::value_type ia32_debugctl_msr() const override
     { return m_ia32_debugctl_msr; }
-    uint64_t ia32_pat_msr() const override
+    intel_x64::msrs::value_type ia32_pat_msr() const override
     { return m_ia32_pat_msr; }
-    uint64_t ia32_efer_msr() const override
+    intel_x64::msrs::value_type ia32_efer_msr() const override
     { return m_ia32_efer_msr; }
-    uint64_t ia32_perf_global_ctrl_msr() const override
+    intel_x64::msrs::value_type ia32_perf_global_ctrl_msr() const override
     { return m_ia32_perf_global_ctrl_msr; }
-    uint64_t ia32_sysenter_cs_msr() const override
+    intel_x64::msrs::value_type ia32_sysenter_cs_msr() const override
     { return m_ia32_sysenter_cs_msr; }
-    uint64_t ia32_sysenter_esp_msr() const override
+    intel_x64::msrs::value_type ia32_sysenter_esp_msr() const override
     { return m_ia32_sysenter_esp_msr; }
-    uint64_t ia32_sysenter_eip_msr() const override
+    intel_x64::msrs::value_type ia32_sysenter_eip_msr() const override
     { return m_ia32_sysenter_eip_msr; }
-    uint64_t ia32_fs_base_msr() const override
+    intel_x64::msrs::value_type ia32_fs_base_msr() const override
     { return m_ia32_fs_base_msr; }
-    uint64_t ia32_gs_base_msr() const override
+    intel_x64::msrs::value_type ia32_gs_base_msr() const override
     { return m_ia32_gs_base_msr; }
 
     void dump() const override
@@ -238,43 +235,43 @@ public:
 
 private:
 
-    uint16_t m_es;
-    uint16_t m_cs;
-    uint16_t m_ss;
-    uint16_t m_ds;
-    uint16_t m_fs;
-    uint16_t m_gs;
-    uint16_t m_ldtr;
-    uint16_t m_tr;
+    x64::segment_register::type m_es;
+    x64::segment_register::type m_cs;
+    x64::segment_register::type m_ss;
+    x64::segment_register::type m_ds;
+    x64::segment_register::type m_fs;
+    x64::segment_register::type m_gs;
+    x64::segment_register::type m_ldtr;
+    x64::segment_register::type m_tr;
 
-    uint16_t m_es_index;
-    uint16_t m_cs_index;
-    uint16_t m_ss_index;
-    uint16_t m_ds_index;
-    uint16_t m_fs_index;
-    uint16_t m_gs_index;
-    uint16_t m_ldtr_index;
-    uint16_t m_tr_index;
+    x64::segment_register::type m_es_index;
+    x64::segment_register::type m_cs_index;
+    x64::segment_register::type m_ss_index;
+    x64::segment_register::type m_ds_index;
+    x64::segment_register::type m_fs_index;
+    x64::segment_register::type m_gs_index;
+    x64::segment_register::type m_ldtr_index;
+    x64::segment_register::type m_tr_index;
 
-    uint64_t m_cr0;
-    uint64_t m_cr3;
-    uint64_t m_cr4;
-    uint64_t m_dr7;
+    intel_x64::cr0::value_type m_cr0;
+    intel_x64::cr3::value_type m_cr3;
+    intel_x64::cr4::value_type m_cr4;
+    x64::dr7::value_type m_dr7;
 
-    uint64_t m_rflags;
+    x64::rflags::value_type m_rflags;
 
     gdt_x64 m_gdt;
     idt_x64 m_idt;
 
-    uint64_t m_ia32_debugctl_msr;
-    uint64_t m_ia32_pat_msr;
-    uint64_t m_ia32_efer_msr;
-    uint64_t m_ia32_perf_global_ctrl_msr;
-    uint64_t m_ia32_sysenter_cs_msr;
-    uint64_t m_ia32_sysenter_esp_msr;
-    uint64_t m_ia32_sysenter_eip_msr;
-    uint64_t m_ia32_fs_base_msr;
-    uint64_t m_ia32_gs_base_msr;
+    intel_x64::msrs::value_type m_ia32_debugctl_msr;
+    intel_x64::msrs::value_type m_ia32_pat_msr;
+    intel_x64::msrs::value_type m_ia32_efer_msr;
+    intel_x64::msrs::value_type m_ia32_perf_global_ctrl_msr;
+    intel_x64::msrs::value_type m_ia32_sysenter_cs_msr;
+    intel_x64::msrs::value_type m_ia32_sysenter_esp_msr;
+    intel_x64::msrs::value_type m_ia32_sysenter_eip_msr;
+    intel_x64::msrs::value_type m_ia32_fs_base_msr;
+    intel_x64::msrs::value_type m_ia32_gs_base_msr;
 };
 
 #endif

--- a/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_control_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_control_fields.h
@@ -28,7 +28,7 @@
 
 /// Intel x86_64 VMCS Natural-Width Control Fields
 ///
-/// The following provides the interface for the natural-width vmcs control
+/// The following provides the interface for the natural-width control VMCS
 /// fields as defined in Appendix B.4.1, Vol. 3 of the Intel Software Developer's
 /// Manual.
 ///

--- a/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_guest_state_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_guest_state_fields.h
@@ -33,9 +33,9 @@
 
 /// Intel x86_64 VMCS Natural-Width Guest-State Fields
 ///
-/// The following provides the interface to the natural-width vmcs
-/// guest state fields as defined in Appendix B.4.3 of the Intel
-/// Software Developer's Manual.
+/// The following provides the interface for the natural-width guest-state VMCS
+/// fields as defined in Appendix B.4.2, Vol. 3 of the Intel Software Developer's
+/// Manual.
 ///
 
 // *INDENT-OFF*

--- a/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_host_state_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_host_state_fields.h
@@ -27,7 +27,7 @@
 
 /// Intel x86_64 VMCS Natural-Width Host-State Fields
 ///
-/// The following provides the interface for the natural-widht host-state VMCS
+/// The following provides the interface for the natural-width host-state VMCS
 /// fields as defined in Appendix B.4.4, Vol. 3 of the Intel Software Developer's
 /// Manual.
 ///

--- a/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_read_only_data_fields.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_natural_width_read_only_data_fields.h
@@ -27,8 +27,8 @@
 
 /// Intel x86_64 VMCS Natural-Width Read-Only Data Fields
 ///
-/// The following provides the interface for the natural-width read-only VMCS
-/// data fields as defined in Appendix B.4.2, Vol. 3 of the Intel Software Developer's
+/// The following provides the interface for the natural-width read-only data VMCS
+/// fields as defined in Appendix B.4.2, Vol. 3 of the Intel Software Developer's
 /// Manual.
 ///
 

--- a/bfvmm/include/vmcs/vmcs_intel_x64_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_state.h
@@ -23,6 +23,14 @@
 #define VMCS_INTEL_X64_STATE_H
 
 #include <intrinsics/x64.h>
+#include <intrinsics/gdt_x64.h>
+#include <intrinsics/idt_x64.h>
+#include <intrinsics/tss_x64.h>
+#include <intrinsics/srs_x64.h>
+#include <intrinsics/debug_x64.h>
+#include <intrinsics/rflags_x64.h>
+#include <intrinsics/crs_intel_x64.h>
+#include <intrinsics/msrs_intel_x64.h>
 
 /// VMCS State
 ///
@@ -52,122 +60,222 @@ public:
     vmcs_intel_x64_state() = default;
     virtual ~vmcs_intel_x64_state() = default;
 
-    virtual uint16_t es() const { return 0; }
-    virtual uint16_t cs() const { return 0; }
-    virtual uint16_t ss() const { return 0; }
-    virtual uint16_t ds() const { return 0; }
-    virtual uint16_t fs() const { return 0; }
-    virtual uint16_t gs() const { return 0; }
-    virtual uint16_t ldtr() const { return 0; }
-    virtual uint16_t tr() const { return 0; }
+    virtual x64::segment_register::type es() const
+    { return 0; }
+    virtual x64::segment_register::type cs() const
+    { return 0; }
+    virtual x64::segment_register::type ss() const
+    { return 0; }
+    virtual x64::segment_register::type ds() const
+    { return 0; }
+    virtual x64::segment_register::type fs() const
+    { return 0; }
+    virtual x64::segment_register::type gs() const
+    { return 0; }
+    virtual x64::segment_register::type ldtr() const
+    { return 0; }
+    virtual x64::segment_register::type tr() const
+    { return 0; }
 
-    virtual void set_es(uint16_t val) { (void) val; }
-    virtual void set_cs(uint16_t val) { (void) val; }
-    virtual void set_ss(uint16_t val) { (void) val; }
-    virtual void set_ds(uint16_t val) { (void) val; }
-    virtual void set_fs(uint16_t val) { (void) val; }
-    virtual void set_gs(uint16_t val) { (void) val; }
-    virtual void set_ldtr(uint16_t val) { (void) val; }
-    virtual void set_tr(uint16_t val) { (void) val; }
+    virtual void set_es(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_cs(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_ss(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_ds(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_fs(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_gs(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_ldtr(x64::segment_register::type val)
+    { (void) val; }
+    virtual void set_tr(x64::segment_register::type val)
+    { (void) val; }
 
-    virtual uint64_t cr0() const { return 0; }
-    virtual uint64_t cr3() const { return 0; }
-    virtual uint64_t cr4() const { return 0; }
-    virtual uint64_t dr7() const { return 0; }
+    virtual intel_x64::cr0::value_type cr0() const
+    { return 0; }
+    virtual intel_x64::cr3::value_type cr3() const
+    { return 0; }
+    virtual intel_x64::cr4::value_type cr4() const
+    { return 0; }
+    virtual x64::dr7::value_type dr7() const
+    { return 0; }
 
-    virtual void set_cr0(uint64_t val) { (void) val; }
-    virtual void set_cr3(uint64_t val) { (void) val; }
-    virtual void set_cr4(uint64_t val) { (void) val; }
-    virtual void set_dr7(uint64_t val) { (void) val; }
+    virtual void set_cr0(intel_x64::cr0::value_type val)
+    { (void) val; }
+    virtual void set_cr3(intel_x64::cr3::value_type val)
+    { (void) val; }
+    virtual void set_cr4(intel_x64::cr4::value_type val)
+    { (void) val; }
+    virtual void set_dr7(x64::dr7::value_type val)
+    { (void) val; }
 
-    virtual uint64_t rflags() const { return 0; }
-    virtual void set_rflags(uint64_t val) { (void) val; }
+    virtual x64::rflags::value_type rflags() const
+    { return 0; }
+    virtual void set_rflags(x64::rflags::value_type val)
+    { (void) val; }
 
-    virtual uint64_t gdt_base() const { return 0; }
-    virtual uint64_t idt_base() const { return 0; }
+    virtual gdt_x64::integer_pointer gdt_base() const
+    { return 0; }
+    virtual idt_x64::integer_pointer idt_base() const
+    { return 0; }
 
-    virtual void set_gdt_base(uint64_t val) { (void) val; }
-    virtual void set_idt_base(uint64_t val) { (void) val; }
+    virtual void set_gdt_base(gdt_x64::integer_pointer val)
+    { (void) val; }
+    virtual void set_idt_base(idt_x64::integer_pointer val)
+    { (void) val; }
 
-    virtual uint16_t gdt_limit() const { return 0; }
-    virtual uint16_t idt_limit() const { return 0; }
+    virtual gdt_x64::size_type gdt_limit() const
+    { return 0; }
+    virtual idt_x64::size_type idt_limit() const
+    { return 0; }
 
-    virtual void set_gdt_limit(uint16_t val) { (void) val; }
-    virtual void set_idt_limit(uint16_t val) { (void) val; }
+    virtual void set_gdt_limit(gdt_x64::size_type val)
+    { (void) val; }
+    virtual void set_idt_limit(idt_x64::size_type val)
+    { (void) val; }
 
-    virtual uint32_t es_limit() const { return 0; }
-    virtual uint32_t cs_limit() const { return 0; }
-    virtual uint32_t ss_limit() const { return 0; }
-    virtual uint32_t ds_limit() const { return 0; }
-    virtual uint32_t fs_limit() const { return 0; }
-    virtual uint32_t gs_limit() const { return 0; }
-    virtual uint32_t ldtr_limit() const { return 0; }
-    virtual uint32_t tr_limit() const { return 0; }
+    virtual gdt_x64::limit_type es_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type cs_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type ss_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type ds_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type fs_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type gs_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type ldtr_limit() const
+    { return 0; }
+    virtual gdt_x64::limit_type tr_limit() const
+    { return 0; }
 
-    virtual void set_es_limit(uint32_t val) { (void) val; }
-    virtual void set_cs_limit(uint32_t val) { (void) val; }
-    virtual void set_ss_limit(uint32_t val) { (void) val; }
-    virtual void set_ds_limit(uint32_t val) { (void) val; }
-    virtual void set_fs_limit(uint32_t val) { (void) val; }
-    virtual void set_gs_limit(uint32_t val) { (void) val; }
-    virtual void set_ldtr_limit(uint32_t val) { (void) val; }
-    virtual void set_tr_limit(uint32_t val) { (void) val; }
+    virtual void set_es_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_cs_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_ss_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_ds_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_fs_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_gs_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_ldtr_limit(gdt_x64::limit_type val)
+    { (void) val; }
+    virtual void set_tr_limit(gdt_x64::limit_type val)
+    { (void) val; }
 
-    virtual uint32_t es_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t cs_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t ss_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t ds_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t fs_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t gs_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t ldtr_access_rights() const { return x64::access_rights::unusable; }
-    virtual uint32_t tr_access_rights() const { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type es_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type cs_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type ss_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type ds_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type fs_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type gs_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type ldtr_access_rights() const
+    { return x64::access_rights::unusable; }
+    virtual gdt_x64::access_rights_type tr_access_rights() const
+    { return x64::access_rights::unusable; }
 
-    virtual void set_es_access_rights(uint32_t val) { (void) val; }
-    virtual void set_cs_access_rights(uint32_t val) { (void) val; }
-    virtual void set_ss_access_rights(uint32_t val) { (void) val; }
-    virtual void set_ds_access_rights(uint32_t val) { (void) val; }
-    virtual void set_fs_access_rights(uint32_t val) { (void) val; }
-    virtual void set_gs_access_rights(uint32_t val) { (void) val; }
-    virtual void set_ldtr_access_rights(uint32_t val) { (void) val; }
-    virtual void set_tr_access_rights(uint32_t val) { (void) val; }
+    virtual void set_es_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_cs_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_ss_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_ds_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_fs_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_gs_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_ldtr_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
+    virtual void set_tr_access_rights(gdt_x64::access_rights_type val)
+    { (void) val; }
 
-    virtual uint64_t es_base() const { return 0; }
-    virtual uint64_t cs_base() const { return 0; }
-    virtual uint64_t ss_base() const { return 0; }
-    virtual uint64_t ds_base() const { return 0; }
-    virtual uint64_t fs_base() const { return 0; }
-    virtual uint64_t gs_base() const { return 0; }
-    virtual uint64_t ldtr_base() const { return 0; }
-    virtual uint64_t tr_base() const { return 0; }
+    virtual gdt_x64::base_type es_base() const
+    { return 0; }
+    virtual gdt_x64::base_type cs_base() const
+    { return 0; }
+    virtual gdt_x64::base_type ss_base() const
+    { return 0; }
+    virtual gdt_x64::base_type ds_base() const
+    { return 0; }
+    virtual gdt_x64::base_type fs_base() const
+    { return 0; }
+    virtual gdt_x64::base_type gs_base() const
+    { return 0; }
+    virtual gdt_x64::base_type ldtr_base() const
+    { return 0; }
+    virtual gdt_x64::base_type tr_base() const
+    { return 0; }
 
-    virtual void set_es_base(uint64_t val) { (void) val; }
-    virtual void set_cs_base(uint64_t val) { (void) val; }
-    virtual void set_ss_base(uint64_t val) { (void) val; }
-    virtual void set_ds_base(uint64_t val) { (void) val; }
-    virtual void set_fs_base(uint64_t val) { (void) val; }
-    virtual void set_gs_base(uint64_t val) { (void) val; }
-    virtual void set_ldtr_base(uint64_t val) { (void) val; }
-    virtual void set_tr_base(uint64_t val) { (void) val; }
+    virtual void set_es_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_cs_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_ss_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_ds_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_fs_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_gs_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_ldtr_base(gdt_x64::base_type val)
+    { (void) val; }
+    virtual void set_tr_base(gdt_x64::base_type val)
+    { (void) val; }
 
-    virtual uint64_t ia32_debugctl_msr() const { return 0; }
-    virtual uint64_t ia32_pat_msr() const { return 0; }
-    virtual uint64_t ia32_efer_msr() const { return 0; }
-    virtual uint64_t ia32_perf_global_ctrl_msr() const { return 0; }
-    virtual uint64_t ia32_sysenter_cs_msr() const { return 0; }
-    virtual uint64_t ia32_sysenter_esp_msr() const { return 0; }
-    virtual uint64_t ia32_sysenter_eip_msr() const { return 0; }
-    virtual uint64_t ia32_fs_base_msr() const { return 0; }
-    virtual uint64_t ia32_gs_base_msr() const { return 0; }
+    virtual intel_x64::msrs::value_type ia32_debugctl_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_pat_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_efer_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_perf_global_ctrl_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_sysenter_cs_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_sysenter_esp_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_sysenter_eip_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_fs_base_msr() const
+    { return 0; }
+    virtual intel_x64::msrs::value_type ia32_gs_base_msr() const
+    { return 0; }
 
-    virtual void set_ia32_debugctl_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_pat_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_efer_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_perf_global_ctrl_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_sysenter_cs_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_sysenter_esp_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_sysenter_eip_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_fs_base_msr(uint64_t val) { (void) val; }
-    virtual void set_ia32_gs_base_msr(uint64_t val) { (void) val; }
+    virtual void set_ia32_debugctl_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_pat_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_efer_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_perf_global_ctrl_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_sysenter_cs_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_sysenter_esp_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_sysenter_eip_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_fs_base_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
+    virtual void set_ia32_gs_base_msr(intel_x64::msrs::value_type val)
+    { (void) val; }
 
     virtual void dump() const {}
 };

--- a/bfvmm/include/vmcs/vmcs_intel_x64_vmm_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_vmm_state.h
@@ -27,9 +27,9 @@
 #include <debug.h>
 #include <vmcs/vmcs_intel_x64_state.h>
 
-#include <intrinsics/gdt_x64.h>
-#include <intrinsics/idt_x64.h>
-#include <intrinsics/tss_x64.h>
+extern tss_x64 g_tss;
+extern gdt_x64 g_gdt;
+extern idt_x64 g_idt;
 
 /// VMCS VMM State
 ///
@@ -52,43 +52,72 @@ public:
     vmcs_intel_x64_vmm_state();
     ~vmcs_intel_x64_vmm_state() override = default;
 
-    uint16_t cs() const override { return m_cs; }
-    uint16_t ss() const override { return m_ss; }
-    uint16_t fs() const override { return m_fs; }
-    uint16_t gs() const override { return m_gs; }
-    uint16_t tr() const override { return m_tr; }
+    x64::segment_register::type cs() const override
+    { return m_cs; }
+    x64::segment_register::type ss() const override
+    { return m_ss; }
+    x64::segment_register::type fs() const override
+    { return m_fs; }
+    x64::segment_register::type gs() const override
+    { return m_gs; }
+    x64::segment_register::type tr() const override
+    { return m_tr; }
 
-    uint64_t cr0() const override { return m_cr0; }
-    uint64_t cr3() const override { return m_cr3; }
-    uint64_t cr4() const override { return m_cr4; }
+    intel_x64::cr0::value_type cr0() const override
+    { return m_cr0; }
+    intel_x64::cr3::value_type cr3() const override
+    { return m_cr3; }
+    intel_x64::cr4::value_type cr4() const override
+    { return m_cr4; }
 
-    uint64_t rflags() const override { return m_rflags; }
+    x64::rflags::value_type rflags() const override
+    { return m_rflags; }
 
-    uint64_t gdt_base() const override { return m_gdt.base(); }
-    uint64_t idt_base() const override { return m_idt.base(); }
+    gdt_x64::integer_pointer gdt_base() const override
+    { return g_gdt.base(); }
+    idt_x64::integer_pointer idt_base() const override
+    { return g_idt.base(); }
 
-    uint16_t gdt_limit() const override { return m_gdt.limit(); }
-    uint16_t idt_limit() const override { return m_idt.limit(); }
+    gdt_x64::size_type gdt_limit() const override
+    { return g_gdt.limit(); }
+    idt_x64::size_type idt_limit() const override
+    { return g_idt.limit(); }
 
-    uint32_t cs_limit() const override { return m_gdt.limit(m_cs_index); }
-    uint32_t ss_limit() const override { return m_gdt.limit(m_ss_index); }
-    uint32_t fs_limit() const override { return m_gdt.limit(m_fs_index); }
-    uint32_t gs_limit() const override { return m_gdt.limit(m_gs_index); }
-    uint32_t tr_limit() const override { return m_gdt.limit(m_tr_index); }
+    gdt_x64::limit_type cs_limit() const override
+    { return g_gdt.limit(m_cs_index); }
+    gdt_x64::limit_type ss_limit() const override
+    { return g_gdt.limit(m_ss_index); }
+    gdt_x64::limit_type fs_limit() const override
+    { return g_gdt.limit(m_fs_index); }
+    gdt_x64::limit_type gs_limit() const override
+    { return g_gdt.limit(m_gs_index); }
+    gdt_x64::limit_type tr_limit() const override
+    { return g_gdt.limit(m_tr_index); }
 
-    uint32_t cs_access_rights() const override { return m_gdt.access_rights(m_cs_index); }
-    uint32_t ss_access_rights() const override { return m_gdt.access_rights(m_ss_index); }
-    uint32_t fs_access_rights() const override { return m_gdt.access_rights(m_fs_index); }
-    uint32_t gs_access_rights() const override { return m_gdt.access_rights(m_gs_index); }
-    uint32_t tr_access_rights() const override { return m_gdt.access_rights(m_tr_index); }
+    gdt_x64::access_rights_type cs_access_rights() const override
+    { return g_gdt.access_rights(m_cs_index); }
+    gdt_x64::access_rights_type ss_access_rights() const override
+    { return g_gdt.access_rights(m_ss_index); }
+    gdt_x64::access_rights_type fs_access_rights() const override
+    { return g_gdt.access_rights(m_fs_index); }
+    gdt_x64::access_rights_type gs_access_rights() const override
+    { return g_gdt.access_rights(m_gs_index); }
+    gdt_x64::access_rights_type tr_access_rights() const override
+    { return g_gdt.access_rights(m_tr_index); }
 
-    uint64_t cs_base() const override { return m_gdt.base(m_cs_index); }
-    uint64_t ss_base() const override { return m_gdt.base(m_ss_index); }
-    uint64_t fs_base() const override { return m_gdt.base(m_fs_index); }
-    uint64_t gs_base() const override { return m_gdt.base(m_gs_index); }
-    uint64_t tr_base() const override { return m_gdt.base(m_tr_index); }
+    gdt_x64::base_type cs_base() const override
+    { return g_gdt.base(m_cs_index); }
+    gdt_x64::base_type ss_base() const override
+    { return g_gdt.base(m_ss_index); }
+    gdt_x64::base_type fs_base() const override
+    { return g_gdt.base(m_fs_index); }
+    gdt_x64::base_type gs_base() const override
+    { return g_gdt.base(m_gs_index); }
+    gdt_x64::base_type tr_base() const override
+    { return g_gdt.base(m_tr_index); }
 
-    uint64_t ia32_efer_msr() const override { return m_ia32_efer_msr; }
+    intel_x64::msrs::value_type ia32_efer_msr() const override
+    { return m_ia32_efer_msr; }
 
     void dump() const override
     {
@@ -140,10 +169,10 @@ public:
 
         bfdebug << bfendl;
         bfdebug << "gdt/idt:" << bfendl;
-        bfdebug << std::setw(35) << view_as_pointer(m_gdt.base()) << bfendl;
-        bfdebug << std::setw(35) << view_as_pointer(m_gdt.limit()) << bfendl;
-        bfdebug << std::setw(35) << view_as_pointer(m_idt.base()) << bfendl;
-        bfdebug << std::setw(35) << view_as_pointer(m_idt.limit()) << bfendl;
+        bfdebug << std::setw(35) << view_as_pointer(g_gdt.base()) << bfendl;
+        bfdebug << std::setw(35) << view_as_pointer(g_gdt.limit()) << bfendl;
+        bfdebug << std::setw(35) << view_as_pointer(g_idt.base()) << bfendl;
+        bfdebug << std::setw(35) << view_as_pointer(g_idt.limit()) << bfendl;
 
         bfdebug << bfendl;
         bfdebug << "model specific registers:" << bfendl;
@@ -154,29 +183,25 @@ public:
 
 private:
 
-    uint16_t m_cs;
-    uint16_t m_ss;
-    uint16_t m_fs;
-    uint16_t m_gs;
-    uint16_t m_tr;
+    x64::segment_register::type m_cs;
+    x64::segment_register::type m_ss;
+    x64::segment_register::type m_fs;
+    x64::segment_register::type m_gs;
+    x64::segment_register::type m_tr;
 
-    uint16_t m_cs_index;
-    uint16_t m_ss_index;
-    uint16_t m_fs_index;
-    uint16_t m_gs_index;
-    uint16_t m_tr_index;
+    x64::segment_register::type m_cs_index;
+    x64::segment_register::type m_ss_index;
+    x64::segment_register::type m_fs_index;
+    x64::segment_register::type m_gs_index;
+    x64::segment_register::type m_tr_index;
 
-    uint64_t m_cr0;
-    uint64_t m_cr3;
-    uint64_t m_cr4;
+    intel_x64::cr0::value_type m_cr0;
+    intel_x64::cr3::value_type m_cr3;
+    intel_x64::cr4::value_type m_cr4;
 
-    uint64_t m_rflags;
+    x64::rflags::value_type m_rflags;
 
-    tss_x64 m_tss;
-    gdt_x64 m_gdt;
-    idt_x64 m_idt;
-
-    uint64_t m_ia32_efer_msr;
+    intel_x64::msrs::value_type m_ia32_efer_msr;
 };
 
 #endif

--- a/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
@@ -74,7 +74,7 @@ intrinsics_ut::test_gdt_constructor_no_size()
 void
 intrinsics_ut::test_gdt_constructor_zero_size()
 {
-    this->expect_exception([&] { gdt_x64{0}; }, ""_ut_ffe);
+    this->expect_no_exception([&] { gdt_x64{0}; });
 }
 
 void

--- a/bfvmm/src/intrinsics/test/test_idt_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_idt_x64.cpp
@@ -74,7 +74,7 @@ intrinsics_ut::test_idt_constructor_no_size()
 void
 intrinsics_ut::test_idt_constructor_zero_size()
 {
-    this->expect_exception([&] { idt_x64{0}; }, ""_ut_ffe);
+    this->expect_no_exception([&] { idt_x64{0}; });
 }
 
 void

--- a/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_intel_x64.cpp
@@ -67,7 +67,7 @@ vcpu_intel_x64::init(void *attr)
     m_state_save->vmcs_ptr = reinterpret_cast<uintptr_t>(m_vmcs.get());
     m_state_save->exit_handler_ptr = reinterpret_cast<uintptr_t>(m_exit_handler.get());
 
-    m_vmcs->set_state_save(m_state_save);
+    m_vmcs->set_state_save(m_state_save.get());
 
     m_exit_handler->set_vmcs(m_vmcs);
     m_exit_handler->set_state_save(m_state_save);
@@ -101,7 +101,7 @@ vcpu_intel_x64::run(void *attr)
                 m_vmxon->stop();
         });
 
-        m_vmcs->launch(m_vmm_state, m_guest_state);
+        m_vmcs->launch(m_vmm_state.get(), m_guest_state.get());
     }
     else
     {

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
@@ -21,12 +21,6 @@
 
 #include <vmcs/vmcs_intel_x64_host_vm_state.h>
 
-#include <intrinsics/srs_x64.h>
-#include <intrinsics/debug_x64.h>
-#include <intrinsics/rflags_x64.h>
-#include <intrinsics/crs_intel_x64.h>
-#include <intrinsics/msrs_intel_x64.h>
-
 using namespace x64;
 using namespace intel_x64;
 

--- a/tools/scripts/build_newlib.sh
+++ b/tools/scripts/build_newlib.sh
@@ -50,8 +50,8 @@ else
 fi
 
 echo "Building newlib. Please wait..."
-../source_newlib/configure --target=x86_64-elf --disable-libgloss AR_FOR_TARGET="$ar" CC_FOR_TARGET="$cc" CXX_FOR_TARGET="$cxx" CFLAGS_FOR_TARGET="$CFLAGS" CXXFLAGS_FOR_TARGET="$CXXFLAGS" --prefix=$BUILD_ABS/sysroot/ 
-make -j2 
+../source_newlib/configure --target=x86_64-elf --disable-libgloss AR_FOR_TARGET="$ar" CC_FOR_TARGET="$cc" CXX_FOR_TARGET="$cxx" CFLAGS_FOR_TARGET="$CFLAGS" CXXFLAGS_FOR_TARGET="$CXXFLAGS" --prefix=$BUILD_ABS/sysroot/ 1>/dev/null 2>/dev/null
+make -j2 1>/dev/null 2>/dev/null
 make -j2 install 1>/dev/null 2>/dev/null
 
 $BUILD_ABS/build_scripts/x86_64-bareflank-clang -shared `find $BUILD_ABS/build_newlib/x86_64-elf/newlib/libc -name "*.o" | xargs echo` -o libc.so


### PR DESCRIPTION
This patch set cleans up the VMCS:
- expects / ensures
- remove virtual
- uses aliases
- reduce memory overhead

Signed-off-by: “Rian <“rianquinn@gmail.com”>