### PR TITLE
VMM Triple Fault on VMCall

### DIFF
--- a/bfvmm/src/memory_manager/src/page_table_x64.cpp
+++ b/bfvmm/src/memory_manager/src/page_table_x64.cpp
@@ -35,7 +35,6 @@ page_table_x64::page_table_x64(gsl::not_null<pointer> pte)
     entry.set_phys_addr(g_mm->virtptr_to_physint(m_pt.get()));
     entry.set_present(true);
     entry.set_rw(true);
-    entry.set_us(true);
     entry.set_pat_index_4k(pat::write_back_index);
 }
 

--- a/bfvmm/src/memory_manager/test/test_root_page_table_x64.cpp
+++ b/bfvmm/src/memory_manager/test/test_root_page_table_x64.cpp
@@ -81,7 +81,7 @@ memory_manager_ut::test_root_page_table_x64_cr3()
     setup_mm(mocks);
     auto &&root_cr3 = root_page_table_x64{};
 
-    this->expect_true(root_cr3.cr3() == 0x0000000ABCDEF001F);
+    this->expect_true(root_cr3.cr3() == 0x0000000ABCDEF001B);
 }
 
 void

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
@@ -91,6 +91,7 @@ vmcs_intel_x64_vmm_state::vmcs_intel_x64_vmm_state()
     m_cr4 |= cr4::page_global_enable::mask;
     m_cr4 |= cr4::performance_monitor_counter_enable::mask;
     m_cr4 |= cr4::osfxsr::mask;
+    m_cr4 |= cr4::osxsave::mask;
     m_cr4 |= cr4::osxmmexcpt::mask;
     m_cr4 |= cr4::vmx_enable_bit::mask;
 

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_vmm_state.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_vmm_state.cpp
@@ -72,6 +72,7 @@ setup_vmm_state(MockRepository &mocks)
     test_cr4 |= cr4::page_global_enable::mask;
     test_cr4 |= cr4::performance_monitor_counter_enable::mask;
     test_cr4 |= cr4::osfxsr::mask;
+    test_cr4 |= cr4::osxsave::mask;
     test_cr4 |= cr4::osxmmexcpt::mask;
     test_cr4 |= cr4::vmx_enable_bit::mask;
     test_cr4 |= cr4::smep_enable_bit::mask;


### PR DESCRIPTION
The minnowboard updates introduced a bug that would cause a triple
fault whena vmcall was introduced. This addresses the issue, and
cleans up an minor bug were we were setting page directories
to U/S when we didn't need to be.

Signed-off-by: “Rian <“rianquinn@gmail.com”>