### PR TITLE
Add Is Number to JSON

### DIFF
--- a/include/json.h
+++ b/include/json.h
@@ -2162,6 +2162,11 @@ public:
         return m_type == value_t::number_unsigned;
     }
 
+    constexpr bool is_number() const noexcept
+    {
+        return is_number_integer() || is_number_unsigned();
+    }
+
     /*!
     @brief return whether value is an object
 


### PR DESCRIPTION
For whatever reason I took this function out when I removed
floating point and it should be there.

Signed-off-by: “Rian <“rianquinn@gmail.com”>