### PR TITLE
Updated setup_cygwin.sh

### DIFF
--- a/tools/scripts/setup_cygwin.sh
+++ b/tools/scripts/setup_cygwin.sh
@@ -40,14 +40,14 @@ parse_arguments $@
 # ------------------------------------------------------------------------------
 
 install_common_packages() {
-    setup-x86_64.exe -q --wait -P make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel
+    setup-x86_64.exe -q --wait -P make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel,curl
 }
 
 install_cmake() {
     rm -Rf cmake-*
-    curl -o -L cmake-3.6.2.tar.gz https://cmake.org/files/v3.6/cmake-3.6.2.tar.gz
+    curl -L -o cmake-3.6.2.tar.gz https://cmake.org/files/v3.6/cmake-3.6.2.tar.gz
     tar xf cmake-*
-    pushd cmake-*
+    pushd cmake-3.6.2
     ./configure
     make
     make install
@@ -72,6 +72,12 @@ setup_ewdk() {
 # ------------------------------------------------------------------------------
 
 case $(uname -r) in
+2.7.*)
+    install_common_packages
+    if [[ ! $APPVEYOR == "true" ]]; then install_cmake; fi
+    setup_ewdk
+    ;;
+
 2.6.*)
     install_common_packages
     if [[ ! $APPVEYOR == "true" ]]; then install_cmake; fi

--- a/tools/scripts/setup_cygwin.sh
+++ b/tools/scripts/setup_cygwin.sh
@@ -40,7 +40,7 @@ parse_arguments $@
 # ------------------------------------------------------------------------------
 
 install_common_packages() {
-    setup-x86_64.exe -q --wait -P make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel,curl
+    setup-x86_64.exe -q --wait -P make,gcc-core,gcc-g++,diffutils,libgmp-devel,libmpfr-devel,libmpc-devel,flex,bison,nasm,texinfo,unzip,git-completion,bash-completion,patch,ncurses,libncurses-devel,clang,libiconv-devel,curl,wget
 }
 
 install_cmake() {


### PR DESCRIPTION
Made a couple changes to make setup work on cygwin:

- Line 43: Added curl and wget to packages installed with cygwin setup. I imagine most systems already have this installed, but since it is needed later in the script it would make sense to get it at this stage just in case. The bare minimum cygwin installation does not include curl and wget.
- Line 48: The output file name has to follow the -o flag. Currently, it follows the -L flag which confuses the terminal when figuring out where you want the output to go.
- Line 50: pushd gets a "too many arguments" error when using `cmake-*`. Since cmake-3.6.2 is hardcoded 2 lines up, I don't think its a problem to hardcode it here and that fixes the issue.
- Line 75: The latest cygwin version is 2.7.* and this is a pretty new release (I think) so this script might not have been updated to support the newest cygwin client.
