### PR TITLE
VMLauch Mods

### DIFF
--- a/bfvmm/include/intrinsics/vmx_intel_x64.h
+++ b/bfvmm/include/intrinsics/vmx_intel_x64.h
@@ -33,6 +33,7 @@ extern "C" bool __vmptrst(void *ptr) noexcept;
 extern "C" bool __vmread(uint64_t field, uint64_t *val) noexcept;
 extern "C" bool __vmwrite(uint64_t field, uint64_t val) noexcept;
 extern "C" bool __vmlaunch(void) noexcept;
+extern "C" bool __vmlaunch_demote(void) noexcept;
 extern "C" void __invept(uint64_t type, void *ptr) noexcept;
 extern "C" void __invvipd(uint64_t type, void *ptr) noexcept;
 
@@ -150,6 +151,12 @@ namespace vm
     {
         if (!__vmlaunch())
             throw std::runtime_error("vm::launch failed");
+    }
+
+    inline void launch_demote()
+    {
+        if (!__vmlaunch_demote())
+            throw std::runtime_error("vm::launch_demote failed");
     }
 }
 }

--- a/bfvmm/include/vmcs/vmcs_intel_x64_state.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_state.h
@@ -277,6 +277,8 @@ public:
     virtual void set_ia32_gs_base_msr(intel_x64::msrs::value_type val)
     { (void) val; }
 
+    virtual bool is_guest() { return false; }
+
     virtual void dump() const {}
 };
 

--- a/bfvmm/src/intrinsics/src/vmx_intel_x64.asm
+++ b/bfvmm/src/intrinsics/src/vmx_intel_x64.asm
@@ -63,6 +63,12 @@ __vmwrite:
     jbe __vmx_failure
     jmp __vmx_success
 
+global __vmlaunch:function
+__vmlaunch:
+    vmlaunch
+    jbe __vmx_failure
+    jmp __vmx_success
+
 __vmx_failure:
     mov rax, 0x0
     ret
@@ -71,11 +77,9 @@ __vmx_success:
     mov rax, 0x1
     ret
 
-; bool __vmlaunch(void)
-;
 ; Since bareflank consists of nothing more than a bunch of shared libraries,
 ; all of the code is position independent, which makes getting the actual
-; address of a labal difficult at compile time since everything is going to be
+; address of a label difficult at compile time since everything is going to be
 ; relocated. In the case of the VMM, RIP is simple, as we can provide a
 ; custom entry point that we can control. In the case of the guest, RIP needs
 ; to continue execution of the guest, which is somewhere in the call stack of
@@ -84,7 +88,7 @@ __vmx_success:
 ; already relocated for us.
 ;
 ; So this function sets up the last two fields in the VMCS with the stack and
-; RIP that it has right before vmlaunch occurs. Since we poped the return
+; RIP that it has right before vmlaunch occurs. Since we popped the return
 ; address off the stack, the "ret" instruction cannot be used as our stack is
 ; corrupt. If the vmlaunch is successful, rax will have a 1 in it because
 ; the launch will "appear" like a "ret", handing control back to the
@@ -93,8 +97,8 @@ __vmx_success:
 ; continue execution.
 ;
 
-global __vmlaunch:function
-__vmlaunch:
+global __vmlaunch_demote:function
+__vmlaunch_demote:
     call __vmlaunch_trampoline
     ret
 

--- a/bfvmm/src/intrinsics/src/vmx_intel_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/vmx_intel_x64_mock.cpp
@@ -91,6 +91,13 @@ __attribute__((weak)) __vmlaunch(void) noexcept
     abort();
 }
 
