### PR TITLE
Remove if_exists in exit handler

### DIFF
--- a/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
+++ b/bfvmm/src/exit_handler/src/exit_handler_intel_x64.cpp
@@ -265,7 +265,6 @@ void
 exit_handler_intel_x64::handle_rdmsr()
 {
     intel_x64::msrs::value_type msr = 0;
-    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
 
     switch (m_state_save->rcx)
     {
@@ -282,7 +281,7 @@ exit_handler_intel_x64::handle_rdmsr()
             break;
 
         case intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            msr = vmcs::guest_ia32_perf_global_ctrl::get_if_exists(verbose);
+            msr = vmcs::guest_ia32_perf_global_ctrl::get();
             break;
 
         case intel_x64::msrs::ia32_sysenter_cs::addr:
@@ -338,7 +337,6 @@ void
 exit_handler_intel_x64::handle_wrmsr()
 {
     intel_x64::msrs::value_type msr = 0;
-    bool verbose = SECONDARY_ENABLE_IF_VERBOSE;
 
     msr |= ((m_state_save->rax & 0x00000000FFFFFFFF) << 0x00);
     msr |= ((m_state_save->rdx & 0x00000000FFFFFFFF) << 0x20);
@@ -358,7 +356,7 @@ exit_handler_intel_x64::handle_wrmsr()
             break;
 
         case intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            vmcs::guest_ia32_perf_global_ctrl::set_if_exists(msr, verbose);
+            vmcs::guest_ia32_perf_global_ctrl::set(msr);
             break;
 
         case intel_x64::msrs::ia32_sysenter_cs::addr:


### PR DESCRIPTION
This removes get_if_exists and set_if_exists from the rdmsr and wrmsr handlers