### PR TITLE
Bug Fixes

### DIFF
--- a/bfdrivers/src/common.c
+++ b/bfdrivers/src/common.c
@@ -461,7 +461,17 @@ common_load_vmm(void)
             goto failure;
     }
 
-    add_raw_md_to_memory_manager((uint64_t)g_tls, MEMORY_TYPE_R | MEMORY_TYPE_W);
+    {
+        uint64_t tlss = (uint64_t)g_tls;
+        uint64_t tlse = tlss + g_tls_size;
+
+        for (; tlss <= tlse; tlss += MAX_PAGE_SIZE)
+        {
+            ret = add_raw_md_to_memory_manager(tlss, MEMORY_TYPE_R | MEMORY_TYPE_W);
+            if (ret != BF_SUCCESS)
+                return ret;
+        }
+    }
 
     g_vmm_status = VMM_LOADED;
     return BF_SUCCESS;
@@ -620,6 +630,15 @@ common_vmcall(struct vmcall_registers_t *regs, uint64_t cpuid)
     int64_t ret = 0;
     int64_t caller_affinity = 0;
     int64_t signed_cpuid = (int64_t)cpuid;
+
+    if (common_vmm_status() == VMM_CORRUPT)
+        return BF_ERROR_VMM_CORRUPTED;
+
+    if (common_vmm_status() == VMM_LOADED)
+        return BF_ERROR_VMM_INVALID_STATE;
+
+    if (common_vmm_status() == VMM_UNLOADED)
+        return BF_ERROR_VMM_INVALID_STATE;
 
     if (regs == 0)
         return BF_ERROR_INVALID_ARG;

--- a/bfdrivers/test/test.cpp
+++ b/bfdrivers/test/test.cpp
@@ -154,6 +154,7 @@ driver_entry_ut::list()
     this->test_common_load_fail_due_to_relocation_error();
     this->test_common_load_fail_due_to_no_modules_added();
     this->test_common_load_add_md_failed();
+    this->test_common_load_add_md_tls_failed();
     this->test_common_load_tls_platform_alloc_failed();
     this->test_common_load_stack_platform_alloc_failed();
     this->test_common_load_loader_add_failed();
@@ -194,6 +195,9 @@ driver_entry_ut::list()
     this->test_common_vmcall_set_affinity_failure();
     this->test_common_vmcall_success();
     this->test_common_vmcall_success_event();
+    this->test_common_vmcall_vmcall_when_unloaded();
+    this->test_common_vmcall_vmcall_when_corrupt();
+    this->test_common_vmcall_vmcall_when_loaded();
 
     this->test_helper_common_vmm_status();
     this->test_helper_get_file_invalid_index();

--- a/bfdrivers/test/test.h
+++ b/bfdrivers/test/test.h
@@ -70,6 +70,7 @@ private:
     void test_common_load_fail_due_to_relocation_error();
     void test_common_load_fail_due_to_no_modules_added();
     void test_common_load_add_md_failed();
+    void test_common_load_add_md_tls_failed();
     void test_common_load_tls_platform_alloc_failed();
     void test_common_load_stack_platform_alloc_failed();
     void test_common_load_loader_add_failed();
@@ -110,6 +111,9 @@ private:
     void test_common_vmcall_set_affinity_failure();
     void test_common_vmcall_success();
     void test_common_vmcall_success_event();
+    void test_common_vmcall_vmcall_when_unloaded();
+    void test_common_vmcall_vmcall_when_corrupt();
+    void test_common_vmcall_vmcall_when_loaded();
 
     void test_helper_common_vmm_status();
     void test_helper_get_file_invalid_index();

--- a/tools/tests/test_hypervisor.sh
+++ b/tools/tests/test_hypervisor.sh
@@ -29,7 +29,13 @@ CC='\033[1;36m'
 CG='\033[1;32m'
 CE='\033[0m'
 