+extern "C" bool
+__attribute__((weak)) __vmlaunch_demote(void) noexcept
+{
+    std::cerr << __FUNC__ << " called" << '\n';
+    abort();
+}
+
 extern "C" void
 __attribute__((weak)) __invept(uint64_t type, void *ptr) noexcept
 {

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -362,6 +362,8 @@ intrinsics_ut::list()
     this->test_vmx_intel_x64_vmread_vmwrite_succcess();
     this->test_vmx_intel_x64_vmlaunch_failure();
     this->test_vmx_intel_x64_vmlaunch_success();
+    this->test_vmx_intel_x64_vmlaunch_demote_failure();
+    this->test_vmx_intel_x64_vmlaunch_demote_success();
     this->test_vmx_intel_x64_invept();
     this->test_vmx_intel_x64_invvpid();
 

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -361,6 +361,8 @@ private:
     void test_vmx_intel_x64_vmread_vmwrite_succcess();
     void test_vmx_intel_x64_vmlaunch_failure();
     void test_vmx_intel_x64_vmlaunch_success();
+    void test_vmx_intel_x64_vmlaunch_demote_failure();
+    void test_vmx_intel_x64_vmlaunch_demote_success();
     void test_vmx_intel_x64_invept();
     void test_vmx_intel_x64_invvpid();
 

--- a/bfvmm/src/intrinsics/test/test_vmx_intel_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_vmx_intel_x64.cpp
@@ -82,6 +82,10 @@ extern "C" bool
 __vmlaunch(void) noexcept
 { return !g_vmlaunch_fails; }
 
+extern "C" bool
+__vmlaunch_demote(void) noexcept
+{ return !g_vmlaunch_fails; }
+
 extern "C" void
 __invept(uint64_t type, void *ptr) noexcept
 { (void) type; (void) ptr; }
@@ -236,6 +240,22 @@ intrinsics_ut::test_vmx_intel_x64_vmlaunch_failure()
 
     g_vmlaunch_fails = true;
     this->expect_exception([&] { vm::launch(); }, ""_ut_ree);
+}
+
+void
+intrinsics_ut::test_vmx_intel_x64_vmlaunch_demote_success()
+{
+    this->expect_no_exception([&] { vm::launch_demote(); });
+}
+
+void
+intrinsics_ut::test_vmx_intel_x64_vmlaunch_demote_failure()
+{
+    auto ___ = gsl::finally([&]
+    { g_vmlaunch_fails = false; });
+
+    g_vmlaunch_fails = true;
+    this->expect_exception([&] { vm::launch_demote(); }, ""_ut_ree);
 }
 
 void

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -74,7 +74,10 @@ vmcs_intel_x64::launch(gsl::not_null<vmcs_intel_x64_state *> host_state,
     auto ___ = gsl::on_failure([&]
     { vmcs::check::all(); });
 
-    vm::launch();
+    if (guest_state->is_guest())
+        vm::launch();
+    else
+        vm::launch_demote();
 }
 
 void

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -166,6 +166,10 @@ extern "C" bool
 __vmlaunch(void) noexcept
 { return !g_vmlaunch_fails; }
 
+extern "C" bool
+__vmlaunch_demote(void) noexcept
+{ return !g_vmlaunch_fails; }
+
 uintptr_t
 virtptr_to_physint(void *ptr)
 {
@@ -209,6 +213,7 @@ vmcs_ut::list_vmcs_intel_x64_cpp()
 {
     this->test_launch_success();
     this->test_launch_vmlaunch_failure();
+    this->test_launch_vmlaunch_demote_failure();
     this->test_launch_create_vmcs_region_failure();
     this->test_launch_create_exit_handler_stack_failure();
     this->test_launch_clear_failure();
@@ -1436,6 +1441,7 @@ vmcs_ut::list()
     this->test_state_segment_registers_access_rights();
     this->test_state_segment_register_base();
     this->test_state_msrs();
+    this->test_state_is_guest();
     this->test_state_dump();
 
     this->test_host_vm_state();

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -157,6 +157,7 @@ private:
 
     void test_launch_success();
     void test_launch_vmlaunch_failure();
+    void test_launch_vmlaunch_demote_failure();
     void test_launch_create_vmcs_region_failure();
     void test_launch_create_exit_handler_stack_failure();
     void test_launch_clear_failure();
@@ -1264,6 +1265,7 @@ private:
     void test_state_segment_registers_access_rights();
     void test_state_segment_register_base();
     void test_state_msrs();
+    void test_state_is_guest();
     void test_state_dump();
 
     void test_host_vm_state();

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_state.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_state.cpp
@@ -254,6 +254,16 @@ vmcs_ut::test_state_msrs()
 }
 
 void
+vmcs_ut::test_state_is_guest()
+{
+    this->expect_no_exception([&]
+    {
+        vmcs_intel_x64_state state{};
+        this->expect_false(state.is_guest());
+    });
+}
+
+void
 vmcs_ut::test_state_dump()
 {
     this->expect_no_exception([&]


### PR DESCRIPTION
This patch adds a traditional vmlaunch which is needed to start
guests with the VMCS. Now, you can declare a guest state as a
guest and not a host (the default), and vmlauch will be executed
without the demotion. This means you will have to specify
RIP and RSP manually until we add support for RIP and RSP in
the state class.

Signed-off-by: “Rian <“rianquinn@gmail.com”>