### PR TITLE
Update setup_ubuntu.sh

### DIFF
--- a/tools/scripts/setup_ubuntu.sh
+++ b/tools/scripts/setup_ubuntu.sh
@@ -146,6 +146,7 @@ case $( grep ^VERSION_ID= /etc/os-release | cut -d'=' -f 2 | tr -d '"' ) in
     ;;
 
 16.04)
+    install_apt_tools
     install_common_packages
     install_clang_1604
     install_docker_1604


### PR DESCRIPTION
setup_ubuntu.sh wasn't working on Ubuntu 16.04 because it was missing the software-properties-common package. I added install_apt_tools to the beginning of the 16.04 setup and that solved the bug.