+# ------------------------------------------------------------------------------
+# Environment
+# ------------------------------------------------------------------------------
+
 export INCLUDE_LIBCXX_UNITTESTS=yes
+
+NUM_CORES=`grep -c ^processor /proc/cpuinfo`
 
 # ------------------------------------------------------------------------------
 # Tests
@@ -63,96 +69,117 @@ turn_off_tests() {
 }
 
 vmcall_version() {
-    echo -e "$CC""testing:$CB vmcall_version$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="versions 0" make vmcall
-    ARGS="versions 1" make vmcall
-    ARGS="versions 10" make vmcall
-    ARGS="versions 100" make vmcall || true
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_version on core #$core$CE"
+        ARGS="--cpuid $core versions 0" make vmcall
+        ARGS="--cpuid $core versions 1" make vmcall
+        ARGS="--cpuid $core versions 10" make vmcall
+        ARGS="--cpuid $core versions 100" make vmcall > /dev/null 2>&1 || true
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_registers() {
-    echo -e "$CC""testing:$CB vmcall_registers$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="registers 1" make vmcall
-    ARGS="registers 1 2 3 4 5 6 7 8 9 10 11" make vmcall
-    ARGS="registers 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16" make vmcall
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_registers on core #$core$CE"
+        ARGS="--cpuid $core registers 1" make vmcall
+        ARGS="--cpuid $core registers 1 2 3 4 5 6 7 8 9 10 11" make vmcall
+        ARGS="--cpuid $core registers 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16" make vmcall
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_event() {
-    echo -e "$CC""testing:$CB vmcall_event$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="event 1" make vmcall
-    ARGS="event 2" make vmcall
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_event on core #$core$CE"
+        ARGS="--cpuid $core event 1" make vmcall
+        ARGS="--cpuid $core event 2" make vmcall
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_unittest() {
-    echo -e "$CC""testing:$CB vmcall_unittest$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    echo -e ""
-    ARGS="unittest 0x1001" make vmcall
-    ARGS="unittest 0x1002" make vmcall
-    ARGS="unittest 0x1003" make vmcall
-    ARGS="unittest 0x1004" make vmcall
-    ARGS="unittest 0x1005" make vmcall
-    ARGS="unittest 0x1006" make vmcall
-    ARGS="unittest 0x1007" make vmcall
-    ARGS="unittest 0x1008" make vmcall
-    ARGS="unittest 0x1009" make vmcall
-    ARGS="unittest 0x100A" make vmcall
-    ARGS="unittest 0x1100" make vmcall
-    ARGS="unittest 0x1101" make vmcall
-    echo -e ""
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_unittest on core #$core$CE"
+        echo -e ""
+        ARGS="--cpuid $core unittest 0x1001" make vmcall
+        ARGS="--cpuid $core unittest 0x1002" make vmcall
+        ARGS="--cpuid $core unittest 0x1003" make vmcall
+        ARGS="--cpuid $core unittest 0x1004" make vmcall
+        ARGS="--cpuid $core unittest 0x1005" make vmcall
+        ARGS="--cpuid $core unittest 0x1006" make vmcall
+        ARGS="--cpuid $core unittest 0x1007" make vmcall
+        ARGS="--cpuid $core unittest 0x1008" make vmcall
+        ARGS="--cpuid $core unittest 0x1009" make vmcall
+        ARGS="--cpuid $core unittest 0x100A" make vmcall
+        ARGS="--cpuid $core unittest 0x1100" make vmcall
+        ARGS="--cpuid $core unittest 0x1101" make vmcall
+        echo -e ""
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_string_unformatted() {
-    echo -e "$CC""testing:$CB vmcall_string_unformatted$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="string unformatted 'hello world'" make vmcall
-    ARGS="string unformatted 'hello world'" make vmcall
-    ARGS="string unformatted 'hello world'" make vmcall
-    ARGS="string unformatted 'hello world'" make vmcall
-    ARGS="string unformatted 'hello world'" make vmcall
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_string_unformatted on core #$core$CE"
+        ARGS="--cpuid $core string unformatted 'hello world'" make vmcall
+        ARGS="--cpuid $core string unformatted 'hello world'" make vmcall
+        ARGS="--cpuid $core string unformatted 'hello world'" make vmcall
+        ARGS="--cpuid $core string unformatted 'hello world'" make vmcall
+        ARGS="--cpuid $core string unformatted 'hello world'" make vmcall
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_string_json() {
-    echo -e "$CC""testing:$CB vmcall_string_json$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    ARGS="string json '{\"msg\":\"hello world\"}'" make vmcall
-    ARGS="string json '{\"msg\":\"hello world\"}'" make vmcall
-    ARGS="string json '{\"msg\":\"hello world\"}'" make vmcall
-    ARGS="string json '{\"msg\":\"hello world\"}'" make vmcall
-    ARGS="string json '{\"msg\":\"hello world\"}'" make vmcall
-    ARGS="string json 'hello world'" make vmcall || true
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_string_json on core #$core$CE"
+        ARGS="--cpuid $core string json '{\"msg\":\"hello world\"}'" make vmcall
+        ARGS="--cpuid $core string json '{\"msg\":\"hello world\"}'" make vmcall
+        ARGS="--cpuid $core string json '{\"msg\":\"hello world\"}'" make vmcall
+        ARGS="--cpuid $core string json '{\"msg\":\"hello world\"}'" make vmcall
+        ARGS="--cpuid $core string json '{\"msg\":\"hello world\"}'" make vmcall
+        ARGS="--cpuid $core string json 'hello world'" make vmcall > /dev/null 2>&1 || true
+    done
     make driver_unload > /dev/null 2>&1
 }
 
 vmcall_data_unformatted() {
-    echo -e "$CC""testing:$CB vmcall_data_unformatted$CE"
     make driver_load > /dev/null 2>&1
     make quick
-    rm -Rf /tmp/test_indata.txt
-    rm -Rf /tmp/test_outdata.txt
-    echo "hello world" > /tmp/test_indata.txt
-    ARGS="data unformatted /tmp/test_indata.txt /tmp/test_outdata.txt" make vmcall
-    if cmp -s "/tmp/test_indata.txt" "/tmp/test_outdata.txt"; then
+    for (( core=0; core<$NUM_CORES; core++ ))
+    do
+        echo -e "$CC""testing:$CB vmcall_data_unformatted on core #$core$CE"
         rm -Rf /tmp/test_indata.txt
         rm -Rf /tmp/test_outdata.txt
-    else
-        echo "ERROR: binary files do not match"
-        exit 1
-    fi
+        echo "hello world" > /tmp/test_indata.txt
+        ARGS="--cpuid $core data unformatted /tmp/test_indata.txt /tmp/test_outdata.txt" make vmcall
+        if cmp -s "/tmp/test_indata.txt" "/tmp/test_outdata.txt"; then
+            rm -Rf /tmp/test_indata.txt
+            rm -Rf /tmp/test_outdata.txt
+        else
+            echo "ERROR: binary files do not match"
+            exit 1
+        fi
+    done
     make driver_unload > /dev/null 2>&1
 }
 


### PR DESCRIPTION
This patch fixes too issues with the bfdriver. The first issue
is we were not verifying that the VMM was running when doing
a vmcall which causes all sorts of nasty things to happen if you
vmcall at the wrong time.

The second issue this addresses is we were not mapping in the
TLS data for all of the cores. We were only mapping in the
TLS for core 0. Not to mention we were never checking the
error case for the map in the first place, so this code was
just wrong on so many levels.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/394
[ISSUE]: https://github.com/Bareflank/hypervisor/issues/392

Signed-off-by: “Rian <“rianquinn@gmail.com”>