### PR TITLE
Clang Tidy Fix / VMCall CPUID Fix

### DIFF
--- a/bfdrivers/src/common.c
+++ b/bfdrivers/src/common.c
@@ -624,19 +624,23 @@ common_vmcall(struct vmcall_registers_t *regs, uint64_t cpuid)
     if (regs == 0)
         return BF_ERROR_INVALID_ARG;
 
-    if (signed_cpuid < 0 || signed_cpuid >= g_num_cpus_started)
+    if (signed_cpuid >= g_num_cpus_started)
         return BF_ERROR_INVALID_ARG;
 
-    ret = caller_affinity = platform_set_affinity((int64_t)cpuid);
-    if (caller_affinity < 0)
-        return ret;
+    if (signed_cpuid >= 0)
+    {
+        ret = caller_affinity = platform_set_affinity((int64_t)cpuid);
+        if (caller_affinity < 0)
+            return ret;
+    }
 
     if (regs->r00 == VMCALL_EVENT)
         platform_vmcall_event(regs);
     else
         platform_vmcall(regs);
 
-    platform_restore_affinity(caller_affinity);
+    if (signed_cpuid >= 0)
+        platform_restore_affinity(caller_affinity);
 
     return BF_SUCCESS;
 }

--- a/bfdrivers/test/test_common_vmcall.cpp
+++ b/bfdrivers/test/test_common_vmcall.cpp
@@ -35,7 +35,6 @@ driver_entry_ut::test_common_vmcall_invalid_args()
 
     this->expect_true(common_vmcall(nullptr, 0) == BF_ERROR_INVALID_ARG);
     this->expect_true(common_vmcall(&regs, 10) == BF_ERROR_INVALID_ARG);
-    this->expect_true(common_vmcall(&regs, 0xFFFFFFFFFFFFFFFF) == BF_ERROR_INVALID_ARG);
 }
 
 void
@@ -74,6 +73,7 @@ driver_entry_ut::test_common_vmcall_success()
     this->expect_true(common_start_vmm() == BF_SUCCESS);
 
     this->expect_true(common_vmcall(&regs, 0) == BF_SUCCESS);
+    this->expect_true(common_vmcall(&regs, 0xFFFFFFFFFFFFFFFF) == BF_SUCCESS);
 
     this->expect_true(common_stop_vmm() == BF_SUCCESS);
     this->expect_true(common_unload_vmm() == BF_SUCCESS);
@@ -93,6 +93,7 @@ driver_entry_ut::test_common_vmcall_success_event()
     this->expect_true(common_start_vmm() == BF_SUCCESS);
 
     this->expect_true(common_vmcall(&regs, 0) == BF_SUCCESS);
+    this->expect_true(common_vmcall(&regs, 0xFFFFFFFFFFFFFFFF) == BF_SUCCESS);
 
     this->expect_true(common_stop_vmm() == BF_SUCCESS);
     this->expect_true(common_unload_vmm() == BF_SUCCESS);

--- a/tools/scripts/verify_source.sh
+++ b/tools/scripts/verify_source.sh
@@ -161,6 +161,10 @@ if ls src_*/ 1> /dev/null 2>&1; then
         run_clang_tidy "mode*,-clang-analyzer*"
         popd > /dev/null
     done
+
+    if [[ $SRC_EXTENSION == "true" ]]; then
+        exit 0
+    fi
 fi
 
 #
@@ -179,6 +183,10 @@ if ls hypervisor_*/ 1> /dev/null 2>&1; then
         run_clang_tidy "mode*,-clang-analyzer*"
         popd > /dev/null
     done
+
+    if [[ $HYPERVISOR_EXTENSION == "true" ]]; then
+        exit 0
+    fi
 fi
 
 #
@@ -195,6 +203,10 @@ if [[ -d hyperkernel ]]; then
     run_clang_tidy "read*,-clang-analyzer*,-readability-braces-around-statements"
     run_clang_tidy "mode*,-clang-analyzer*"
     popd > /dev/null
+
+    if [[ $HYPERKERNEL_EXTENSION == "true" ]]; then
+        exit 0
+    fi
 fi
 
 #
@@ -211,6 +223,10 @@ if [[ -d extended_apis ]]; then
     run_clang_tidy "read*,-clang-analyzer*,-readability-braces-around-statements"
     run_clang_tidy "mode*,-clang-analyzer*"
     popd > /dev/null
+
+    if [[ $EXTENDED_APIS_EXTENSION == "true" ]]; then
+        exit 0
+    fi
 fi
 
 verify_bfvmm() {


### PR DESCRIPTION
We need a way to prevent the affinity from always being changed
on a vmcall. Passing -1 as the CPUID will do this. Also, fixed
and issue with Clang Tidy that was causing the other repos
from verifying stuff they don't care about

Signed-off-by: “Rian <“rianquinn@gmail.com”>