### PR TITLE
Verify Source Update

### DIFF
--- a/tools/scripts/verify_source.sh
+++ b/tools/scripts/verify_source.sh
@@ -195,7 +195,7 @@ fi
 if [[ -d hyperkernel ]]; then
     pushd hyperkernel > /dev/null
     header $PWD
-    run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode"
+    run_clang_tidy "clan*,-clang-analyzer-alpha.deadcode.UnreachableCode,-clang-analyzer-alpha.core.CastToStruct"
     run_clang_tidy "cert*,-clang-analyzer*,-cert-err60-cpp"
     run_clang_tidy "misc*,-clang-analyzer*,-misc-noexcept-move-constructor"
     run_clang_tidy "perf*,-clang-analyzer*"


### PR DESCRIPTION
The hyperkernel uses the ELF loader which triggers the
CastToStruct alpha check (as it has to).

Signed-off-by: Rian Quinn <“rianquinn@gmail.com”>