### PR TITLE
CR3 / Paging Update

### DIFF
--- a/bfvmm/include/memory_manager/page_table_entry_x64.h
+++ b/bfvmm/include/memory_manager/page_table_entry_x64.h
@@ -80,28 +80,21 @@ public:
     using integer_pointer = uintptr_t;
     using pat_index_type = uint64_t;
 
-    /// Invalid Constructor
-    ///
-    /// @expects none
-    /// @ensures none
-    ///
-    page_table_entry_x64() noexcept;
-
-    /// Default Constructor
+    /// PTE Constructor
     ///
     /// @expects pte != nullptr
     /// @ensures none
     ///
     /// @param pte the pte that this page table entry encapsulates.
     ///
-    page_table_entry_x64(const gsl::not_null<pointer> &pte) noexcept;
+    page_table_entry_x64(gsl::not_null<pointer> pte) noexcept;
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    virtual ~page_table_entry_x64() = default;
+    ~page_table_entry_x64() = default;
 
     /// Present
     ///

--- a/bfvmm/include/memory_manager/page_table_x64.h
+++ b/bfvmm/include/memory_manager/page_table_x64.h
@@ -28,7 +28,7 @@
 #include <memory>
 #include <memory_manager/page_table_entry_x64.h>
 
-class page_table_x64 : public page_table_entry_x64
+class page_table_x64
 {
 public:
 
@@ -47,26 +47,16 @@ public:
     ///
     /// @param pte the parent page table entry that points to this table
     ///
-    page_table_x64(pointer pte = nullptr);
+    page_table_x64(gsl::not_null<pointer> pte);
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    ~page_table_x64() override = default;
+    ~page_table_x64() = default;
 
-    /// Global Size
-    ///
-    /// @expects none
-    /// @ensures none
-    ///
-    /// @return returns the number of entries in the entire page table
-    ///     tree. Note that this function is expensive.
-    ///
-    size_type global_size() const noexcept;
-
-    /// Add Page
+    /// Add Page (1g Granularity)
     ///
     /// Adds a page to the page table structure. Note that this is the
     /// public function, and should only be used to add pages to the
@@ -74,14 +64,51 @@ public:
     /// will parse through the different levels making sure the virtual
     /// address provided is valid.
     ///
-    /// @expects virt_addr != 0
+    /// @expects none
     /// @ensures none
     ///
-    /// @param virt_addr the virtual address to the page to add
+    /// @param addr the virtual address to the page to add
     /// @return the resulting pte. Note that this pte is blank, and its
     ///     properties (like present) should be set by the caller
     ///
-    gsl::not_null<page_table_entry_x64 *> add_page_x64(integer_pointer virt_addr);
+    page_table_entry_x64 add_page_1g(integer_pointer addr)
+    { return add_page(addr, x64::page_table::pml4::from, x64::page_table::pdpt::from); }
+
+    /// Add Page (2m Granularity)
+    ///
+    /// Adds a page to the page table structure. Note that this is the
+    /// public function, and should only be used to add pages to the
+    /// PML4 page table. This function will call a private version that
+    /// will parse through the different levels making sure the virtual
+    /// address provided is valid.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param addr the virtual address to the page to add
+    /// @return the resulting pte. Note that this pte is blank, and its
+    ///     properties (like present) should be set by the caller
+    ///
+    page_table_entry_x64 add_page_2m(integer_pointer addr)
+    { return add_page(addr, x64::page_table::pml4::from, x64::page_table::pd::from); }
+
+    /// Add Page (4k Granularity)
+    ///
+    /// Adds a page to the page table structure. Note that this is the
+    /// public function, and should only be used to add pages to the
+    /// PML4 page table. This function will call a private version that
+    /// will parse through the different levels making sure the virtual
+    /// address provided is valid.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param addr the virtual address to the page to add
+    /// @return the resulting pte. Note that this pte is blank, and its
+    ///     properties (like present) should be set by the caller
+    ///
+    page_table_entry_x64 add_page_4k(integer_pointer addr)
+    { return add_page(addr, x64::page_table::pml4::from, x64::page_table::pt::from); }
 
     /// Remove Page
     ///
@@ -91,42 +118,43 @@ public:
     /// occurs side by side with addresses that are similar (page tables will
     /// be needlessly removed)
     ///
-    /// @expects virt_addr != 0
+    /// @expects none
     /// @ensures none
     ///
-    /// @param virt_addr the virtual address of the page to remove
+    /// @param addr the virtual address of the page to remove
     ///
-    void remove_page_x64(integer_pointer virt_addr);
+    void remove_page(integer_pointer addr)
+    { remove_page(addr, x64::page_table::pml4::from); }
 
-    /// CR3 Shadow
+    /// Virt to Page Table Entry
+    ///
+    /// Returns the PTE associated with the provided virtual address. If no
+    /// PTE exists for the virtual address provided, an exception is thrown.
     ///
     /// @expects none
     /// @ensures none
     ///
-    /// @return returns the CR3 shadow
+    /// @param addr the virtual address of the pte to locate
     ///
-    auto cr3_shadow() const noexcept
-    { return m_cr3_shadow; }
+    page_table_entry_x64 virt_to_pte(integer_pointer addr)
+    { return virt_to_pte(addr, x64::page_table::pml4::from); }
 
 private:
 
-    template<class T> std::unique_ptr<T> add_pte(pointer p);
-    template<class T> std::unique_ptr<T> remove_pte();
+    page_table_entry_x64 add_page(integer_pointer addr, integer_pointer bits, integer_pointer end);
+    void remove_page(integer_pointer addr, integer_pointer bits);
+    page_table_entry_x64 virt_to_pte(integer_pointer addr, integer_pointer bits);
 
-    gsl::not_null<page_table_entry_x64 *> add_page_x64(integer_pointer virt_addr, integer_pointer bits);
-    void remove_page_x64(integer_pointer virt_addr, integer_pointer bits);
-
-    auto empty() const noexcept
-    { return m_size == 0; }
+    bool empty() const noexcept;
+    size_type global_size() const noexcept;
+    size_type global_capacity() const noexcept;
 
 private:
 
-    gsl::span<integer_pointer> m_pt;
-    std::unique_ptr<integer_pointer[]> m_pt_owner;
+    friend class memory_manager_ut;
 
-    size_type m_size;
-    integer_pointer m_cr3_shadow;
-    std::vector<std::unique_ptr<page_table_entry_x64>> m_ptes;
+    std::unique_ptr<integer_pointer[]> m_pt;
+    std::vector<std::unique_ptr<page_table_x64>> m_pts;
 
 public:
 

--- a/bfvmm/include/memory_manager/root_page_table_x64.h
+++ b/bfvmm/include/memory_manager/root_page_table_x64.h
@@ -118,7 +118,7 @@ private:
 
     root_page_table_x64() noexcept;
 
-    gsl::not_null<page_table_entry_x64 *> add_page(integer_pointer virt);
+    page_table_entry_x64 add_page(integer_pointer virt);
     void remove_page(integer_pointer virt);
 
     void map_page(integer_pointer virt, integer_pointer phys, attr_type attr);
@@ -126,6 +126,7 @@ private:
 
 private:
 
+    integer_pointer m_cr3;
     std::unique_ptr<page_table_x64> m_root_pt;
 
 public:

--- a/bfvmm/src/memory_manager/src/page_table_entry_x64.cpp
+++ b/bfvmm/src/memory_manager/src/page_table_entry_x64.cpp
@@ -25,13 +25,7 @@
 #include <intrinsics/x64.h>
 using namespace x64;
 
-static page_table_entry_x64::integer_pointer g_invalid_pte = 0;
-
-page_table_entry_x64::page_table_entry_x64() noexcept :
-    m_pte(&g_invalid_pte)
-{ }
-
-page_table_entry_x64::page_table_entry_x64(const gsl::not_null<pointer> &pte) noexcept :
+page_table_entry_x64::page_table_entry_x64(gsl::not_null<pointer> pte) noexcept :
     m_pte(pte.get())
 { }
 

--- a/bfvmm/src/memory_manager/test/test.cpp
+++ b/bfvmm/src/memory_manager/test/test.cpp
@@ -82,15 +82,17 @@ memory_manager_ut::list()
     this->test_memory_manager_x64_virtint_to_attrint_random_address();
     this->test_memory_manager_x64_virtint_to_attrint_nullptr();
 
-    this->test_page_table_x64_no_entry();
-    this->test_page_table_x64_with_entry();
-    this->test_page_table_x64_add_remove_page_success();
-    this->test_page_table_x64_add_remove_many_pages_success();
-    this->test_page_table_x64_add_page_twice_failure();
-    this->test_page_table_x64_remove_page_twice_failure();
-    this->test_page_table_x64_remove_page_unknown_failure();
+    this->test_page_table_x64_add_remove_page_success_without_setting();
+    this->test_page_table_x64_add_remove_page_1g_success();
+    this->test_page_table_x64_add_remove_page_2m_success();
+    this->test_page_table_x64_add_remove_page_4k_success();
+    this->test_page_table_x64_add_remove_page_swap_success();
+    this->test_page_table_x64_add_page_twice_success();
+    this->test_page_table_x64_remove_page_twice_success();
+    this->test_page_table_x64_remove_page_unknown_success();
+    this->test_page_table_x64_virt_to_pte_invalid();
+    this->test_page_table_x64_virt_to_pte_success();
 
-    this->test_page_table_entry_x64_invalid();
     this->test_page_table_entry_x64_present();
     this->test_page_table_entry_x64_rw();
     this->test_page_table_entry_x64_us();
@@ -115,8 +117,11 @@ memory_manager_ut::list()
     this->test_unique_map_ptr_x64_phys_range_constructor_success();
     this->test_unique_map_ptr_x64_virt_cr3_constructor_invalid_args();
     this->test_unique_map_ptr_x64_virt_cr3_constructor_mm_map_fails();
-    this->test_unique_map_ptr_x64_virt_cr3_constructor_success();
-    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_large_page();
+    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_1g();
+    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_2m();
+    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_4k();
+    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_4k_aligned_addr();
+    this->test_unique_map_ptr_x64_virt_cr3_constructor_success_4k_aligned_size();
     this->test_unique_map_ptr_x64_virt_cr3_constructor_not_present();
     this->test_unique_map_ptr_x64_virt_cr3_constructor_invalid_phys_addr();
     this->test_unique_map_ptr_x64_copy_constructor();
@@ -130,6 +135,10 @@ memory_manager_ut::list()
     this->test_unique_map_ptr_x64_cache_flush();
     this->test_unique_map_ptr_x64_comparison();
     this->test_unique_map_ptr_x64_make_failure();
+    this->test_virt_to_phys_with_cr3_invalid();
+    this->test_virt_to_phys_with_cr3_1g();
+    this->test_virt_to_phys_with_cr3_2m();
+    this->test_virt_to_phys_with_cr3_4k();
 
     this->test_root_page_table_x64_init_failure();
     this->test_root_page_table_x64_init_success();

--- a/bfvmm/src/memory_manager/test/test.h
+++ b/bfvmm/src/memory_manager/test/test.h
@@ -78,15 +78,17 @@ private:
     void test_memory_manager_x64_virtint_to_attrint_random_address();
     void test_memory_manager_x64_virtint_to_attrint_nullptr();
 
-    void test_page_table_x64_no_entry();
-    void test_page_table_x64_with_entry();
-    void test_page_table_x64_add_remove_page_success();
-    void test_page_table_x64_add_remove_many_pages_success();
-    void test_page_table_x64_add_page_twice_failure();
-    void test_page_table_x64_remove_page_twice_failure();
-    void test_page_table_x64_remove_page_unknown_failure();
+    void test_page_table_x64_add_remove_page_success_without_setting();
+    void test_page_table_x64_add_remove_page_1g_success();
+    void test_page_table_x64_add_remove_page_2m_success();
+    void test_page_table_x64_add_remove_page_4k_success();
+    void test_page_table_x64_add_remove_page_swap_success();
+    void test_page_table_x64_add_page_twice_success();
+    void test_page_table_x64_remove_page_twice_success();
+    void test_page_table_x64_remove_page_unknown_success();
+    void test_page_table_x64_virt_to_pte_invalid();
+    void test_page_table_x64_virt_to_pte_success();
 
-    void test_page_table_entry_x64_invalid();
     void test_page_table_entry_x64_present();
     void test_page_table_entry_x64_rw();
     void test_page_table_entry_x64_us();
@@ -111,8 +113,11 @@ private:
     void test_unique_map_ptr_x64_phys_range_constructor_success();
     void test_unique_map_ptr_x64_virt_cr3_constructor_invalid_args();
     void test_unique_map_ptr_x64_virt_cr3_constructor_mm_map_fails();
-    void test_unique_map_ptr_x64_virt_cr3_constructor_success();
-    void test_unique_map_ptr_x64_virt_cr3_constructor_success_large_page();
+    void test_unique_map_ptr_x64_virt_cr3_constructor_success_1g();
+    void test_unique_map_ptr_x64_virt_cr3_constructor_success_2m();
+    void test_unique_map_ptr_x64_virt_cr3_constructor_success_4k();
+    void test_unique_map_ptr_x64_virt_cr3_constructor_success_4k_aligned_addr();
+    void test_unique_map_ptr_x64_virt_cr3_constructor_success_4k_aligned_size();
     void test_unique_map_ptr_x64_virt_cr3_constructor_not_present();
     void test_unique_map_ptr_x64_virt_cr3_constructor_invalid_phys_addr();
     void test_unique_map_ptr_x64_copy_constructor();
@@ -126,6 +131,10 @@ private:
     void test_unique_map_ptr_x64_cache_flush();
     void test_unique_map_ptr_x64_comparison();
     void test_unique_map_ptr_x64_make_failure();
+    void test_virt_to_phys_with_cr3_invalid();
+    void test_virt_to_phys_with_cr3_1g();
+    void test_virt_to_phys_with_cr3_2m();
+    void test_virt_to_phys_with_cr3_4k();
 
     void test_root_page_table_x64_init_failure();
     void test_root_page_table_x64_init_success();

--- a/bfvmm/src/memory_manager/test/test_page_table_entry_x64.cpp
+++ b/bfvmm/src/memory_manager/test/test_page_table_entry_x64.cpp
@@ -27,12 +27,6 @@
 using pte_type = page_table_entry_x64::integer_pointer;
 
 void
-memory_manager_ut::test_page_table_entry_x64_invalid()
-{
-    std::make_unique<page_table_entry_x64>();
-}
-
-void
 memory_manager_ut::test_page_table_entry_x64_present()
 {
     pte_type entry = 0;


### PR DESCRIPTION
This patch makes several changes to the CR3 / paging logic:
- Memory usage is about as small as it's going to get. With this patch,
  all that is needed is the page table itself, and a list of the next
  set of page tables. Mapping / unmapping performance should be about
  the same, if changed at all
- 1g, 2m and 4k granularity has been added
- You can now swap between different granularities without corrupting
  the page tables.
- A new capacity function has been added to measure how much capacity
  has been allocated vs the total size. This is mainly used by the
  unit tests, but you can use it in your code if your curious about
  how much memory your consuming.
- virt_to_pte has been added so that you can locate a PTE for a
  given virtual address.

Signed-off-by: “Rian <“rianquinn@gmail.com”>