### PR TITLE
Fix for last gdt descriptor not getting copied/allocated

### DIFF
--- a/bfvmm/include/intrinsics/gdt_x64.h
+++ b/bfvmm/include/intrinsics/gdt_x64.h
@@ -219,7 +219,7 @@ public:
             m_gdt_reg.base = x64::gdt::base::get();
             m_gdt_reg.limit = x64::gdt::limit::get();
 
-            std::copy_n(m_gdt_reg.base, (m_gdt_reg.limit+1) >> 3, std::back_inserter(m_gdt));
+            std::copy_n(m_gdt_reg.base, (m_gdt_reg.limit + 1) >> 3, std::back_inserter(m_gdt));
         });
     }
 
@@ -239,7 +239,7 @@ public:
         guard_exceptions([&]
         {
             m_gdt_reg.base = m_gdt.data();
-            m_gdt_reg.limit = gsl::narrow_cast<size_type>(size << 3);
+            m_gdt_reg.limit = gsl::narrow_cast<size_type>((size << 3) - 1);
         });
     }
 

--- a/bfvmm/include/intrinsics/gdt_x64.h
+++ b/bfvmm/include/intrinsics/gdt_x64.h
@@ -219,7 +219,7 @@ public:
             m_gdt_reg.base = x64::gdt::base::get();
             m_gdt_reg.limit = x64::gdt::limit::get();
 
-            std::copy_n(m_gdt_reg.base, m_gdt_reg.limit >> 3, std::back_inserter(m_gdt));
+            std::copy_n(m_gdt_reg.base, (m_gdt_reg.limit+1) >> 3, std::back_inserter(m_gdt));
         });
     }
 

--- a/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
+++ b/bfvmm/src/intrinsics/test/test_gdt_x64.cpp
@@ -45,10 +45,10 @@ __write_gdt(gdt_reg_x64_t *gdt_reg) noexcept
 void
 intrinsics_ut::test_gdt_reg_set_get()
 {
-    x64::gdt::set(g_gdt.data(), 4 << 3);
+    x64::gdt::set(g_gdt.data(), (4 << 3) - 1);
 
     this->expect_true(x64::gdt::get().base == g_gdt.data());
-    this->expect_true(x64::gdt::get().limit == 4 << 3);
+    this->expect_true(x64::gdt::get().limit == (4 << 3) - 1);
 }
 
 void
@@ -61,8 +61,8 @@ intrinsics_ut::test_gdt_reg_base_set_get()
 void
 intrinsics_ut::test_gdt_reg_limit_set_get()
 {
-    x64::gdt::limit::set(4 << 3);
-    this->expect_true(x64::gdt::limit::get() == 4 << 3);
+    x64::gdt::limit::set((4 << 3) - 1);
+    this->expect_true(x64::gdt::limit::get() == (4 << 3) - 1);
 }
 
 void
@@ -82,7 +82,7 @@ intrinsics_ut::test_gdt_constructor_size()
 {
     gdt_x64 gdt{4};
     this->expect_true(gdt.base() != 0);
-    this->expect_true(gdt.limit() == 4 * sizeof(gdt_x64::segment_descriptor_type));
+    this->expect_true(gdt.limit() == (4 * sizeof(gdt_x64::segment_descriptor_type)) - 1);
 }
 
 void
@@ -96,7 +96,7 @@ void
 intrinsics_ut::test_gdt_limit()
 {
     gdt_x64 gdt;
-    this->expect_true(gdt.limit() == 4 * sizeof(gdt_x64::segment_descriptor_type));
+    this->expect_true(gdt.limit() == (4 * sizeof(gdt_x64::segment_descriptor_type)) - 1);
 }
 
 void


### PR DESCRIPTION
The fix that resolved the issue we discussed here: https://github.com/Bareflank/hypervisor/issues/461
The rationale behind this change is that m_gdt_reg.limit is coming directly from SGDT and therefore is size minus one. 