### PR TITLE
Add Double Word Port IO

### DIFF
--- a/bfvmm/include/intrinsics/portio_x64.h
+++ b/bfvmm/include/intrinsics/portio_x64.h
@@ -26,9 +26,27 @@
 
 extern "C" uint8_t __inb(uint16_t port) noexcept;
 extern "C" uint16_t __inw(uint16_t port) noexcept;
+extern "C" uint32_t __ind(uint16_t port) noexcept;
+
+extern "C" void __insb(uint16_t port, uint64_t m8) noexcept;
+extern "C" void __insw(uint16_t port, uint64_t m16) noexcept;
+extern "C" void __insd(uint16_t port, uint64_t m32) noexcept;
+
+extern "C" void __insbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept;
+extern "C" void __inswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept;
+extern "C" void __insdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept;
 
 extern "C" void __outb(uint16_t port, uint8_t val) noexcept;
 extern "C" void __outw(uint16_t port, uint16_t val) noexcept;
+extern "C" void __outd(uint16_t port, uint32_t val) noexcept;
+
+extern "C" void __outsb(uint16_t port, uint64_t m8) noexcept;
+extern "C" void __outsw(uint16_t port, uint64_t m16) noexcept;
+extern "C" void __outsd(uint16_t port, uint64_t m32) noexcept;
+
+extern "C" void __outsbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept;
+extern "C" void __outswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept;
+extern "C" void __outsdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept;
 
 // *INDENT-OFF*
 
@@ -39,12 +57,54 @@ namespace portio
     using port_addr_type = uint16_t;
     using port_8bit_type = uint8_t;
     using port_16bit_type = uint16_t;
