### PR TITLE
Fix osxsave issue with Minnowboard

### DIFF
--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -94,6 +94,10 @@ extern "C" uint16_t
 __read_tr(void) noexcept
 { return 0; }
 
+extern "C" uint32_t
+__cpuid_ecx(uint32_t val) noexcept
+{ (void) val; return 0x04000000U; }
+
 extern "C" void
 __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
 {

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_vmm_state.cpp
@@ -91,9 +91,11 @@ vmcs_intel_x64_vmm_state::vmcs_intel_x64_vmm_state()
     m_cr4 |= cr4::page_global_enable::mask;
     m_cr4 |= cr4::performance_monitor_counter_enable::mask;
     m_cr4 |= cr4::osfxsr::mask;
-    m_cr4 |= cr4::osxsave::mask;
     m_cr4 |= cr4::osxmmexcpt::mask;
     m_cr4 |= cr4::vmx_enable_bit::mask;
+
+    if (cpuid::feature_information::ecx::xsave::get())
+        m_cr4 |= cr4::osxsave::mask;
 
     if (cpuid::extended_feature_flags::subleaf0::ebx::smep::get())
         m_cr4 |= cr4::smep_enable_bit::mask;

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -130,6 +130,9 @@ extern "C" uint32_t
 __cpuid_eax(uint32_t val) noexcept
 { return g_eax_cpuid[val]; }
 
+extern "C" uint32_t
+__cpuid_ecx(uint32_t val) noexcept
+{ (void) val; return 0x04000000U; }
 
 extern "C" void
 __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept


### PR DESCRIPTION
Since the Minnowboard does not support AVX, it also do not
support cr4.osxsave, and thus we need to check for support
prior to setting this bit.

Signed-off-by: “Rian <“rianquinn@gmail.com”>