### PR TITLE
Serial Bug

### DIFF
--- a/bfvmm/include/serial/serial_port_intel_x64.h
+++ b/bfvmm/include/serial/serial_port_intel_x64.h
@@ -30,11 +30,6 @@
 
 namespace serial_intel_x64
 {
-constexpr const x64::portio::port_addr_type com1_port = 0x3F8U;
-constexpr const x64::portio::port_addr_type com2_port = 0x2F8U;
-constexpr const x64::portio::port_addr_type com3_port = 0x3E8U;
-constexpr const x64::portio::port_addr_type com4_port = 0x2E8U;
-
 constexpr const x64::portio::port_8bit_type dlab = 1U << 7;
 
 constexpr const x64::portio::port_addr_type baud_rate_lo_reg = 0U;
@@ -135,7 +130,7 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    serial_port_intel_x64(port_type port = serial_intel_x64::DEFAULT_COM_PORT) noexcept;
+    serial_port_intel_x64(port_type port = DEFAULT_COM_PORT) noexcept;
 
     /// Destructor
     ///

--- a/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
+++ b/bfvmm/src/serial/test/test_serial_port_intel_x64.cpp
@@ -46,20 +46,20 @@ serial_ut::test_serial_null_intrinsics()
 void
 serial_ut::test_serial_success()
 {
-    this->expect_true(serial_port_intel_x64::instance()->port() == serial_intel_x64::DEFAULT_COM_PORT);
+    this->expect_true(serial_port_intel_x64::instance()->port() == DEFAULT_COM_PORT);
     this->expect_true(serial_port_intel_x64::instance()->baud_rate() == serial_port_intel_x64::DEFAULT_BAUD_RATE);
     this->expect_true(serial_port_intel_x64::instance()->data_bits() == serial_port_intel_x64::DEFAULT_DATA_BITS);
     this->expect_true(serial_port_intel_x64::instance()->stop_bits() == serial_port_intel_x64::DEFAULT_STOP_BITS);
     this->expect_true(serial_port_intel_x64::instance()->parity_bits() == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_lo_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::baud_rate_hi_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_enable_fifos) != 0);
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_recieve_fifo) != 0);
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_transmit_fifo) != 0);
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_data_mask) == serial_port_intel_x64::DEFAULT_DATA_BITS);
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_stop_mask) == serial_port_intel_x64::DEFAULT_STOP_BITS);
-    this->expect_true((g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_parity_mask) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::baud_rate_lo_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0x00FF) >> 0));
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::baud_rate_hi_reg]) == ((serial_port_intel_x64::DEFAULT_BAUD_RATE & 0xFF00) >> 8));
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_enable_fifos) != 0);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_recieve_fifo) != 0);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::fifo_control_reg] & serial_intel_x64::fifo_control_clear_transmit_fifo) != 0);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_data_mask) == serial_port_intel_x64::DEFAULT_DATA_BITS);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_stop_mask) == serial_port_intel_x64::DEFAULT_STOP_BITS);
+    this->expect_true((g_ports[DEFAULT_COM_PORT + serial_intel_x64::line_control_reg] & serial_intel_x64::line_control_parity_mask) == serial_port_intel_x64::DEFAULT_PARITY_BITS);
 }
 
 void
@@ -190,7 +190,7 @@ serial_ut::test_serial_set_parity_bits_success_extra_bits()
 void
 serial_ut::test_serial_write_character()
 {
-    g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
+    g_ports[DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
 
     auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write('c');
@@ -199,7 +199,7 @@ serial_ut::test_serial_write_character()
 void
 serial_ut::test_serial_write_string()
 {
-    g_ports[serial_intel_x64::DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
+    g_ports[DEFAULT_COM_PORT + serial_intel_x64::line_status_reg] = 0xFF;
 
     auto serial = std::make_unique<serial_port_intel_x64>();
     serial->write("hello world");

--- a/include/constants.h
+++ b/include/constants.h
@@ -276,10 +276,18 @@
 /**
  * Default Serial COM Port
  *
+ * Possible values include:
+ *    - 0x3F8U  // COM1
+ *    - 0x2F8U  // COM2
+ *    - 0x3E8U  // COM3
+ *    - 0x2E8U  // COM4
+ *    - 0xE000
+ *    - 0xE010
+ *
  * Note: See bfvmm/serial/serial_port_intel_x64.h
  */
 #ifndef DEFAULT_COM_PORT
-#define DEFAULT_COM_PORT com1_port
+#define DEFAULT_COM_PORT 0x3F8U
 #endif
 
 /**


### PR DESCRIPTION
The predefined port #s don't work in the serial namespace becasue
we cannot define all possible port #s. This became apparent when
trying to use the PCI based serial ports that were not predefined.
This patch gets rid of the predefine port numbers, allowing any
port number to be used.

Signed-off-by: “Rian <“rianquinn@gmail.com”>