### PR TITLE
Fix issue with rebuilds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,7 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFSDK_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfsdk/build
     UPDATE_DISCONNECTED ${BFSDK_UPDATE_DISCONNECTED}
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     BUILD_COMMAND       ""
 )
 
@@ -235,8 +236,9 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFSYSROOT_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfsysroot/build
     UPDATE_DISCONNECTED ${BFSYSROOT_UPDATE_DISCONNECTED}
-    DEPENDS             bfsdk
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     INSTALL_COMMAND     ""
+    DEPENDS             bfsdk
 )
 
 # ------------------------------------------------------------------------------
@@ -262,6 +264,7 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFELF_LOADER_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfelf_loader/build
     UPDATE_DISCONNECTED ${BFELF_LOADER_UPDATE_DISCONNECTED}
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     BUILD_COMMAND       ""
     DEPENDS             bfsdk
 )
@@ -289,6 +292,7 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFM_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfm/build
     UPDATE_DISCONNECTED ${BFM_UPDATE_DISCONNECTED}
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     BUILD_COMMAND       ""
     DEPENDS             bfsdk bfelf_loader
 )
@@ -314,6 +318,7 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFVMM_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfvmm/build
     UPDATE_DISCONNECTED ${BFVMM_UPDATE_DISCONNECTED}
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     BUILD_COMMAND       ""
     DEPENDS             bfsdk bfsysroot
 )
@@ -337,6 +342,7 @@ if(ENABLE_UNITTESTING)
         DOWNLOAD_DIR        ${CMAKE_BINARY_DIR}/test_bfvmm/download
         SOURCE_DIR          ${BFVMM_PATH}
         BINARY_DIR          ${CMAKE_BINARY_DIR}/test_bfvmm/build
+        UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
         BUILD_COMMAND       ""
         DEPENDS             bfvmm
     )
@@ -366,6 +372,7 @@ ExternalProject_Add(
     SOURCE_DIR          ${BFDRIVER_PATH}
     BINARY_DIR          ${CMAKE_BINARY_DIR}/bfdriver/build
     UPDATE_DISCONNECTED ${BFDRIVER_UPDATE_DISCONNECTED}
+    UPDATE_COMMAND      ${CMAKE_COMMAND} -E echo "checking for updates"
     BUILD_COMMAND       ""
     INSTALL_COMMAND     ""
     DEPENDS             bfsdk bfelf_loader


### PR DESCRIPTION
Right now, if you set the _PATH variables, rebuilds don't work
because ExternalProject_Add doesn't think anything changed as
there is no defined UPDATE_COMMAND. It just needs to execute
something so that it attempts to reduild, which will trigger
the build system to properly recompile based on what has actually
changed. So, all this patch does is provide an UPDATE_COMMAND that
echos to the screen which fixes the problem

Signed-off-by: Rian Quinn <“rianquinn@gmail.com”>