+    using port_32bit_type = uint32_t;
+    using integer_pointer = uintptr_t;
+    using size_type = uint32_t;
 
     template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
     auto inb(P port) noexcept { return __inb(gsl::narrow_cast<port_addr_type>(port)); }
 
     template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
     auto inw(P port) noexcept { return __inw(gsl::narrow_cast<port_addr_type>(port)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto ind(P port) noexcept { return __ind(gsl::narrow_cast<port_addr_type>(port)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insb(P port, integer_pointer m8) noexcept { return __insb(gsl::narrow_cast<port_addr_type>(port), m8); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insw(P port, integer_pointer m16) noexcept { return __insw(gsl::narrow_cast<port_addr_type>(port), m16); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insd(P port, integer_pointer m32) noexcept { return __insd(gsl::narrow_cast<port_addr_type>(port), m32); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insb(P port, void *m8) noexcept { return __insb(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m8)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insw(P port, void *m16) noexcept { return __insw(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m16)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insd(P port, void *m32) noexcept { return __insd(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m32)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insbrep(P port, integer_pointer m8, size_type count) noexcept { return __insbrep(gsl::narrow_cast<port_addr_type>(port), m8, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto inswrep(P port, integer_pointer m16, size_type count) noexcept { return __inswrep(gsl::narrow_cast<port_addr_type>(port), m16, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insdrep(P port, integer_pointer m32, size_type count) noexcept { return __insdrep(gsl::narrow_cast<port_addr_type>(port), m32, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insbrep(P port, void *m8, size_type count) noexcept { return __insbrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m8), count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto inswrep(P port, void *m16, size_type count) noexcept { return __inswrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m16), count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    auto insdrep(P port, void *m32, size_type count) noexcept { return __insdrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m32), count); }
 
     template<class P, class T,
              class = typename std::enable_if<std::is_integral<P>::value>::type,
@@ -55,6 +115,47 @@ namespace portio
              class = typename std::enable_if<std::is_integral<P>::value>::type,
              class = typename std::enable_if<std::is_integral<T>::value>::type>
     void outw(P port, T val) noexcept { __outw(gsl::narrow_cast<port_addr_type>(port), gsl::narrow_cast<port_16bit_type>(val)); }
+
+    template<class P, class T,
+             class = typename std::enable_if<std::is_integral<P>::value>::type,
+             class = typename std::enable_if<std::is_integral<T>::value>::type>
+    void outd(P port, T val) noexcept { __outd(gsl::narrow_cast<port_addr_type>(port), gsl::narrow_cast<port_32bit_type>(val)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsb(P port, integer_pointer m8) noexcept { __outsb(gsl::narrow_cast<port_addr_type>(port), m8); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsw(P port, integer_pointer m16) noexcept { __outsw(gsl::narrow_cast<port_addr_type>(port), m16); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsd(P port, integer_pointer m32) noexcept { __outsd(gsl::narrow_cast<port_addr_type>(port), m32); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsb(P port, void *m8) noexcept { __outsb(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m8)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsw(P port, void *m16) noexcept { __outsw(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m16)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsd(P port, void *m32) noexcept { __outsd(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m32)); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsbrep(P port, integer_pointer m8, size_type count) noexcept { __outsbrep(gsl::narrow_cast<port_addr_type>(port), m8, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outswrep(P port, integer_pointer m16, size_type count) noexcept { __outswrep(gsl::narrow_cast<port_addr_type>(port), m16, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsdrep(P port, integer_pointer m32, size_type count) noexcept { __outsdrep(gsl::narrow_cast<port_addr_type>(port), m32, count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsbrep(P port, void *m8, size_type count) noexcept { __outsbrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m8), count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outswrep(P port, void *m16, size_type count) noexcept { __outswrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m16), count); }
+
+    template<class P, class = typename std::enable_if<std::is_integral<P>::value>::type>
+    void outsdrep(P port, void *m32, size_type count) noexcept { __outsdrep(gsl::narrow_cast<port_addr_type>(port), reinterpret_cast<integer_pointer>(m32), count); }
 }
 }
 

--- a/bfvmm/src/intrinsics/src/portio_x64.asm
+++ b/bfvmm/src/intrinsics/src/portio_x64.asm
@@ -27,27 +27,146 @@ section .text
 global __inb:function
 __inb:
     xor rax, rax
-    mov dx, di
+    mov rdx, rdi
     in al, dx
     ret
 
 global __inw:function
 __inw:
     xor rax, rax
-    mov dx, di
+    mov rdx, rdi
     in ax, dx
+    ret
+
+global __ind:function
+__ind:
+    xor rax, rax
+    mov rdx, rdi
+    in eax, dx
+    ret
+
+global __insb:function
+__insb:
+    mov rdx, rdi
+    mov rdi, rsi
+    insb
+    xor rax, rax
+    ret
+
+global __insw:function
+__insw:
+    mov rdx, rdi
+    mov rdi, rsi
+    insw
+    xor rax, rax
+    ret
+
+global __insd:function
+__insd:
+    mov rdx, rdi
+    mov rdi, rsi
+    insd
+    xor rax, rax
+    ret
+
+global __insbrep:function
+__insbrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    rep insb
+    xor rax, rax
+    ret
+
+global __inswrep:function
+__inswrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    rep insw
+    xor rax, rax
+    ret
+
+global __insdrep:function
+__insdrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    rep insd
+    xor rax, rax
     ret
 
 global __outb:function
 __outb:
-    mov dx, di
-    mov ax, si
+    mov rdx, rdi
+    mov rax, rsi
     out dx, al
+    xor rax, rax
     ret
 
 global __outw:function
 __outw:
-    mov dx, di
-    mov ax, si
+    mov rdx, rdi
+    mov rax, rsi
     out dx, ax
+    xor rax, rax
+    ret
+
+global __outd:function
+__outd:
+    mov rdx, rdi
+    mov rax, rsi
+    out dx, eax
+    xor rax, rax
+    ret
+
+global __outbs:function
+__outbs:
+    mov rdx, rdi
+    mov rdi, rsi
+    outsb
+    xor rax, rax
+    ret
+
+global __outws:function
+__outws:
+    mov rdx, rdi
+    mov rdi, rsi
+    outsw
+    xor rax, rax
+    ret
+
+global __outds:function
+__outds:
+    mov rdx, rdi
+    mov rdi, rsi
+    outsd
+    xor rax, rax
+    ret
+
+global __outbsrep:function
+__outbsrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    outsb
+    xor rax, rax
+    ret
+
+global __outwsrep:function
+__outwsrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    outsw
+    xor rax, rax
+    ret
+
+global __outdsrep:function
+__outdsrep:
+    mov rcx, rdx
+    mov rdx, rdi
+    mov rdi, rsi
+    outsd
+    xor rax, rax
     ret

--- a/bfvmm/src/intrinsics/src/portio_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/portio_x64_mock.cpp
@@ -38,6 +38,71 @@ __attribute__((weak)) __inw(uint16_t port) noexcept
     abort();
 }
 
+extern "C" uint32_t
+__attribute__((weak)) __ind(uint16_t port) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __insb(uint16_t port, uint64_t m8) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m8: " << view_as_pointer(m8) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __insw(uint16_t port, uint64_t m16) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m16: " << view_as_pointer(m16) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __insd(uint16_t port, uint64_t m32) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m32: " << view_as_pointer(m32) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __insbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m8: " << view_as_pointer(m8) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __inswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m16: " << view_as_pointer(m16) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __insdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m32: " << view_as_pointer(m32) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
+    abort();
+}
+
 extern "C" void
 __attribute__((weak)) __outb(uint16_t port, uint8_t val) noexcept
 {
@@ -53,5 +118,71 @@ __attribute__((weak)) __outw(uint16_t port, uint16_t val) noexcept
     std::cerr << __FUNC__ << " called with: " << '\n';
     std::cerr << "    - port: " << view_as_pointer(port) << '\n';
     std::cerr << "    - val: " << view_as_pointer(val) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outd(uint16_t port, uint32_t val) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - val: " << view_as_pointer(val) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outsb(uint16_t port, uint64_t m8) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m8: " << view_as_pointer(m8) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outsw(uint16_t port, uint64_t m16) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m16: " << view_as_pointer(m16) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outsd(uint16_t port, uint64_t m32) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m32: " << view_as_pointer(m32) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outsbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m8: " << view_as_pointer(m8) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m16: " << view_as_pointer(m16) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __outsdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << '\n';
+    std::cerr << "    - port: " << view_as_pointer(port) << '\n';
+    std::cerr << "    - m32: " << view_as_pointer(m32) << '\n';
+    std::cerr << "    - count: " << view_as_pointer(count) << '\n';
     abort();
 }

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -340,6 +340,7 @@ intrinsics_ut::list()
 
     this->test_portio_x64_byte();
     this->test_portio_x64_word();
+    this->test_portio_x64_doubleword();
 
     this->test_vmx_intel_x64_vmxon_nullptr();
     this->test_vmx_intel_x64_vmxon_failure();

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -339,6 +339,7 @@ private:
 
     void test_portio_x64_byte();
     void test_portio_x64_word();
+    void test_portio_x64_doubleword();
 
     void test_vmx_intel_x64_vmxon_nullptr();
     void test_vmx_intel_x64_vmxon_failure();

--- a/bfvmm/src/intrinsics/test/test_portio_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_portio_x64.cpp
@@ -19,12 +19,19 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <vector>
+
 #include <test.h>
 #include <intrinsics/portio_x64.h>
 
 using namespace x64;
 
-std::map<portio::port_addr_type, portio::port_16bit_type> g_ports;
+constexpr const auto buf_size = 4;
+std::map<portio::port_addr_type, portio::port_32bit_type> g_ports;
+
+uint8_t g_buf_8bit[buf_size] = {};
+uint16_t g_buf_16bit[buf_size] = {};
+uint32_t g_buf_32bit[buf_size] = {};
 
 extern "C" uint8_t
 __inb(uint16_t port) noexcept
@@ -32,7 +39,35 @@ __inb(uint16_t port) noexcept
 
 extern "C" uint16_t
 __inw(uint16_t port) noexcept
-{ return g_ports[port]; }
+{ return gsl::narrow_cast<portio::port_16bit_type>(g_ports[port]); }
+
+extern "C" uint32_t
+__ind(uint16_t port) noexcept
+{ return gsl::narrow_cast<portio::port_32bit_type>(g_ports[port]); }
+
+extern "C" void
+__insb(uint16_t port, uint64_t m8) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m8), static_cast<void *>(g_buf_8bit), 1); }
+
+extern "C" void
+__insw(uint16_t port, uint64_t m16) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m16), static_cast<void *>(g_buf_16bit), 2); }
+
+extern "C" void
+__insd(uint16_t port, uint64_t m32) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m32), static_cast<void *>(g_buf_32bit), 4); }
+
+extern "C" void
+__insbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m8), static_cast<void *>(g_buf_8bit), count * 1); }
+
+extern "C" void
+__inswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m16), static_cast<void *>(g_buf_16bit), count * 2); }
+
+extern "C" void
+__insdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(reinterpret_cast<void *>(m32), static_cast<void *>(g_buf_32bit), count * 4); }
 
 extern "C" void
 __outb(uint16_t port, uint8_t val) noexcept
@@ -42,16 +77,129 @@ extern "C" void
 __outw(uint16_t port, uint16_t val) noexcept
 { g_ports[port] = val; }
 
+extern "C" void
+__outd(uint16_t port, uint32_t val) noexcept
+{ g_ports[port] = val; }
+
+extern "C" void
+__outsb(uint16_t port, uint64_t m8) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_8bit), reinterpret_cast<void *>(m8), 1); }
+
+extern "C" void
+__outsw(uint16_t port, uint64_t m16) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_16bit), reinterpret_cast<void *>(m16), 2); }
+
+extern "C" void
+__outsd(uint16_t port, uint64_t m32) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_32bit), reinterpret_cast<void *>(m32), 4); }
+
+extern "C" void
+__outsbrep(uint16_t port, uint64_t m8, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_8bit), reinterpret_cast<void *>(m8), count * 1); }
+
+extern "C" void
+__outswrep(uint16_t port, uint64_t m16, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_16bit), reinterpret_cast<void *>(m16), count * 2); }
+
+extern "C" void
+__outsdrep(uint16_t port, uint64_t m32, uint32_t count) noexcept
+{ (void) port; __builtin_memcpy(static_cast<void *>(g_buf_32bit), reinterpret_cast<void *>(m32), count * 4); }
+
 void
 intrinsics_ut::test_portio_x64_byte()
 {
+    std::vector<uint8_t> buf1 = {0, 1, 2, 3};
+    std::vector<uint8_t> buf2 = {42, 42, 42, 42};
+    std::vector<uint8_t> buf3 = {42, 42, 42, 42};
+
     portio::outb(10, 100U);
     this->expect_true(portio::inb(10) == 100U);
+
+    portio::outsb(10, buf1.data());
+    portio::insb(10, buf2.data());
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outsb(10, reinterpret_cast<portio::integer_pointer>(buf1.data()));
+    portio::insb(10, reinterpret_cast<portio::integer_pointer>(buf2.data()));
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outsbrep(10, buf1.data(), buf_size);
+    portio::insbrep(10, buf3.data(), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
+
+    portio::outsbrep(10, reinterpret_cast<portio::integer_pointer>(buf1.data()), buf_size);
+    portio::insbrep(10, reinterpret_cast<portio::integer_pointer>(buf3.data()), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
 }
 
 void
 intrinsics_ut::test_portio_x64_word()
 {
+    std::vector<uint16_t> buf1 = {0, 1, 2, 3};
+    std::vector<uint16_t> buf2 = {42, 42, 42, 42};
+    std::vector<uint16_t> buf3 = {42, 42, 42, 42};
+
     portio::outw(10, 10000U);
     this->expect_true(portio::inw(10) == 10000U);
+
+    portio::outsw(10, buf1.data());
+    portio::insw(10, buf2.data());
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outsw(10, reinterpret_cast<portio::integer_pointer>(buf1.data()));
+    portio::insw(10, reinterpret_cast<portio::integer_pointer>(buf2.data()));
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outswrep(10, buf1.data(), buf_size);
+    portio::inswrep(10, buf3.data(), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
+
+    portio::outswrep(10, reinterpret_cast<portio::integer_pointer>(buf1.data()), buf_size);
+    portio::inswrep(10, reinterpret_cast<portio::integer_pointer>(buf3.data()), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
+}
+
+void
+intrinsics_ut::test_portio_x64_doubleword()
+{
+    std::vector<uint32_t> buf1 = {0, 1, 2, 3};
+    std::vector<uint32_t> buf2 = {42, 42, 42, 42};
+    std::vector<uint32_t> buf3 = {42, 42, 42, 42};
+
+    portio::outd(10, 10000U);
+    this->expect_true(portio::ind(10) == 10000U);
+
+    portio::outsd(10, buf1.data());
+    portio::insd(10, buf2.data());
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outsd(10, reinterpret_cast<portio::integer_pointer>(buf1.data()));
+    portio::insd(10, reinterpret_cast<portio::integer_pointer>(buf2.data()));
+    this->expect_true(buf2.at(0) == 0);
+
+    portio::outsdrep(10, buf1.data(), buf_size);
+    portio::insdrep(10, buf3.data(), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
+
+    portio::outsdrep(10, reinterpret_cast<portio::integer_pointer>(buf1.data()), buf_size);
+    portio::insdrep(10, reinterpret_cast<portio::integer_pointer>(buf3.data()), buf_size);
+    this->expect_true(buf3.at(0) == 0);
+    this->expect_true(buf3.at(1) == 1);
+    this->expect_true(buf3.at(2) == 2);
+    this->expect_true(buf3.at(3) == 3);
 }


### PR DESCRIPTION
For some reason we only have byte and word, and we were missing
double word for portio, so this adds the missing API.

Signed-off-by: “Rian <“rianquinn@gmail.com”>