### PR TITLE
Build System Support for Aarch64 #498

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+    config.vm.provider "virtualbox" do |vb|
+        vb.memory = "2048"
+        vb.cpus = 2
+    end
+
+    config.vm.define "ubuntu17_04", primary: true do |ubuntu17_04|
+        ubuntu17_04.vm.box = "ubuntu/zesty64"
+        ubuntu17_04.vm.provision "shell",
+            path: "scripts/vagrant/provision_ubuntu17_04.sh"
+    end
+end

--- a/scripts/vagrant/provision_ubuntu17_04.sh
+++ b/scripts/vagrant/provision_ubuntu17_04.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+VAGRANT_BUILD_DIR="/vagrant/build_ubuntu17_04"
+VAGRANT_HOME_DIR="/home/ubuntu"
+
+sudo apt-get update
+sudo apt-get install -y git build-essential linux-headers-$(uname -r) clang \
+    binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu nasm cmake
+
+# Setup Bareflank environment variables
+echo "source /vagrant/env.sh $VAGRANT_BUILD_DIR" >> $VAGRANT_HOME_DIR/.profile
+
+# Have 'vagrant ssh' bring you straight to the configured build directory
+echo "cd $VAGRANT_BUILD_DIR" >> $VAGRANT_HOME_DIR/.profile


### PR DESCRIPTION
Added Vagrant support for the latest three versions of Ubuntu

1) Added a Vagrantfile

2) Added provisioning scripts for each version of Ubuntu

[RFC] Build System Support for Aarch64 #498