### PR TITLE
Global should be static

### DIFF
--- a/bfvmm/src/memory_manager/src/page_table_entry_x64.cpp
+++ b/bfvmm/src/memory_manager/src/page_table_entry_x64.cpp
@@ -25,7 +25,7 @@
 #include <intrinsics/x64.h>
 using namespace x64;
 
-page_table_entry_x64::integer_pointer g_invalid_pte = 0;
+static page_table_entry_x64::integer_pointer g_invalid_pte = 0;
 
 page_table_entry_x64::page_table_entry_x64() noexcept :
     m_pte(&g_invalid_pte)


### PR DESCRIPTION
No reason for this variable to be non-static

Signed-off-by: “Rian <“rianquinn@gmail.com”>