### PR TITLE
Add Cache Flush

### DIFF
--- a/bfvmm/include/intrinsics/cache_x64.h
+++ b/bfvmm/include/intrinsics/cache_x64.h
@@ -24,6 +24,7 @@
 
 extern "C" void __invd(void) noexcept;
 extern "C" void __wbinvd(void) noexcept;
+extern "C" void __clflush(void *addr) noexcept;
 
 // *INDENT-OFF*
 
@@ -31,11 +32,20 @@ namespace x64
 {
 namespace cache
 {
+    using pointer = void *;
+    using integer_pointer = uintptr_t;
+
     inline void invd() noexcept
     { __invd(); }
 
     inline void wbinvd() noexcept
     { __wbinvd(); }
+
+    inline void clflush(integer_pointer addr) noexcept
+    { __clflush(reinterpret_cast<pointer>(addr)); }
+
+    inline void clflush(pointer addr) noexcept
+    { __clflush(addr); }
 }
 }
 

--- a/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/test/test_exit_handler_intel_x64.cpp
@@ -105,6 +105,10 @@ __wbinvd(void) noexcept
 { }
 
 extern "C" void
+__clflush(void *addr) noexcept
+{ (void) addr; }
+
+extern "C" void
 __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
 { (void) eax; (void) ebx; (void) ecx; (void) edx; }
 

--- a/bfvmm/src/intrinsics/src/cache_x64.asm
+++ b/bfvmm/src/intrinsics/src/cache_x64.asm
@@ -33,3 +33,8 @@ global __wbinvd:function
 __wbinvd:
     wbinvd
     ret
+
+global __clflush:function
+__clflush:
+    clflush [rdi]
+    ret

--- a/bfvmm/src/intrinsics/src/cache_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/cache_x64_mock.cpp
@@ -35,3 +35,10 @@ __attribute__((weak)) __wbinvd(void) noexcept
     std::cerr << __FUNC__ << " called" << '\n';
     abort();
 }
+
+extern "C" void
+__attribute__((weak)) __clflush(void *addr) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << addr << '\n';
+    abort();
+}

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -409,6 +409,7 @@ intrinsics_ut::list()
 
     this->test_cache_x64_invd();
     this->test_cache_x64_wbinvd();
+    this->test_cache_x64_clflush();
 
     this->test_tlb_x64_invlpg();
 

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -408,6 +408,7 @@ private:
 
     void test_cache_x64_invd();
     void test_cache_x64_wbinvd();
+    void test_cache_x64_clflush();
 
     void test_tlb_x64_invlpg();
 

--- a/bfvmm/src/intrinsics/test/test_cache_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_cache_x64.cpp
@@ -32,6 +32,10 @@ extern "C" void
 __wbinvd(void) noexcept
 { }
 
+extern "C" void
+__clflush(void *addr) noexcept
+{ (void) addr; }
+
 void
 intrinsics_ut::test_cache_x64_invd()
 {
@@ -42,4 +46,11 @@ void
 intrinsics_ut::test_cache_x64_wbinvd()
 {
     this->expect_no_exception([&] { cache::wbinvd(); });
+}
+
+void
+intrinsics_ut::test_cache_x64_clflush()
+{
+    this->expect_no_exception([&] { cache::clflush(0x10); });
+    this->expect_no_exception([&] { cache::clflush(this); });
 }

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -124,6 +124,7 @@ memory_manager_ut::list()
     this->test_unique_map_ptr_x64_reset();
     this->test_unique_map_ptr_x64_swap();
     this->test_unique_map_ptr_x64_flush();
+    this->test_unique_map_ptr_x64_cache_flush();
     this->test_unique_map_ptr_x64_comparison();
     this->test_unique_map_ptr_x64_make_failure();
 

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -120,6 +120,7 @@ private:
     void test_unique_map_ptr_x64_reset();
     void test_unique_map_ptr_x64_swap();
     void test_unique_map_ptr_x64_flush();
+    void test_unique_map_ptr_x64_cache_flush();
     void test_unique_map_ptr_x64_comparison();
     void test_unique_map_ptr_x64_make_failure();
 


### PR DESCRIPTION
This adds the cache flush intrinsic, and adds cache flush to
unique_map. Altough it was working before, it seems sensible
to flush the cache on an unmap to ensure all mapped memory
is written.

Signed-off-by: “Rian <“rianquinn@gmail.com”>