### PR TITLE
Fixed Cygwin sudo Error

### DIFF
--- a/tools/tests/bf_test.sh
+++ b/tools/tests/bf_test.sh
@@ -133,7 +133,10 @@ test_cpuid()
     sudo make
     sudo make driver_load
     sudo make quick
-    sudo ARGS="string json '{\"get\":\"count\"}'" make vmcall
+    if [ "$distro" != "Cygwin" ] ; then
+        sudo ARGS="string json '{\"get\":\"count\"}'" make vmcall
+    else
+        ARGS="string json '{\"get\":\"count\"}'" make vmcall
     sudo make stop
     sudo make driver_unload
     echo CPUID Done

--- a/tools/tests/bf_test.sh
+++ b/tools/tests/bf_test.sh
@@ -137,6 +137,7 @@ test_cpuid()
         sudo ARGS="string json '{\"get\":\"count\"}'" make vmcall
     else
         ARGS="string json '{\"get\":\"count\"}'" make vmcall
+    fi
     sudo make stop
     sudo make driver_unload
     echo CPUID Done


### PR DESCRIPTION
Cygwin couldn't run the `sudo ARGS...` call in the cpuid example test. This change makes sure it can pass.