### PR TITLE
RDTSC Compilation Issue

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,16 +5,7 @@ environment:
     global:
         CYG_ROOT: C:\cygwin64
         CYG_MIRROR: http://cygwin.mirror.constant.com
-        CYG_CACHE: C:\cygwin64\var\cache\setup
         CYG_BASH: C:\cygwin64\bin\bash
-        CYG_EWDK: C:\cygdrive\c\ewdk
-
-#
-# Cache Cygwin files to speed up build
-#
-cache:
-    - '%CYG_CACHE%'
-    - '%CYG_EWDK%'
 
 #
 # Do a shallow clone of the repo to speed up build

--- a/bfvmm/include/intrinsics/rdtsc_x64.h
+++ b/bfvmm/include/intrinsics/rdtsc_x64.h
@@ -22,28 +22,28 @@
 #ifndef RDTSC_X64_H
 #define RDTSC_X64_H
 
-extern "C" uint64_t __rdtsc(void) noexcept;
-extern "C" uint64_t __rdtscp(void) noexcept;
+extern "C" uint64_t __read_tsc(void) noexcept;
+extern "C" uint64_t __read_tscp(void) noexcept;
 
 // *INDENT-OFF*
 
 namespace x64
 {
 
-namespace rdtsc
+namespace read_tsc
 {
     using value_type = uint64_t;
 
     inline auto get() noexcept
-    { return __rdtsc(); }
+    { return __read_tsc(); }
 }
 
-namespace rdtscp
+namespace read_tscp
 {
     using value_type = uint64_t;
 
     inline auto get() noexcept
-    { return __rdtscp(); }
+    { return __read_tscp(); }
 }
 
 }

--- a/bfvmm/src/intrinsics/src/rdtsc_x64.asm
+++ b/bfvmm/src/intrinsics/src/rdtsc_x64.asm
@@ -38,8 +38,8 @@ section .text
 ; randomly accessing different leaf functions in CPUID introducing variance.
 ;
 
-global __rdtsc:function
-__rdtsc:
+global __read_tsc:function
+__read_tsc:
 
     push rbx
 
@@ -56,8 +56,8 @@ __rdtsc:
     pop rbx
     ret
 
-global __rdtscp:function
-__rdtscp:
+global __read_tscp:function
+__read_tscp:
 
     push rbx
 

--- a/bfvmm/src/intrinsics/src/rdtsc_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/rdtsc_x64_mock.cpp
@@ -23,14 +23,14 @@
 #include <debug.h>
 
 extern "C" uint64_t
-__attribute__((weak)) __rdtsc(void) noexcept
+__attribute__((weak)) __read_tsc(void) noexcept
 {
     std::cerr << __FUNC__ << " called" << '\n';
     abort();
 }
 
 extern "C" uint64_t
-__attribute__((weak)) __rdtscp(void) noexcept
+__attribute__((weak)) __read_tscp(void) noexcept
 {
     std::cerr << __FUNC__ << " called" << '\n';
     abort();

--- a/bfvmm/src/intrinsics/test/test_rdtsc_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_rdtsc_x64.cpp
@@ -24,27 +24,27 @@
 
 using namespace x64;
 
-rdtsc::value_type g_rdtsc = 0;
-rdtscp::value_type g_rdtscp = 0;
+read_tsc::value_type g_read_tsc = 0;
+read_tscp::value_type g_read_tscp = 0;
 
 extern "C" uint64_t
-__rdtsc(void) noexcept
-{ return g_rdtsc; }
+__read_tsc(void) noexcept
+{ return g_read_tsc; }
 
 extern "C" uint64_t
-__rdtscp(void) noexcept
-{ return g_rdtscp; }
+__read_tscp(void) noexcept
+{ return g_read_tscp; }
 
 void
 intrinsics_ut::test_rdtsc_x64()
 {
-    g_rdtsc = 10U;
-    this->expect_true(rdtsc::get() == 10U);
+    g_read_tsc = 10U;
+    this->expect_true(read_tsc::get() == 10U);
 }
 
 void
 intrinsics_ut::test_rdtscp_x64()
 {
-    g_rdtscp = 10U;
-    this->expect_true(rdtscp::get() == 10U);
+    g_read_tscp = 10U;
+    this->expect_true(read_tscp::get() == 10U);
 }

--- a/tools/scripts/setup_cygwin.sh
+++ b/tools/scripts/setup_cygwin.sh
@@ -40,12 +40,12 @@ parse_arguments $@
 # ------------------------------------------------------------------------------
 
 install_common_packages() {
-    setup-x86_64.exe -q --wait -P wget,make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel
+    setup-x86_64.exe -q --wait -P make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel
 }
 
 install_cmake() {
     rm -Rf cmake-*
-    wget https://cmake.org/files/v3.6/cmake-3.6.2.tar.gz
+    curl -o -L cmake-3.6.2.tar.gz https://cmake.org/files/v3.6/cmake-3.6.2.tar.gz
     tar xf cmake-*
     pushd cmake-*
     ./configure
@@ -58,7 +58,7 @@ install_cmake() {
 setup_ewdk() {
     if [[ ! -d /cygdrive/c/ewdk ]]; then
         echo "Fetching EWDK. Please wait..."
-        wget -nv -O /tmp/ewdk.zip "https://go.microsoft.com/fwlink/p/?LinkID=699461"
+        curl "https://go.microsoft.com/fwlink/p/?LinkID=699461" -L --output /tmp/ewdk.zip
         echo "Installing EWDK. Please wait..."
         unzip -qq /tmp/ewdk.zip -d /cygdrive/c/ewdk/
         chown -R $USER:SYSTEM /cygdrive/c/ewdk

--- a/tools/scripts/setup_ubuntu.sh
+++ b/tools/scripts/setup_ubuntu.sh
@@ -51,6 +51,7 @@ install_common_packages() {
     sudo apt-get install --yes nasm
     sudo apt-get install --yes texinfo
     sudo apt-get install --yes cmake
+    sudo apt-get install --yes realpath
 }
 
 install_clang_1610() {


### PR DESCRIPTION
The "__rdtsc" function name is taken by some code in GCC,
which seems to collide on some 16.04 machines. This patch
renames rdtsc to read_tsc.

Signed-off-by: “Rian <“rianquinn@gmail.com”>