### PR TITLE
Fixed bf-gcc bug

### DIFF
--- a/tools/scripts/bareflank_gcc_wrapper.sh
+++ b/tools/scripts/bareflank_gcc_wrapper.sh
@@ -374,12 +374,12 @@ if [[ -d "$HOME/compilers/$compiler/x86_64-elf/include/" ]]; then
     SYSROOT_INC_PATH="$SYSROOT_INC_PATH -isystem $HOME/compilers/$compiler/x86_64-elf/include/"
 fi
 
-if [[ -d "$BUILD_ABS/sysroot/x86_64-elf/include/" ]]; then
-    SYSROOT_INC_PATH="$SYSROOT_INC_PATH -isystem $BUILD_ABS/sysroot/x86_64-elf/include/"
-fi
-
 if [[ -d "$BUILD_ABS/sysroot/x86_64-elf/include/c++/v1/" ]]; then
     SYSROOT_INC_PATH="$SYSROOT_INC_PATH -isystem $BUILD_ABS/sysroot/x86_64-elf/include/c++/v1/"
+fi
+
+if [[ -d "$BUILD_ABS/sysroot/x86_64-elf/include/" ]]; then
+    SYSROOT_INC_PATH="$SYSROOT_INC_PATH -isystem $BUILD_ABS/sysroot/x86_64-elf/include/"
 fi
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Some header files are using #include_next extension, for example, cmath includes math.h.
It searches include directories in the same order as that specified by -isystem option.
So system include directories must be reordered correctly.

-isystem on a system include directory causes errors
http://stackoverflow.com/questions/37218953/isystem-on-a-system-include-directory-causes-errors