### PR TITLE
Add support for bareflank on kvm

### DIFF
--- a/bfvmm/include/intrinsics/cpuid_x64.h
+++ b/bfvmm/include/intrinsics/cpuid_x64.h
@@ -1031,6 +1031,150 @@ namespace cpuid
         }
     }
 
+    namespace arch_perf_monitoring
+    {
+        constexpr const auto addr = 0x0000000AUL;
+        constexpr const auto name = "arch_perf_monitoring";
+
+        namespace eax
+        {
+            namespace version_id
+            {
+                constexpr const auto mask = 0x000000FFUL;
+                constexpr const auto from = 0UL;
+                constexpr const auto name = "version_id";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace gppmc_count
+            {
+                constexpr const auto mask = 0x0000FF00UL;
+                constexpr const auto from = 8UL;
+                constexpr const auto name = "gppmc_count";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace gppmc_bit_width
+            {
+                constexpr const auto mask = 0x00FF0000UL;
+                constexpr const auto from = 16UL;
+                constexpr const auto name = "gppmc_bit_width";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_eax(addr), mask) >> from; }
+            }
+
+            namespace ebx_enumeration_length
+            {
+                constexpr const auto mask = 0xFF000000UL;
+                constexpr const auto from = 24;
+                constexpr const auto name = "ebx_enumeration_length";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_eax(addr), mask) >> from; }
+            }
+        }
+
+        namespace ebx
+        {
+            namespace core_cycle_event
+            {
+                constexpr const auto mask = 0x00000001UL;
+                constexpr const auto from = 0UL;
+                constexpr const auto name = "core_cycle_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace instr_retired_event
+            {
+                constexpr const auto mask = 0x00000002UL;
+                constexpr const auto from = 1UL;
+                constexpr const auto name = "instr_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace reference_cycles_event
+            {
+                constexpr const auto mask = 0x00000004UL;
+                constexpr const auto from = 2UL;
+                constexpr const auto name = "reference_cycles_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace llc_reference_event
+            {
+                constexpr const auto mask = 0x00000008UL;
+                constexpr const auto from = 3UL;
+                constexpr const auto name = "llc_reference_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace llc_misses_event
+            {
+                constexpr const auto mask = 0x00000010UL;
+                constexpr const auto from = 4UL;
+                constexpr const auto name = "llc_misses_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace branch_instr_retired_event
+            {
+                constexpr const auto mask = 0x00000020UL;
+                constexpr const auto from = 5UL;
+                constexpr const auto name = "branch_instr_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+
+            namespace branch_mispredict_retired_event
+            {
+                constexpr const auto mask = 0x00000040UL;
+                constexpr const auto from = 6UL;
+                constexpr const auto name = "branch_mispredict_retired_event";
+
+                inline auto is_available() noexcept
+                { return get_bit(__cpuid_ebx(addr), from) == 0; }
+            }
+        }
+
+        namespace edx
+        {
+            namespace ffpmc_count
+            {
+                constexpr const auto mask = 0x0000001FUL;
+                constexpr const auto from = 0;
+                constexpr const auto name = "ffpmc_count";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_edx(addr), mask) >> from; }
+            }
+
+            namespace ffpmc_bit_width
+            {
+                constexpr const auto mask = 0x00001FE0UL;
+                constexpr const auto from = 5;
+                constexpr const auto name = "ffpmc_bit_width";
+
+                inline auto get() noexcept
+                { return get_bits(__cpuid_edx(addr), mask) >> from; }
+            }
+        }
+    }
 }
 }
 

--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -265,6 +265,7 @@ void
 exit_handler_intel_x64::handle_rdmsr()
 {
     intel_x64::msrs::value_type msr = 0;
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
 
     switch (m_state_save->rcx)
     {
@@ -281,7 +282,7 @@ exit_handler_intel_x64::handle_rdmsr()
             break;
 
         case intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            msr = vmcs::guest_ia32_perf_global_ctrl::get();
+            msr = vmcs::guest_ia32_perf_global_ctrl::get_if_exists(verbose);
             break;
 
         case intel_x64::msrs::ia32_sysenter_cs::addr:
@@ -337,6 +338,7 @@ void
 exit_handler_intel_x64::handle_wrmsr()
 {
     intel_x64::msrs::value_type msr = 0;
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
 
     msr |= ((m_state_save->rax & 0x00000000FFFFFFFF) << 0x00);
     msr |= ((m_state_save->rdx & 0x00000000FFFFFFFF) << 0x20);
@@ -356,7 +358,7 @@ exit_handler_intel_x64::handle_wrmsr()
             break;
 
         case intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            vmcs::guest_ia32_perf_global_ctrl::set(msr);
+            vmcs::guest_ia32_perf_global_ctrl::set_if_exists(msr, verbose);
             break;
 
         case intel_x64::msrs::ia32_sysenter_cs::addr:

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -428,6 +428,19 @@ intrinsics_ut::list()
     this->test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_processor_trace();
     this->test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_sha();
     this->test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_dump();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_eax_version_id();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_count();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_bit_width();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_eax_ebx_enumeration_length();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_core_cycle_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_instr_retired_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_reference_cycles_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_reference_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_misses_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_instr_retired_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_mispredict_retired_event();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_count();
+    this->test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_bit_width();
 
     this->test_pm_x64_halt();
     this->test_pm_x64_stop();

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -427,6 +427,19 @@ private:
     void test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_processor_trace();
     void test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_sha();
     void test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_dump();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_eax_version_id();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_count();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_bit_width();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_eax_ebx_enumeration_length();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_core_cycle_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_instr_retired_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_reference_cycles_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_reference_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_misses_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_instr_retired_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_mispredict_retired_event();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_count();
+    void test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_bit_width();
 
     void test_pm_x64_halt();
     void test_pm_x64_stop();

--- a/bfvmm/src/intrinsics/test/test_cpuid_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_cpuid_x64.cpp
@@ -675,3 +675,115 @@ intrinsics_ut::test_cpuid_x64_cpuid_extended_feature_flags_subleaf0_ebx_dump()
     g_regs.ebx = 0xFFFFFFFFU;
     cpuid::extended_feature_flags::subleaf0::ebx::dump();
 }
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_eax_version_id()
+{
+    g_eax_cpuid[0xA] = 2;
+    this->expect_true(cpuid::arch_perf_monitoring::eax::version_id::get() == 2);
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_count()
+{
+    g_eax_cpuid[0xA] = 0xFF02;
+    this->expect_true(cpuid::arch_perf_monitoring::eax::gppmc_count::get() == 0xFF);
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_eax_gppmc_bit_width()
+{
+    g_eax_cpuid[0xA] = 0xFF0002;
+    this->expect_true(cpuid::arch_perf_monitoring::eax::gppmc_bit_width::get() == 0xFF);
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_eax_ebx_enumeration_length()
+{
+    g_eax_cpuid[0xA] = 0xFF000000;
+    this->expect_true(cpuid::arch_perf_monitoring::eax::ebx_enumeration_length::get() == 0xFF);
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_core_cycle_event()
+{
+    g_ebx_cpuid[0xA] = 0x1U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::core_cycle_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x1U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::core_cycle_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_instr_retired_event()
+{
+    g_ebx_cpuid[0xA] = 0x2U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::instr_retired_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x2U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::instr_retired_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_reference_cycles_event()
+{
+    g_ebx_cpuid[0xA] = 0x4U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::reference_cycles_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x4U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::reference_cycles_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_reference_event()
+{
+    g_ebx_cpuid[0xA] = 0x8U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::llc_reference_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x8U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::llc_reference_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_llc_misses_event()
+{
+    g_ebx_cpuid[0xA] = 0x10U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::llc_misses_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x10U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::llc_misses_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_instr_retired_event()
+{
+    g_ebx_cpuid[0xA] = 0x20U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::branch_instr_retired_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x20U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::branch_instr_retired_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_ebx_branch_mispredict_retired_event()
+{
+    g_ebx_cpuid[0xA] = 0x40U;
+    this->expect_false(cpuid::arch_perf_monitoring::ebx::branch_mispredict_retired_event::is_available());
+
+    g_ebx_cpuid[0xA] = ~0x40U;
+    this->expect_true(cpuid::arch_perf_monitoring::ebx::branch_mispredict_retired_event::is_available());
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_count()
+{
+    g_edx_cpuid[0xA] = 2;
+    this->expect_true(cpuid::arch_perf_monitoring::edx::ffpmc_count::get() == 2);
+}
+
+void
+intrinsics_ut::test_cpuid_x64_cpuid_arch_perf_monitoring_edx_ffpmc_bit_width()
+{
+    g_edx_cpuid[0xA] = 0xE2;
+    this->expect_true(cpuid::arch_perf_monitoring::edx::ffpmc_bit_width::get() == 7);
+}

--- a/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
+++ b/bfvmm/src/vcpu/test/test_vcpu_intel_x64.cpp
@@ -98,6 +98,10 @@ extern "C" uint32_t
 __cpuid_ecx(uint32_t val) noexcept
 { (void) val; return 0x04000000U; }
 
+extern "C" uint32_t
+__cpuid_eax(uint32_t val) noexcept
+{ (void) val; return 0x2U; }
+
 extern "C" void
 __cpuid(void *eax, void *ebx, void *ecx, void *edx) noexcept
 {

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -283,7 +283,7 @@ vmcs_intel_x64::write_64bit_guest_state(gsl::not_null<vmcs_intel_x64_state *> st
     vmcs::guest_ia32_debugctl::set(state->ia32_debugctl_msr());
     vmcs::guest_ia32_pat::set(state->ia32_pat_msr());
     vmcs::guest_ia32_efer::set(state->ia32_efer_msr());
-    vmcs::guest_ia32_perf_global_ctrl::set(state->ia32_perf_global_ctrl_msr());
+    vmcs::guest_ia32_perf_global_ctrl::set_if_exists(state->ia32_perf_global_ctrl_msr());
 
     // unused: VMCS_GUEST_PDPTE0
     // unused: VMCS_GUEST_PDPTE1
@@ -370,7 +370,7 @@ vmcs_intel_x64::write_64bit_host_state(gsl::not_null<vmcs_intel_x64_state *> sta
 {
     vmcs::host_ia32_pat::set(state->ia32_pat_msr());
     vmcs::host_ia32_efer::set(state->ia32_efer_msr());
-    vmcs::host_ia32_perf_global_ctrl::set(state->ia32_perf_global_ctrl_msr());
+    vmcs::host_ia32_perf_global_ctrl::set_if_exists(state->ia32_perf_global_ctrl_msr());
 }
 
 void
@@ -474,9 +474,12 @@ vmcs_intel_x64::secondary_processor_based_vm_execution_controls()
 void
 vmcs_intel_x64::vm_exit_controls()
 {
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
+
     vm_exit_controls::save_debug_controls::enable();
     vm_exit_controls::host_address_space_size::enable();
-    vm_exit_controls::load_ia32_perf_global_ctrl::enable();
+    vm_exit_controls::load_ia32_perf_global_ctrl::enable_if_allowed(verbose);
+
     // vm_exit_controls::acknowledge_interrupt_on_exit::enable();
     vm_exit_controls::save_ia32_pat::enable();
     vm_exit_controls::load_ia32_pat::enable();
@@ -488,11 +491,14 @@ vmcs_intel_x64::vm_exit_controls()
 void
 vmcs_intel_x64::vm_entry_controls()
 {
+    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
+
     vm_entry_controls::load_debug_controls::enable();
     vm_entry_controls::ia_32e_mode_guest::enable();
     // vm_entry_controls::entry_to_smm::enable();
     // vm_entry_controls::deactivate_dual_monitor_treatment::enable();
-    vm_entry_controls::load_ia32_perf_global_ctrl::enable();
+    vm_entry_controls::load_ia32_perf_global_ctrl::enable_if_allowed(verbose);
+
     vm_entry_controls::load_ia32_pat::enable();
     vm_entry_controls::load_ia32_efer::enable();
 }

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_host_vm_state.cpp
@@ -23,9 +23,11 @@
 
 #include <intrinsics/msrs_x64.h>
 #include <intrinsics/msrs_intel_x64.h>
+#include <intrinsics/cpuid_x64.h>
 
 using namespace x64;
 using namespace intel_x64;
+using namespace cpuid;
 
 vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state() :
     m_gdt{},
@@ -59,7 +61,10 @@ vmcs_intel_x64_host_vm_state::vmcs_intel_x64_host_vm_state() :
     m_ia32_debugctl_msr = intel_x64::msrs::ia32_debugctl::get();
     m_ia32_pat_msr = x64::msrs::ia32_pat::get();
     m_ia32_efer_msr = intel_x64::msrs::ia32_efer::get();
-    m_ia32_perf_global_ctrl_msr = intel_x64::msrs::ia32_perf_global_ctrl::get();
+
+    if (arch_perf_monitoring::eax::version_id::get() >= 2)
+        m_ia32_perf_global_ctrl_msr = intel_x64::msrs::ia32_perf_global_ctrl::get();
+
     m_ia32_sysenter_cs_msr = intel_x64::msrs::ia32_sysenter_cs::get();
     m_ia32_sysenter_esp_msr = intel_x64::msrs::ia32_sysenter_esp::get();
     m_ia32_sysenter_eip_msr = intel_x64::msrs::ia32_sysenter_eip::get();

--- a/bfvmm/src/vmcs/test/test.cpp
+++ b/bfvmm/src/vmcs/test/test.cpp
@@ -1476,7 +1476,8 @@ vmcs_ut::list()
     this->test_host_vm_state_gs_base();
     this->test_host_vm_state_tr_base();
     this->test_host_vm_state_ldtr_base();
-    this->test_host_vm_state_ia32_msrs();
+    this->test_host_vm_state_ia32_msrs_with_perf_global_ctrl();
+    this->test_host_vm_state_ia32_msrs_without_perf_global_ctrl();
     this->test_host_vm_state_dump();
 
     this->test_vmm_state_gdt_not_setup();

--- a/bfvmm/src/vmcs/test/test.h
+++ b/bfvmm/src/vmcs/test/test.h
@@ -1302,6 +1302,8 @@ private:
     void test_host_vm_state_tr_base();
     void test_host_vm_state_ldtr_base();
     void test_host_vm_state_ia32_msrs();
+    void test_host_vm_state_ia32_msrs_with_perf_global_ctrl();
+    void test_host_vm_state_ia32_msrs_without_perf_global_ctrl();
     void test_host_vm_state_dump();
 
     void test_vmm_state_gdt_not_setup();

--- a/bfvmm/src/vmcs/test/test_vmcs_intel_x64_host_vm_state.cpp
+++ b/bfvmm/src/vmcs/test/test_vmcs_intel_x64_host_vm_state.cpp
@@ -778,8 +778,10 @@ vmcs_ut::test_host_vm_state_ldtr_base()
 }
 
 void
-vmcs_ut::test_host_vm_state_ia32_msrs()
+vmcs_ut::test_host_vm_state_ia32_msrs_with_perf_global_ctrl()
 {
+    g_eax_cpuid[0xA] = 2;
+
     intel_x64::msrs::ia32_debugctl::set(42U);
     x64::msrs::ia32_pat::set(42U);
     intel_x64::msrs::ia32_efer::set(42U);
@@ -798,6 +800,35 @@ vmcs_ut::test_host_vm_state_ia32_msrs()
         this->expect_true(state.ia32_pat_msr() == 42U);
         this->expect_true(state.ia32_efer_msr() == 42U);
         this->expect_true(state.ia32_perf_global_ctrl_msr() == 42U);
+        this->expect_true(state.ia32_sysenter_cs_msr() == 42U);
+        this->expect_true(state.ia32_sysenter_esp_msr() == 42U);
+        this->expect_true(state.ia32_sysenter_eip_msr() == 42U);
+        this->expect_true(state.ia32_fs_base_msr() == 42U);
+        this->expect_true(state.ia32_gs_base_msr() == 42U);
+    });
+}
+
+void
+vmcs_ut::test_host_vm_state_ia32_msrs_without_perf_global_ctrl()
+{
+    g_eax_cpuid[0xA] = 1;
+
+    intel_x64::msrs::ia32_debugctl::set(42U);
+    x64::msrs::ia32_pat::set(42U);
+    intel_x64::msrs::ia32_efer::set(42U);
+    intel_x64::msrs::ia32_sysenter_cs::set(42U);
+    intel_x64::msrs::ia32_sysenter_esp::set(42U);
+    intel_x64::msrs::ia32_sysenter_eip::set(42U);
+    intel_x64::msrs::ia32_fs_base::set(42U);
+    intel_x64::msrs::ia32_gs_base::set(42U);
+
+    this->expect_no_exception([&]
+    {
+        vmcs_intel_x64_host_vm_state state{};
+
+        this->expect_true(state.ia32_debugctl_msr() == 42U);
+        this->expect_true(state.ia32_pat_msr() == 42U);
+        this->expect_true(state.ia32_efer_msr() == 42U);
         this->expect_true(state.ia32_sysenter_cs_msr() == 42U);
         this->expect_true(state.ia32_sysenter_esp_msr() == 42U);
         this->expect_true(state.ia32_sysenter_eip_msr() == 42U);

--- a/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
+++ b/bfvmm/src/vmxon/src/vmxon_intel_x64.cpp
@@ -126,8 +126,11 @@ vmxon_intel_x64::check_ia32_vmx_cr4_fixed_msr()
 void
 vmxon_intel_x64::check_ia32_feature_control_msr()
 {
-    if (!msrs::ia32_feature_control::lock_bit::get())
-        throw std::logic_error("vmx lock bit == 0 is unsupported");
+    if (msrs::ia32_feature_control::lock_bit::get())
+        return;
+
+    msrs::ia32_feature_control::enable_vmx_outside_smx::set(true);
+    msrs::ia32_feature_control::lock_bit::set(true);
 }
 
 void

--- a/bfvmm/src/vmxon/test/test.cpp
+++ b/bfvmm/src/vmxon/test/test.cpp
@@ -49,7 +49,8 @@ vmxon_ut::list()
     this->test_start_check_ia32_vmx_cr4_fixed1_msr_failure();
     this->test_start_enable_vmx_operation_failure();
     this->test_start_v8086_disabled_failure();
-    this->test_start_check_ia32_feature_control_msr();
+    this->test_start_check_ia32_feature_control_msr_lock_bit_clear();
+    this->test_start_check_ia32_feature_control_msr_lock_bit_set();
     this->test_start_check_ia32_vmx_cr0_fixed0_msr();
     this->test_start_check_ia32_vmx_cr0_fixed1_msr();
     this->test_start_check_vmx_capabilities_msr_memtype_failure();

--- a/bfvmm/src/vmxon/test/test.h
+++ b/bfvmm/src/vmxon/test/test.h
@@ -47,7 +47,8 @@ private:
     void test_start_check_ia32_vmx_cr4_fixed1_msr_failure();
     void test_start_enable_vmx_operation_failure();
     void test_start_v8086_disabled_failure();
-    void test_start_check_ia32_feature_control_msr();
+    void test_start_check_ia32_feature_control_msr_lock_bit_clear();
+    void test_start_check_ia32_feature_control_msr_lock_bit_set();
     void test_start_check_ia32_vmx_cr0_fixed0_msr();
     void test_start_check_ia32_vmx_cr0_fixed1_msr();
     void test_start_check_vmx_capabilities_msr_memtype_failure();


### PR DESCRIPTION
There were two problems encountered when trying to run
Bareflank as a guest on KVM:

    1. KVM doesn't pass through access to the IA32_PERF_GLOBAL_CTRL
    msr (address 0x38F).

    2. KVM doesn't set the lock bit in the IA32_FEATURE_CONTROL msr
    (address 0x3A).

This commit is a minimal change to prevent unchecked accesses to
IA32_PERF_GLOBAL_CTRL and to allow for VMXON to succeed by setting
the enable_vmx_outside_smx bit (bit 2) and then the lock bit (bit 0)
in IA32_FEATURE_CONTROL.

Note that this patch was tested with Ubuntu 16.10 and Arch Linux
guest VMs running on an Ubuntu 16.10 KVM.