### PR TITLE
Fix use of private

### DIFF
--- a/bfvmm/include/exit_handler/exit_handler_intel_x64.h
+++ b/bfvmm/include/exit_handler/exit_handler_intel_x64.h
@@ -126,6 +126,22 @@ protected:
         vmcall_registers_t &regs, const json &str,
         const bfn::unique_map_ptr_x64<char> &omap);
 
+    vmcs_intel_x64 *m_vmcs;
+    state_save_intel_x64 *m_state_save;
+
+private:
+
+    friend class vcpu_ut;
+    friend class vcpu_intel_x64;
+    friend class exit_handler_intel_x64_ut;
+    friend exit_handler_intel_x64 setup_ehlr(gsl::not_null<vmcs_intel_x64 *> vmcs);
+
+    virtual void set_vmcs(gsl::not_null<vmcs_intel_x64 *> vmcs)
+    { m_vmcs = vmcs; }
+
+    virtual void set_state_save(gsl::not_null<state_save_intel_x64 *> state_save)
+    { m_state_save = state_save; }
+
 private:
 
 #ifdef INCLUDE_LIBCXX_UNITTESTS
@@ -144,21 +160,6 @@ private:
     void unittest_1101_io_manipulators() const;
 #endif
 
-private:
-
-    friend class vcpu_ut;
-    friend class vcpu_intel_x64;
-    friend class exit_handler_intel_x64_ut;
-    friend exit_handler_intel_x64 setup_ehlr(gsl::not_null<vmcs_intel_x64 *> vmcs);
-
-    vmcs_intel_x64 *m_vmcs;
-    state_save_intel_x64 *m_state_save;
-
-    virtual void set_vmcs(gsl::not_null<vmcs_intel_x64 *> vmcs)
-    { m_vmcs = vmcs; }
-
-    virtual void set_state_save(gsl::not_null<state_save_intel_x64 *> state_save)
-    { m_state_save = state_save; }
 };
 
 #endif

--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -190,20 +190,19 @@ protected:
 
 protected:
 
+    uintptr_t m_vmcs_region_phys;
+    std::unique_ptr<uint32_t[]> m_vmcs_region;
+
+    state_save_intel_x64 *m_state_save;
+    std::unique_ptr<char[]> m_exit_handler_stack;
+
+private:
+
     friend class vcpu_ut;
     friend class vmcs_ut;
     friend class vcpu_intel_x64;
     friend class exit_handler_intel_x64;
     friend class exit_handler_intel_x64_ut;
-
-    uintptr_t m_vmcs_region_phys;
-    std::unique_ptr<uint32_t[]> m_vmcs_region;
-
-    std::unique_ptr<char[]> m_exit_handler_stack;
-
-private:
-
-    state_save_intel_x64 *m_state_save;
 
     virtual void set_state_save(gsl::not_null<state_save_intel_x64 *> state_save)
     { m_state_save = state_save; }

--- a/include/mainpage.h
+++ b/include/mainpage.h
@@ -107,24 +107,24 @@
 /// class exit_handler_cpuidcount : public exit_handler_intel_x64
 /// {
 /// public:
-/// 
+///
 ///     exit_handler_cpuidcount() :
 ///         m_count(0)
 ///     { }
-/// 
+///
 ///     ~exit_handler_cpuidcount() override
 ///     { bfdebug << "cpuid count = " << m_count << bfendl; }
-/// 
+///
 ///     void handle_exit(intel_x64::vmcs::value_type reason) override
 ///     {
 ///         if (reason == vmcs::exit_reason::basic_exit_reason::cpuid)
 ///             m_count++;
-/// 
+///
 ///         exit_handler_intel_x64::handle_exit(reason);
 ///     }
-/// 
+///
 /// private:
-/// 
+///
 ///     int64_t m_count;
 /// };
 /// @endcode
@@ -152,7 +152,7 @@
 /// vcpu_factory::make_vcpu(vcpuid::type vcpuid, user_data *data)
 /// {
 ///     auto &&my_exit_handler = std::make_unique<exit_handler_cpuidcount>();
-/// 
+///
 ///     (void) data;
 ///     return std::make_unique<vcpu_intel_x64>(
 ///                vcpuid,
@@ -211,7 +211,7 @@
 /// To use in-tree, simply place your code in a folder at Bareflank's root
 /// starting with hypervisor_* or src_* and run make. To perform out-of-tree
 /// compilation, configure your build with "-m" to point to your module file
-/// and "-e" to point to your extensions. 
+/// and "-e" to point to your extensions.
 ///
 /// <a href="https://github.com/Bareflank/hypervisor_example_vpid">Bareflank Hypervisor VPID Example</a>
 /// <br>


### PR DESCRIPTION
This patch fixes the use of private for the VMCS and exit handler
members that extensions will need access to

Signed-off-by: “Rian <“rianquinn@gmail.com”>