### PR TITLE
Missing Virtual Functions / JSON Helper

### DIFF
--- a/bfvmm/include/debug_ring/debug_ring.h
+++ b/bfvmm/include/debug_ring/debug_ring.h
@@ -51,7 +51,7 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    virtual ~debug_ring() noexcept;
+    virtual ~debug_ring() noexcept = default;
 
     /// Write to Debug Ring
     ///

--- a/bfvmm/include/exit_handler/exit_handler_intel_x64.h
+++ b/bfvmm/include/exit_handler/exit_handler_intel_x64.h
@@ -105,15 +105,15 @@ protected:
     void handle_vmcall_event(vmcall_registers_t &regs);
     void handle_vmcall_unittest(vmcall_registers_t &regs);
 
-    void handle_vmcall_data_string_unformatted(
+    virtual void handle_vmcall_data_string_unformatted(
         vmcall_registers_t &regs, const std::string &str,
         const bfn::unique_map_ptr_x64<char> &omap);
 
-    void handle_vmcall_data_string_json(
+    virtual void handle_vmcall_data_string_json(
         vmcall_registers_t &regs, const json &str,
         const bfn::unique_map_ptr_x64<char> &omap);
 
-    void handle_vmcall_data_binary_unformatted(
+    virtual void handle_vmcall_data_binary_unformatted(
         vmcall_registers_t &regs,
         const bfn::unique_map_ptr_x64<char> &imap,
         const bfn::unique_map_ptr_x64<char> &omap);
@@ -124,6 +124,12 @@ protected:
     friend class vcpu_intel_x64;
     friend class exit_handler_intel_x64_ut;
     friend exit_handler_intel_x64 setup_ehlr(gsl::not_null<vmcs_intel_x64 *> vmcs);
+
+    void reply_with_string(vmcall_registers_t &regs, const std::string &str,
+                           const bfn::unique_map_ptr_x64<char> &omap);
+
+    void reply_with_json(vmcall_registers_t &regs, const json &str,
+                         const bfn::unique_map_ptr_x64<char> &omap);
 
 private:
 

--- a/bfvmm/src/debug_ring/src/debug_ring.cpp
+++ b/bfvmm/src/debug_ring/src/debug_ring.cpp
@@ -75,12 +75,6 @@ debug_ring::debug_ring(vcpuid::type vcpuid) noexcept
     { }
 }
 
-debug_ring::~debug_ring() noexcept
-{
-    std::lock_guard<std::mutex> guard(g_debug_mutex);
-    g_drrs.erase(m_vcpuid);
-}
-
 void
 debug_ring::write(const std::string &str) noexcept
 {


### PR DESCRIPTION
This patch provides for missing vitual functions and it
also provides some helpers for passing data back to
BFM from the hypervisor.

Signed-off-by: “Rian <“rianquinn@gmail.com”>