### PR TITLE
Map guest GDT read-write before promotion

### DIFF
--- a/bfvmm/include/exit_handler/exit_handler_intel_x64.h
+++ b/bfvmm/include/exit_handler/exit_handler_intel_x64.h
@@ -123,7 +123,7 @@ public:
 protected:
 #endif
 
-    virtual void promote();
+    virtual void promote(gsl::not_null<const void *> guest_gdt);
 
     virtual void resume();
     virtual void advance_and_resume();

--- a/bfvmm/include/intrinsics/x86/common/gdt_x64.h
+++ b/bfvmm/include/intrinsics/x86/common/gdt_x64.h
@@ -29,6 +29,8 @@
 #include <bfexception.h>
 #include <bftypes.h>
 
+#include <intrinsics/x86/common/x64.h>
+
 // -----------------------------------------------------------------------------
 // Exports
 // -----------------------------------------------------------------------------
@@ -90,6 +92,8 @@ namespace x64
 {
 namespace gdt
 {
+    using length_type = uint64_t;
+
     inline auto get() noexcept
     {
         auto reg = gdt_reg_x64_t{};
@@ -143,6 +147,14 @@ namespace gdt
             _write_gdt(&reg);
         }
     }
+
+    inline auto paged_length(length_type bytes)
+    {
+        auto pages = ((bytes & (x64::page_size - 1)) != 0ULL) ? 1ULL : 0ULL;
+        pages += bytes >> x64::page_shift;
+        return pages * x64::page_size;
+    }
+
 }
 }
 

--- a/bfvmm/include/intrinsics/x86/common/idt_x64.h
+++ b/bfvmm/include/intrinsics/x86/common/idt_x64.h
@@ -92,6 +92,8 @@ namespace x64
 {
 namespace idt
 {
+    using length_type = uint64_t;
+
     inline auto get() noexcept
     {
         auto reg = idt_reg_x64_t{};
@@ -144,6 +146,13 @@ namespace idt
             reg.limit = limit;
             _write_idt(&reg);
         }
+    }
+
+    inline auto paged_length(length_type bytes)
+    {
+        auto pages = ((bytes & (x64::page_size - 1)) != 0ULL) ? 1ULL : 0ULL;
+        pages += bytes >> x64::page_shift;
+        return pages * x64::page_size;
     }
 }
 }

--- a/bfvmm/include/vmcs/vmcs_intel_x64.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64.h
@@ -137,10 +137,16 @@ public:
     ///       when "-O3" was enabled. The order of each instruction is very
     ///       important
     ///
-    /// @expects none
+    /// @note guest_gdt is the virtual address of the guest's GDT that
+    ///       has been mapped into the VMM read/write.  It is marked const
+    ///       in order to prevent static analysis from complaining, but
+    ///       the memory will be written by the processor in
+    ///       vmcs_intel_x64_promote.asm
+    ///
+    /// @expects guest_gdt != nullptr
     /// @ensures none
     ///
-    virtual void promote();
+    virtual void promote(gsl::not_null<const void *> guest_gdt);
 
     /// Load
     ///

--- a/bfvmm/include/vmcs/vmcs_intel_x64_promote.h
+++ b/bfvmm/include/vmcs/vmcs_intel_x64_promote.h
@@ -23,6 +23,7 @@
 #define VMCS_INTEL_X64_PROMOTE_H
 
 #include <cstdint>
+#include <exit_handler/state_save_intel_x64.h>
 
 /// Promote VMCS
 ///
@@ -31,6 +32,8 @@
 ///
 /// @note this function does not return
 ///
-extern "C" void vmcs_promote(uintptr_t state_save) noexcept;
+extern "C" void
+vmcs_promote(
+    state_save_intel_x64 *state_save, const void * guest_gdt) noexcept;
 
 #endif

--- a/bfvmm/src/intrinsics/tests/test_gdt_x64.cpp
+++ b/bfvmm/src/intrinsics/tests/test_gdt_x64.cpp
@@ -83,6 +83,24 @@ TEST_CASE("gdt_reg_limit_set_get")
     CHECK(x64::gdt::limit::get() == 4 << 3);
 }
 
