### PR TITLE
bfelf_loader/test: compile fix for test

### DIFF
--- a/bfelf_loader/test/test.h
+++ b/bfelf_loader/test/test.h
@@ -140,8 +140,8 @@ private:
     uint64_t m_dummy_misc_length;
     uint64_t m_dummy_code_length;
 
-    std::shared_ptr<char> m_dummy_misc_exec;
-    std::shared_ptr<char> m_dummy_code_exec;
+    std::unique_ptr<char[]> m_dummy_misc_exec;
+    std::unique_ptr<char[]> m_dummy_code_exec;
 };
 
 #endif


### PR DESCRIPTION
Fixes error compiling:

/home/chris/git/hypervisor/bfelf_loader/test/test_loader_relocate.cpp: In member function ‘void bfelf_loader_ut::test_bfelf_loader_relocate_uninitialized_files()’:
/home/chris/git/hypervisor/bfelf_loader/test/test_loader_relocate.cpp:56:63: error: no match for ‘operator=’ (operand types are ‘std::shared_ptr<char>’ and ‘std::remove_reference<std::unique_ptr<char []>&>::type {aka std::unique_ptr<char []>}’)
     m_dummy_misc_exec = std::move(std::get<0>(dummy_misc_pair));
...

Convert m_dummy_misc_exec and m_dummy_code_exec from:
- shared_ptr to unique_ptr
- from char to char[].

On a side note, how is this not caught by automated CI build/test?

Signed-off-by: Chris Patterson <pattersonc@ainfosec.com>