### PR TITLE
Deadlock Bug

### DIFF
--- a/bfvmm/src/vcpu/src/vcpu_manager.cpp
+++ b/bfvmm/src/vcpu/src/vcpu_manager.cpp
@@ -111,7 +111,7 @@ vcpu_manager::hlt_vcpu(vcpuid::type vcpuid, user_data *data)
 void
 vcpu_manager::write(vcpuid::type vcpuid, const std::string &str) noexcept
 {
-    if (auto && vcpu = get_vcpu(vcpuid))
+    if (auto && vcpu = m_vcpus[vcpuid])
         vcpu->write(str);
 }
 


### PR DESCRIPTION
This patch fixes a deadlock bug with using debug statements in
constructors / destructors.

Signed-off-by: “Rian <“rianquinn@gmail.com”>