+TEST_CASE("gdt_paged_length")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto bytes = 0x0;
+    CHECK(x64::gdt::paged_length(bytes) == 0U * x64::page_size);
+
+    bytes = 0x2;
+    CHECK(x64::gdt::paged_length(bytes) == 1U * x64::page_size);
+
+    bytes = 0x1000;
+    CHECK(x64::gdt::paged_length(bytes) == 1U * x64::page_size);
+
+    bytes = 0x1001;
+    CHECK(x64::gdt::paged_length(bytes) == 2U * x64::page_size);
+}
+
 TEST_CASE("gdt_constructor_no_size")
 {
     MockRepository mocks;

--- a/bfvmm/src/intrinsics/tests/test_idt_x64.cpp
+++ b/bfvmm/src/intrinsics/tests/test_idt_x64.cpp
@@ -79,6 +79,24 @@ TEST_CASE("idt_reg_limit_set_get")
     CHECK(x64::idt::limit::get() == (4 << 3) - 1);
 }
 
+TEST_CASE("idt_paged_length")
+{
+    MockRepository mocks;
+    setup_intrinsics(mocks);
+
+    auto bytes = 0;
+    CHECK(x64::idt::paged_length::(bytes) == 0U * x64::page_size);
+
+    bytes = 0xfff;
+    CHECK(x64::idt::paged_length::(bytes) == 1U * x64::page_size);
+
+    bytes = 0x1000;
+    CHECK(x64::idt::paged_length::(bytes) == 1U * x64::page_size);
+
+    bytes = 0x4001;
+    CHECK(x64::idt::paged_length::(bytes) == 5U * x64::page_size);
+}
+
 TEST_CASE("idt_constructor_no_size")
 {
     MockRepository mocks;

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64.cpp
@@ -77,14 +77,9 @@ vmcs_intel_x64::launch(gsl::not_null<vmcs_intel_x64_state *> host_state,
 }
 
 void
-vmcs_intel_x64::promote()
+vmcs_intel_x64::promote(gsl::not_null<const void *> guest_gdt)
 {
-    // TODO:
-    //
-    // Why are we not passing m_state_save? Seems safer then using the
-    // VMCS
-
-    vmcs_promote(vmcs::host_gs_base::get());
+    vmcs_promote(m_state_save, guest_gdt);
     throw std::runtime_error("vmcs promote failed");
 }
 

--- a/bfvmm/src/vmcs/src/vmcs_intel_x64_promote_mock.cpp
+++ b/bfvmm/src/vmcs/src/vmcs_intel_x64_promote_mock.cpp
@@ -23,7 +23,10 @@
 #include <vmcs/vmcs_intel_x64_promote.h>
 
 extern "C" void
-vmcs_promote(uintptr_t state_save) noexcept
+vmcs_promote(
+    state_save_intel_x64 *state_save,
+    const void * guest_gdt) noexcept
 {
     bfignored(state_save);
+    bfignored(guest_gdt);
 }

--- a/bfvmm/src/vmcs/tests/test_vmcs_intel_x64.cpp
+++ b/bfvmm/src/vmcs/tests/test_vmcs_intel_x64.cpp
@@ -107,9 +107,10 @@ test_cpuid_eax(uint32_t val) noexcept
 { return g_eax_cpuid[val]; }
 
 static void
-vmcs_promote_fail(bool state_save)
+vmcs_promote_fail(bool state_save, gsl::not_null<const void *> addr)
 {
     (void) state_save;
+    (void) addr;
 }
 
 static void
@@ -399,7 +400,7 @@ TEST_CASE("vmcs: promote_failure")
     mocks.OnCallFunc(_vmread).Do(test_vmread);
 
     vmcs_intel_x64 vmcs{};
-    CHECK_THROWS(vmcs.promote());
+    CHECK_THROWS(vmcs.promote(reinterpret_cast<char *>(0x1000UL)));
 }
 
 TEST_CASE("vmcs: resume_failure")

--- a/bfvmm/src/vmcs/tests/test_vmcs_intel_x64_promote_mock.cpp
+++ b/bfvmm/src/vmcs/tests/test_vmcs_intel_x64_promote_mock.cpp
@@ -25,5 +25,5 @@
 
 TEST_CASE("")
 {
-    CHECK_NOTHROW(vmcs_promote(0));
+    CHECK_NOTHROW(vmcs_promote(0, 0));
 }


### PR DESCRIPTION
This patch maps the guest's GDT into the hypervisor read/write
in exit_handler_intel_x64::handle_vmxoff.  This allows the
processor to set the TSS busy bit without it causing
a page fault if the guest has mapped in the GDT read-only
(Linux now exposes a read-only GDT, see 69218e4 and 45fc875
in the linux tree for more details).