### PR TITLE
Add CR8 To the Hypervisor

### DIFF
--- a/bfvmm/include/intrinsics/crs_intel_x64.h
+++ b/bfvmm/include/intrinsics/crs_intel_x64.h
@@ -37,6 +37,9 @@ extern "C" void __write_cr3(uint64_t val) noexcept;
 extern "C" uint64_t __read_cr4(void) noexcept;
 extern "C" void __write_cr4(uint64_t val) noexcept;
 
+extern "C" uint64_t __read_cr8(void) noexcept;
+extern "C" void __write_cr8(uint64_t val) noexcept;
+
 // *INDENT-OFF*
 
 namespace intel_x64
@@ -548,6 +551,18 @@ namespace cr4
             bfdebug << "    - " << protection_key_enable_bit::name << bfendl;
     }
 }
+
+namespace cr8
+{
+    using value_type = uint64_t;
+
+    inline auto get() noexcept
+    { return __read_cr8(); }
+
+    template<class T, class = typename std::enable_if<std::is_integral<T>::value>::type>
+    void set(T val) noexcept { __write_cr8(val); }
+}
+
 }
 
 // *INDENT-ON*

--- a/bfvmm/src/intrinsics/src/crs_intel_x64.asm
+++ b/bfvmm/src/intrinsics/src/crs_intel_x64.asm
@@ -63,3 +63,13 @@ global __write_cr4:function
 __write_cr4:
     mov cr4, rdi
     ret
+
+global __read_cr8:function
+__read_cr8:
+    mov rax, cr8
+    ret
+
+global __write_cr8:function
+__write_cr8:
+    mov cr8, rdi
+    ret

--- a/bfvmm/src/intrinsics/src/crs_intel_x64_mock.cpp
+++ b/bfvmm/src/intrinsics/src/crs_intel_x64_mock.cpp
@@ -77,3 +77,17 @@ __attribute__((weak)) __write_cr4(uint64_t val) noexcept
     std::cerr << __FUNC__ << " called with: " << view_as_pointer(val) << '\n';
     abort();
 }
+
+extern "C" uint64_t
+__attribute__((weak)) __read_cr8(void) noexcept
+{
+    std::cerr << __FUNC__ << " called" << '\n';
+    abort();
+}
+
+extern "C" void
+__attribute__((weak)) __write_cr8(uint64_t val) noexcept
+{
+    std::cerr << __FUNC__ << " called with: " << view_as_pointer(val) << '\n';
+    abort();
+}

--- a/bfvmm/src/intrinsics/test/test.cpp
+++ b/bfvmm/src/intrinsics/test/test.cpp
@@ -306,6 +306,7 @@ intrinsics_ut::list()
     this->test_cr4_intel_x64_smep_enable_bit();
     this->test_cr4_intel_x64_smap_enable_bit();
     this->test_cr4_intel_x64_protection_key_enable_bit();
+    this->test_cr8_intel_x64();
 
     this->test_srs_x64_es();
     this->test_srs_x64_es_rpl();

--- a/bfvmm/src/intrinsics/test/test.h
+++ b/bfvmm/src/intrinsics/test/test.h
@@ -305,6 +305,7 @@ private:
     void test_cr4_intel_x64_smep_enable_bit();
     void test_cr4_intel_x64_smap_enable_bit();
     void test_cr4_intel_x64_protection_key_enable_bit();
+    void test_cr8_intel_x64();
 
     void test_srs_x64_es();
     void test_srs_x64_es_rpl();

--- a/bfvmm/src/intrinsics/test/test_crs_intel_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_crs_intel_x64.cpp
@@ -28,6 +28,7 @@ cr0::value_type g_cr0 = 0;
 cr2::value_type g_cr2 = 0;
 cr3::value_type g_cr3 = 0;
 cr4::value_type g_cr4 = 0;
+cr8::value_type g_cr8 = 0;
 
 extern "C" uint64_t
 __read_cr0(void) noexcept
@@ -60,6 +61,14 @@ __read_cr4(void) noexcept
 extern "C" void
 __write_cr4(uint64_t val) noexcept
 { g_cr4 = val; }
+
+extern "C" uint64_t
+__read_cr8(void) noexcept
+{ return g_cr8; }
+
+extern "C" void
+__write_cr8(uint64_t val) noexcept
+{ g_cr8 = val; }
 
 void
 intrinsics_ut::test_cr0_intel_x64()
@@ -457,4 +466,11 @@ intrinsics_ut::test_cr4_intel_x64_protection_key_enable_bit()
     this->expect_false(cr4::protection_key_enable_bit::get());
 
     this->expect_true(cr4::get() == 0x0);
+}
+
+void
+intrinsics_ut::test_cr8_intel_x64()
+{
+    cr8::set(0x100U);
+    this->expect_true(cr8::get() == 0x100U);
 }


### PR DESCRIPTION
CR8 was missing from the control registers

Signed-off-by: Rian Quinn <“rianquinn@gmail.com”>