### PR TITLE
Debian Stretch Bug

### DIFF
--- a/tools/scripts/setup_debian.sh
+++ b/tools/scripts/setup_debian.sh
@@ -78,7 +78,7 @@ prepare_docker() {
 # Setup System
 # ------------------------------------------------------------------------------
 
-case $( grep ^VERSION_ID= /etc/os-release | cut -d'=' -f 2 | tr -d '"' ) in
+case $(lsb_release -sr) in
 testing)
     install_apt_tools
     add_docker_repositories


### PR DESCRIPTION
Debian doesn't provide a VERSION_ID so it's setup script was
broken once we updated to using os-release instead of
lsb_release. This fixes that issue:

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/388

Signed-off-by: “Rian <“rianquinn@gmail.com”>