### PR TITLE
Add PL011 serial driver, genericize portio interface

### DIFF
--- a/bfsdk/include/bfconstants.h
+++ b/bfsdk/include/bfconstants.h
@@ -286,6 +286,24 @@
 #endif
 
 /*
+ * Default serial baud rate divisor, integer part (for PL011)
+ *
+ * Note: See bfvmm/serial/serial_port_pl011.h
+ */
+#ifndef DEFAULT_BAUD_RATE_INT
+#define DEFAULT_BAUD_RATE_INT 0x4
+#endif
+
+/*
+ * Default serial baud rate divisor, fractional part (for PL011)
+ *
+ * Note: See bfvmm/serial/serial_port_pl011.h
+ */
+#ifndef DEFAULT_BAUD_RATE_FRAC
+#define DEFAULT_BAUD_RATE_FRAC 0x0
+#endif
+
+/*
  * Default Serial Data Bits
  *
  * Note: See bfvmm/serial/serial_port_ns16550a.h

--- a/bfvmm/include/intrinsics/aarch64/common/portio_aarch64.h
+++ b/bfvmm/include/intrinsics/aarch64/common/portio_aarch64.h
@@ -1,0 +1,67 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2017 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef PORTIO_AARCH64_H
+#define PORTIO_AARCH64_H
+
+namespace intrinsics
+{
+namespace portio
+{
+
+    using port_addr_type = uintptr_t;
+    using port_8bit_type = uint8_t;
+    using port_16bit_type = uint16_t;
+    using port_32bit_type = uint32_t;
+    using port_64bit_type = uint64_t;
+    using integer_pointer = uintptr_t;
+    using size_type = size_t;
+
+    template<typename T> inline T in(port_addr_type port) noexcept
+    { return *reinterpret_cast<T volatile *>(port); }
+
+    template<typename T> inline void out(port_addr_type port, T data) noexcept
+    { *reinterpret_cast<T volatile *>(port) = data; }
+
+    inline auto inb(port_addr_type port) noexcept
+    { return in<port_8bit_type>(port); }
+
+    inline auto inw(port_addr_type port) noexcept
+    { return in<port_16bit_type>(port); }
+
+    inline auto ind(port_addr_type port) noexcept
+    { return in<port_32bit_type>(port); }
+
+    inline auto inq(port_addr_type port) noexcept
+    { return in<port_64bit_type>(port); }
+
+    inline void outb(port_addr_type port, uint8_t data) noexcept
+    { return out(port, data); }
+
+    inline void outw(port_addr_type port, uint16_t data) noexcept
+    { return out(port, data); }
+
+    inline void outd(port_addr_type port, uint32_t data) noexcept
+    { return out(port, data); }
+
+    inline void outq(port_addr_type port, uint64_t data) noexcept
+    { return out(port, data); }
+}
+}
+
+#endif

--- a/bfvmm/include/intrinsics/aarch64/common_aarch64.h
+++ b/bfvmm/include/intrinsics/aarch64/common_aarch64.h
@@ -1,0 +1,24 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef INTRINSICS_AARCH64_COMMON_AARCH64_H
+#define INTRINSICS_AARCH64_COMMON_AARCH64_H
+
+#include <intrinsics/aarch64/common/portio_aarch64.h>
+
+#endif

--- a/bfvmm/include/intrinsics/common.h
+++ b/bfvmm/include/intrinsics/common.h
@@ -1,0 +1,30 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2017 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef INTRINSICS_H
+#define INTRINSICS_H
+
+#include <bfarch.h>
+
+#if defined(BF_AARCH64)
+#   include <intrinsics/aarch64/common_aarch64.h>
+#elif defined(BF_X64)
+#   include <intrinsics/x86/common_x64.h>
+#endif
+
+#endif

--- a/bfvmm/include/intrinsics/x86/common/portio_x64.h
+++ b/bfvmm/include/intrinsics/x86/common/portio_x64.h
@@ -65,7 +65,7 @@ extern "C" EXPORT_INTRINSICS void _outsdrep(uint16_t port, uint64_t m32, uint32_
 
 // *INDENT-OFF*
 
-namespace x64
+namespace intrinsics
 {
 namespace portio
 {

--- a/bfvmm/include/serial/serial_port_ns16550a.h
+++ b/bfvmm/include/serial/serial_port_ns16550a.h
@@ -16,14 +16,14 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef SERIAL_PORT_INTEL_X64_H
-#define SERIAL_PORT_INTEL_X64_H
+#ifndef SERIAL_PORT_NS16550A_H
+#define SERIAL_PORT_NS16550A_H
 
 #include <string>
 #include <memory>
 
 #include <bfconstants.h>
-#include <intrinsics/x86/common_x64.h>
+#include <intrinsics/common.h>
 
 // -----------------------------------------------------------------------------
 // Exports
@@ -55,32 +55,32 @@
 namespace serial_ns16550a
 {
 
-constexpr const x64::portio::port_8bit_type dlab = 1U << 7;
+constexpr const intrinsics::portio::port_8bit_type dlab = 1U << 7;
 
-constexpr const x64::portio::port_addr_type baud_rate_lo_reg = 0U;
-constexpr const x64::portio::port_addr_type baud_rate_hi_reg = 1U;
-constexpr const x64::portio::port_addr_type interrupt_en_reg = 1U;
-constexpr const x64::portio::port_addr_type fifo_control_reg = 2U;
-constexpr const x64::portio::port_addr_type line_control_reg = 3U;
-constexpr const x64::portio::port_addr_type line_status_reg = 5U;
+constexpr const intrinsics::portio::port_addr_type baud_rate_lo_reg = 0U;
+constexpr const intrinsics::portio::port_addr_type baud_rate_hi_reg = 1U;
+constexpr const intrinsics::portio::port_addr_type interrupt_en_reg = 1U;
+constexpr const intrinsics::portio::port_addr_type fifo_control_reg = 2U;
+constexpr const intrinsics::portio::port_addr_type line_control_reg = 3U;
+constexpr const intrinsics::portio::port_addr_type line_status_reg = 5U;
 
-constexpr const x64::portio::port_8bit_type fifo_control_enable_fifos = 1U << 0;
-constexpr const x64::portio::port_8bit_type fifo_control_clear_recieve_fifo = 1U << 1;
-constexpr const x64::portio::port_8bit_type fifo_control_clear_transmit_fifo = 1U << 2;
-constexpr const x64::portio::port_8bit_type fifo_control_dma_mode_select = 1U << 3;
+constexpr const intrinsics::portio::port_8bit_type fifo_control_enable_fifos = 1U << 0;
+constexpr const intrinsics::portio::port_8bit_type fifo_control_clear_recieve_fifo = 1U << 1;
+constexpr const intrinsics::portio::port_8bit_type fifo_control_clear_transmit_fifo = 1U << 2;
+constexpr const intrinsics::portio::port_8bit_type fifo_control_dma_mode_select = 1U << 3;
 
-constexpr const x64::portio::port_8bit_type line_status_data_ready = 1U << 0;
-constexpr const x64::portio::port_8bit_type line_status_overrun_error = 1U << 1;
-constexpr const x64::portio::port_8bit_type line_status_parity_error = 1U << 2;
-constexpr const x64::portio::port_8bit_type line_status_framing_error = 1U << 3;
-constexpr const x64::portio::port_8bit_type line_status_break_interrupt = 1U << 4;
-constexpr const x64::portio::port_8bit_type line_status_empty_transmitter = 1U << 5;
-constexpr const x64::portio::port_8bit_type line_status_empty_data = 1U << 6;
-constexpr const x64::portio::port_8bit_type line_status_recieved_fifo_error = 1U << 7;
+constexpr const intrinsics::portio::port_8bit_type line_status_data_ready = 1U << 0;
+constexpr const intrinsics::portio::port_8bit_type line_status_overrun_error = 1U << 1;
+constexpr const intrinsics::portio::port_8bit_type line_status_parity_error = 1U << 2;
+constexpr const intrinsics::portio::port_8bit_type line_status_framing_error = 1U << 3;
+constexpr const intrinsics::portio::port_8bit_type line_status_break_interrupt = 1U << 4;
+constexpr const intrinsics::portio::port_8bit_type line_status_empty_transmitter = 1U << 5;
+constexpr const intrinsics::portio::port_8bit_type line_status_empty_data = 1U << 6;
+constexpr const intrinsics::portio::port_8bit_type line_status_recieved_fifo_error = 1U << 7;
 
-constexpr const x64::portio::port_8bit_type line_control_data_mask = 0x03;
-constexpr const x64::portio::port_8bit_type line_control_stop_mask = 0x04;
-constexpr const x64::portio::port_8bit_type line_control_parity_mask = 0x38;
+constexpr const intrinsics::portio::port_8bit_type line_control_data_mask = 0x03;
+constexpr const intrinsics::portio::port_8bit_type line_control_stop_mask = 0x04;
+constexpr const intrinsics::portio::port_8bit_type line_control_parity_mask = 0x38;
 
 }
 
@@ -90,7 +90,7 @@ constexpr const x64::portio::port_8bit_type line_control_parity_mask = 0x38;
 // Definitions
 // -----------------------------------------------------------------------------
 
-/// Serial Port (Intel x64)
+/// Serial Port (NatSemi 16550A and compatible)
 ///
 /// This class implements the serial device for Intel specific archiectures.
 /// All of the serial devices start off with the same default settings (minus
@@ -107,8 +107,8 @@ class EXPORT_SERIAL serial_port_ns16550a
 {
 public:
 
-    using port_type = x64::portio::port_addr_type;          ///< Port type
-    using value_type = x64::portio::port_8bit_type;         ///< Value type
+    using port_type = intrinsics::portio::port_addr_type;          ///< Port type
+    using value_type = intrinsics::portio::port_8bit_type;         ///< Value type
 
 public:
 

--- a/bfvmm/include/serial/serial_port_pl011.h
+++ b/bfvmm/include/serial/serial_port_pl011.h
@@ -1,0 +1,414 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef SERIAL_PORT_PL011_H
+#define SERIAL_PORT_PL011_H
+
+#include <string>
+#include <memory>
+
+#include <bfconstants.h>
+#include <intrinsics/common.h>
+
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+#include <bfexports.h>
+
+#ifndef STATIC_SERIAL
+#ifdef SHARED_SERIAL
+#define EXPORT_SERIAL EXPORT_SYM
+#else
+#define EXPORT_SERIAL IMPORT_SYM
+#endif
+#else
+#define EXPORT_SERIAL
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
+
+// -----------------------------------------------------------------------------
+// Constants
+// -----------------------------------------------------------------------------
+
+/// @cond
+
+// from ARM PrimeCell UART (PL011) Technical Reference Manual
+// http://infocenter.arm.com/help/topic/com.arm.doc.ddi0183f/DDI0183.pdf
+
+namespace serial_pl011
+{
+constexpr const intrinsics::portio::port_addr_type uartdr_reg = 0x000u;
+constexpr const intrinsics::portio::port_addr_type uartrsr_reg = 0x004u;
+constexpr const intrinsics::portio::port_addr_type uartecr_reg = 0x004u;
+constexpr const intrinsics::portio::port_addr_type uartfr_reg = 0x018u;
+constexpr const intrinsics::portio::port_addr_type uartilpr_reg = 0x020u;
+constexpr const intrinsics::portio::port_addr_type uartibrd_reg = 0x024u;
+constexpr const intrinsics::portio::port_addr_type uartfbrd_reg = 0x028u;
+constexpr const intrinsics::portio::port_addr_type uartlcr_h_reg = 0x02Cu;
+constexpr const intrinsics::portio::port_addr_type uartcr_reg = 0x030u;
+constexpr const intrinsics::portio::port_addr_type uartifls_reg = 0x034u;
+constexpr const intrinsics::portio::port_addr_type uartimsc_reg = 0x038u;
+constexpr const intrinsics::portio::port_addr_type uartris_reg = 0x03Cu;
+constexpr const intrinsics::portio::port_addr_type uartmis_reg = 0x040u;
+constexpr const intrinsics::portio::port_addr_type uarticr_reg = 0x044u;
+constexpr const intrinsics::portio::port_addr_type uartdmacr_reg = 0x048u;
+constexpr const intrinsics::portio::port_addr_type uartperiphid0_reg = 0xFE0u;
+constexpr const intrinsics::portio::port_addr_type uartperiphid1_reg = 0xFE4u;
+constexpr const intrinsics::portio::port_addr_type uartperiphid2_reg = 0xFE8u;
+constexpr const intrinsics::portio::port_addr_type uartperiphid3_reg = 0xFECu;
+constexpr const intrinsics::portio::port_addr_type uartpcellid0_reg = 0xFF0u;
+constexpr const intrinsics::portio::port_addr_type uartpcellid1_reg = 0xFF4u;
+constexpr const intrinsics::portio::port_addr_type uartpcellid2_reg = 0xFF8u;
+constexpr const intrinsics::portio::port_addr_type uartpcellid3_reg = 0xFFCu;
+
+// Data register (UARTDR)
+constexpr const intrinsics::portio::port_32bit_type uartdr_overrun_error = 1U << 11;
+constexpr const intrinsics::portio::port_32bit_type uartdr_break_error = 1U << 10;
+constexpr const intrinsics::portio::port_32bit_type uartdr_parity_error = 1U << 9;
+constexpr const intrinsics::portio::port_32bit_type uartdr_framing_error = 1U << 8;
+constexpr const intrinsics::portio::port_32bit_type uartdr_data_mask = 0xFFu;
+
+// Receive status register (UARTRSR)
+// Error clear register (UARTECR)
+constexpr const intrinsics::portio::port_32bit_type uartrsr_overrun_error = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartrsr_break_error = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartrsr_parity_error = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartrsr_framing_error = 1U << 0;
+
+// Flag register (UARTFR)
+constexpr const intrinsics::portio::port_32bit_type uartfr_ring_indicator = 1U << 8;
+constexpr const intrinsics::portio::port_32bit_type uartfr_tx_empty = 1U << 7;
+constexpr const intrinsics::portio::port_32bit_type uartfr_rx_full = 1U << 6;
+constexpr const intrinsics::portio::port_32bit_type uartfr_tx_full = 1U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartfr_rx_empty = 1U << 4;
+constexpr const intrinsics::portio::port_32bit_type uartfr_busy = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartfr_dcd = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartfr_dsr = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartfr_cts = 1U << 0;
+
+// Line control register (UARTLCR_H)
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_wlen_mask = 3U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_wlen_8bit = 3U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_wlen_7bit = 2U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_wlen_6bit = 1U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_wlen_5bit = 0U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_fifo_enable = 1U << 4;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_stop_mask = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_stop_1bit = 0U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_stop_2bit = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_sps = 1U << 7;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_eps = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_pen = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_mask = uartlcr_h_sps | uartlcr_h_eps | uartlcr_h_pen;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_even = uartlcr_h_eps | uartlcr_h_pen;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_odd = uartlcr_h_pen;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_none = 0;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_one = uartlcr_h_pen | uartlcr_h_sps;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_parity_zero = uartlcr_h_pen | uartlcr_h_sps | uartlcr_h_eps;
+constexpr const intrinsics::portio::port_32bit_type uartlcr_h_send_break = 1U << 0;
+
+// Control register (UARTCR)
+constexpr const intrinsics::portio::port_32bit_type uartcr_ctse_n = 1U << 15;
+constexpr const intrinsics::portio::port_32bit_type uartcr_rtse_n = 1U << 14;
+constexpr const intrinsics::portio::port_32bit_type uartcr_out2 = 1U << 13;
+constexpr const intrinsics::portio::port_32bit_type uartcr_out1 = 1U << 12;
+constexpr const intrinsics::portio::port_32bit_type uartcr_rts = 1U << 11;
+constexpr const intrinsics::portio::port_32bit_type uartcr_dtr = 1U << 10;
+constexpr const intrinsics::portio::port_32bit_type uartcr_rx_en = 1U << 9;
+constexpr const intrinsics::portio::port_32bit_type uartcr_tx_en = 1U << 8;
+constexpr const intrinsics::portio::port_32bit_type uartcr_loopback_en = 1U << 7;
+constexpr const intrinsics::portio::port_32bit_type uartcr_sirlp = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartcr_siren = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartcr_uart_en = 1U << 0;
+
+// Interrupt FIFO level select register (UARTIFLS)
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_mask = 7U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_1_8 = 0U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_1_4 = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_1_2 = 2U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_3_4 = 3U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_rxiflsel_7_8 = 4U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_mask = 7U << 0;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_1_8 = 0U << 0;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_1_4 = 1U << 0;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_1_2 = 2U << 0;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_3_4 = 3U << 0;
+constexpr const intrinsics::portio::port_32bit_type uartifls_txiflsel_7_8 = 4U << 0;
+
+// Interrupt mask set/clear register (UARTIMSC)
+// Raw interrupt status register (UARTRIS)
+// Masked interrupt status register (UARTMIS)
+// Interrupt clear register (UARTICR)
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_oe = 1U << 10;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_be = 1U << 9;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_pe = 1U << 8;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_fe = 1U << 7;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_rt = 1U << 6;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_tx = 1U << 5;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_rx = 1U << 4;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_dsrm = 1U << 3;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_dcdm = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_ctsm = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartinterrupt_rim = 1U << 0;
+
+// DMA control register (UARTDMACR)
+constexpr const intrinsics::portio::port_32bit_type uartdmacr_dmaonerr = 1U << 2;
+constexpr const intrinsics::portio::port_32bit_type uartdmacr_txdma_en = 1U << 1;
+constexpr const intrinsics::portio::port_32bit_type uartdmacr_rxdma_en = 1U << 0;
+
+}
+
+/// @endcond
+
+// -----------------------------------------------------------------------------
+// Definitions
+// -----------------------------------------------------------------------------
+
+/// Serial Port (ARM PrimeCell PL011)
+///
+/// This class implements the serial peripheral for ARM devices implementing
+/// PrimeCell PL011 (note that many implement NatSemi NS16550A instead).
+///
+/// Note that by default, a FIFO is used / required, and interrupts are
+/// disabled.
+///
+class EXPORT_SERIAL serial_port_pl011
+{
+public:
+
+    using port_type = intrinsics::portio::port_addr_type;          ///< Port type
+    using value_type = intrinsics::portio::port_32bit_type;         ///< Value type
+
+public:
+
+    /// @cond
+
+    enum data_bits_t : value_type {
+        char_length_5 = serial_pl011::uartlcr_h_wlen_5bit,
+        char_length_6 = serial_pl011::uartlcr_h_wlen_6bit,
+        char_length_7 = serial_pl011::uartlcr_h_wlen_7bit,
+        char_length_8 = serial_pl011::uartlcr_h_wlen_8bit,
+    };
+
+    enum stop_bits_t : value_type {
+        stop_bits_1 = serial_pl011::uartlcr_h_stop_1bit,
+        stop_bits_2 = serial_pl011::uartlcr_h_stop_2bit,
+    };
+
+    enum parity_bits_t : value_type {
+        parity_none = serial_pl011::uartlcr_h_parity_none,
+        parity_odd = serial_pl011::uartlcr_h_parity_odd,
+        parity_even = serial_pl011::uartlcr_h_parity_even,
+        parity_mark = serial_pl011::uartlcr_h_parity_one,
+        parity_space = serial_pl011::uartlcr_h_parity_zero,
+    };
+
+    /// @endcond
+
+public:
+
+    /// Default Constructor
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param port the serial port to connect to
+    ///
+    serial_port_pl011(port_type port = DEFAULT_COM_PORT) noexcept;
+
+    /// Destructor
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    ~serial_port_pl011() = default;
+
+    /// Get Instance
+    ///
+    /// Get an instance to the class.
+    ///
+    /// @expects none
+    /// @ensures ret != nullptr
+    ///
+    /// @return a singleton instance of serial_port_pl011
+    ///
+    static serial_port_pl011 *instance() noexcept;
+
+    /// Set Baud Rate Divisor
+    ///
+    /// Sets the divisor used to generate the baud rate. The real baud rate
+    /// will equal the UART clock divided by (int_part * 16 + frac_part).
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param int_part integer part of the divisor
+    /// @param frac_part fractional part of the divisor
+    ///
+    void set_baud_rate_divisor(uint32_t int_part, uint32_t frac_part) noexcept;
+
+    /// Baud Rate Divisor
+    ///
+    /// Gets the integer and fractional parts of the baud rate divisor.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param int_part outparam for integer part of the divisor
+    /// @param frac_part outparam for fractional part of the divisor
+    ///
+    void baud_rate_divisor(uint32_t &int_part, uint32_t &frac_part) const noexcept;
+
+    /// Set Data Bits
+    ///
+    /// Sets the size of the data that is transmitted.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param bits the desired data bits
+    ///
+    void set_data_bits(data_bits_t bits) noexcept;
+
+    /// Data Bits
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return the serial device's data bits
+    ///
+    data_bits_t data_bits() const noexcept;
+
+    /// Set Stop Bits
+    ///
+    /// Sets the stop bits used for transmission.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param bits the desired stop bits
+    ///
+    void set_stop_bits(stop_bits_t bits) noexcept;
+
+    /// Stop Bits
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return the serial device's stop bits
+    ///
+    stop_bits_t stop_bits() const noexcept;
+
+    /// Set Parity Bits
+    ///
+    /// Sets the parity bits used for transmission.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param bits the desired parity bits
+    ///
+    void set_parity_bits(parity_bits_t bits) noexcept;
+
+    /// Parity Bits
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return the serial device's parity bits
+    ///
+    parity_bits_t parity_bits() const noexcept;
+
+    /// Port
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return the serial device's port
+    ///
+    port_type port() const noexcept
+    { return m_port; }
+
+    /// Write Character
+    ///
+    /// Writes a character to the serial device.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param c character to write
+    ///
+    void write(char c) noexcept;
+
+    /// Write String
+    ///
+    /// Writes a string to the serial device.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param str string to write
+    ///
+    void write(const std::string &str) noexcept;
+
+    /// Write String
+    ///
+    /// Writes a string to the serial device.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param str string to write
+    /// @param len length of the string to write
+    ///
+    void write(const char *str, size_t len) noexcept;
+
+private:
+
+    bool get_status_full_transmitter() const noexcept;
+
+    value_type offset_ind(intrinsics::portio::port_addr_type offset) const noexcept;
+    void offset_outd(intrinsics::portio::port_addr_type offset, value_type data) noexcept;
+
+private:
+
+    port_type m_port;
+
+public:
+
+    /// @cond
+
+    serial_port_pl011(serial_port_pl011 &&) noexcept = default;
+    serial_port_pl011 &operator=(serial_port_pl011 &&) noexcept = default;
+
+    serial_port_pl011(const serial_port_pl011 &) = delete;
+    serial_port_pl011 &operator=(const serial_port_pl011 &) = delete;
+
+    /// @endcond
+};
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+#endif

--- a/bfvmm/src/intrinsics/tests/test_portio_x64.cpp
+++ b/bfvmm/src/intrinsics/tests/test_portio_x64.cpp
@@ -23,7 +23,7 @@
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
-using namespace x64;
+using namespace intrinsics;
 
 TEST_CASE("test name goes here")
 {

--- a/bfvmm/src/serial/src/CMakeLists.txt
+++ b/bfvmm/src/serial/src/CMakeLists.txt
@@ -24,6 +24,7 @@ include(${CMAKE_INSTALL_PREFIX}/cmake/CMakeGlobal_Includes.txt)
 
 list(APPEND SOURCES
     serial_port_ns16550a.cpp
+    serial_port_pl011.cpp
 )
 
 if(BUILD_SHARED_LIBS)

--- a/bfvmm/src/serial/src/serial_port_ns16550a.cpp
+++ b/bfvmm/src/serial/src/serial_port_ns16550a.cpp
@@ -19,7 +19,7 @@
 #include <bfgsl.h>
 #include <serial/serial_port_ns16550a.h>
 
-using namespace x64;
+using namespace intrinsics;
 using namespace portio;
 using namespace serial_ns16550a;
 

--- a/bfvmm/src/serial/src/serial_port_pl011.cpp
+++ b/bfvmm/src/serial/src/serial_port_pl011.cpp
@@ -1,0 +1,194 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <bfgsl.h>
+#include <serial/serial_port_pl011.h>
+
+using namespace intrinsics;
+using namespace portio;
+using namespace serial_pl011;
+
+serial_port_pl011::serial_port_pl011(serial_port_pl011::port_type port) noexcept :
+    m_port(port)
+{
+    auto bits = offset_ind(uartlcr_h_reg);
+
+    bits |= uartlcr_h_fifo_enable;
+
+    offset_outd(uartimsc_reg, 0);
+    offset_outd(uartlcr_h_reg, bits);
+
+    this->set_baud_rate_divisor(DEFAULT_BAUD_RATE_INT, DEFAULT_BAUD_RATE_FRAC);
+    this->set_data_bits(DEFAULT_DATA_BITS);
+    this->set_stop_bits(DEFAULT_STOP_BITS);
+    this->set_parity_bits(DEFAULT_PARITY_BITS);
+}
+
+serial_port_pl011 *
+serial_port_pl011::instance() noexcept
+{
+    static serial_port_pl011 serial{};
+    return &serial;
+}
+
+// This method has to write UARTLCR_H as well because of a quirk in the PL011
+// implementation: UARTIBRD, UARTFBRD, and UARTLCR_H internally form a single
+// register that is only updated on a write to UARTLCR_H.
+void
+serial_port_pl011::set_baud_rate_divisor(uint32_t int_part, uint32_t frac_part) noexcept
+{
+    int_part &= 0xFFFF;
+    frac_part &= 0x3F;
+
+    value_type lcr_h = offset_ind(uartlcr_h_reg);
+
+    offset_outd(uartibrd_reg, int_part);
+    offset_outd(uartfbrd_reg, frac_part);
+    offset_outd(uartlcr_h_reg, lcr_h);
+}
+
+void
+serial_port_pl011::baud_rate_divisor(uint32_t &int_part, uint32_t &frac_part) const noexcept
+{
+    int_part = offset_ind(uartibrd_reg);
+    frac_part = offset_ind(uartfbrd_reg);
+}
+
+void
+serial_port_pl011::set_data_bits(data_bits_t bits) noexcept
+{
+    switch (bits) {
+        case char_length_5:
+        case char_length_6:
+        case char_length_7:
+        case char_length_8:
+            break;
+        default:
+            bits = DEFAULT_DATA_BITS;
+    }
+
+    auto lcr_h = offset_ind(uartlcr_h_reg);
+
+    lcr_h &= ~uartlcr_h_wlen_mask;
+    lcr_h |= bits & uartlcr_h_wlen_mask;
+
+    offset_outd(uartlcr_h_reg, lcr_h);
+}
+
+serial_port_pl011::data_bits_t
+serial_port_pl011::data_bits() const noexcept
+{
+    return static_cast<data_bits_t>(offset_ind(uartlcr_h_reg) & uartlcr_h_wlen_mask);
+}
+
+void
+serial_port_pl011::set_stop_bits(stop_bits_t bits) noexcept
+{
+    switch (bits) {
+        case stop_bits_1:
+        case stop_bits_2:
+            break;
+        default:
+            bits = DEFAULT_STOP_BITS;
+    }
+
+    auto lcr_h = offset_ind(uartlcr_h_reg);
+
+    lcr_h &= ~uartlcr_h_stop_mask;
+    lcr_h |= bits & uartlcr_h_stop_mask;
+
+    offset_outd(uartlcr_h_reg, lcr_h);
+}
+
+serial_port_pl011::stop_bits_t
+serial_port_pl011::stop_bits() const noexcept
+{
+    return static_cast<stop_bits_t>(offset_ind(uartlcr_h_reg) & uartlcr_h_stop_mask);
+}
+
+void
+serial_port_pl011::set_parity_bits(parity_bits_t bits) noexcept
+{
+    switch (bits) {
+        case parity_none:
+        case parity_odd:
+        case parity_even:
+        case parity_mark:
+        case parity_space:
+            break;
+        default:
+            bits = DEFAULT_PARITY_BITS;
+    }
+
+    auto lcr_h = offset_ind(uartlcr_h_reg);
+
+    lcr_h &= ~uartlcr_h_parity_mask;
+    lcr_h |= bits & uartlcr_h_parity_mask;
+
+    offset_outd(uartlcr_h_reg, lcr_h);
+}
+
+serial_port_pl011::parity_bits_t
+serial_port_pl011::parity_bits() const noexcept
+{
+    return static_cast<parity_bits_t>(offset_ind(uartlcr_h_reg) & uartlcr_h_parity_mask);
+}
+
+void
+serial_port_pl011::write(char c) noexcept
+{
+    while (get_status_full_transmitter())
+    { }
+
+    offset_outd(uartdr_reg, static_cast<value_type>(c));
+}
+
+void
+serial_port_pl011::write(const std::string &str) noexcept
+{
+    for (auto c : str) {
+        this->write(c);
+    }
+}
+
+void
+serial_port_pl011::write(const char *str, size_t len) noexcept
+{
+    for (size_t i = 0; i < len; ++i) {
+        this->write(str[i]);
+    }
+}
+
+bool
+serial_port_pl011::get_status_full_transmitter() const noexcept
+{
+    return (offset_ind(uartfr_reg) & uartfr_tx_full) != 0;
+}
+
+serial_port_pl011::value_type
+serial_port_pl011::offset_ind(port_addr_type offset) const noexcept
+{
+    return portio::ind(gsl::narrow_cast<port_addr_type>(m_port + offset));
+}
+
+void
+serial_port_pl011::offset_outd(port_addr_type offset, value_type data) noexcept
+{
+    portio::outd(gsl::narrow_cast<port_addr_type>(m_port + offset),
+                 gsl::narrow_cast<value_type>(data));
+}

--- a/bfvmm/src/serial/tests/CMakeLists.txt
+++ b/bfvmm/src/serial/tests/CMakeLists.txt
@@ -33,3 +33,4 @@ macro(do_test str)
 endmacro(do_test)
 
 do_test(serial_port_ns16550a)
+do_test(serial_port_pl011)

--- a/bfvmm/src/serial/tests/test_serial_port_pl011.cpp
+++ b/bfvmm/src/serial/tests/test_serial_port_pl011.cpp
@@ -1,0 +1,224 @@
+//
+// Bareflank Hypervisor
+//
+// Copyright (C) 2015 Assured Information Security, Inc.
+// Author: Rian Quinn        <quinnr@ainfosec.com>
+// Author: Brendan Kerrigan  <kerriganb@ainfosec.com>
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <catch/catch.hpp>
+
+#include <serial/serial_port_pl011.h>
+#include <hippomocks.h>
+#include <map>
+
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
+
+static std::map<serial_port_pl011::port_type, serial_port_pl011::value_type> g_ports;
+
+static uint32_t
+mock_ind(uint16_t port) noexcept
+{
+    return g_ports[port];
+}
+
+static void
+mock_outd(uint16_t port, uint32_t val) noexcept
+{
+    g_ports[port] = val;
+}
+
+static void
+mock_serial(MockRepository &mocks)
+{
+    mocks.OnCallFunc(_outd).Do(mock_outd);
+    mocks.OnCallFunc(_ind).Do(mock_ind);
+}
+
+TEST_CASE("serial: constructor_null_intrinsics")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    CHECK_NOTHROW(std::make_unique<serial_port_pl011>());
+}
+
+TEST_CASE("serial: success")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    uint32_t brd_int = 0, brd_frac = 0;
+
+    CHECK(serial_port_pl011::instance()->port() == DEFAULT_COM_PORT);
+    CHECK_NOTHROW(serial_port_pl011::instance()->baud_rate_divisor(brd_int, brd_frac));
+    CHECK(brd_int == DEFAULT_BAUD_RATE_INT);
+    CHECK(brd_frac == DEFAULT_BAUD_RATE_FRAC);
+    CHECK(serial_port_pl011::instance()->data_bits() == serial_port_pl011::DEFAULT_DATA_BITS);
+    CHECK(serial_port_pl011::instance()->stop_bits() == serial_port_pl011::DEFAULT_STOP_BITS);
+    CHECK(serial_port_pl011::instance()->parity_bits() == serial_port_pl011::DEFAULT_PARITY_BITS);
+
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartibrd_reg]) == DEFAULT_BAUD_RATE_INT);
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartfbrd_reg]) == DEFAULT_BAUD_RATE_FRAC);
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_fifo_enable) != 0);
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_wlen_mask) == serial_port_pl011::DEFAULT_DATA_BITS);
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_stop_mask) == serial_port_pl011::DEFAULT_STOP_BITS);
+    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_parity_mask) == serial_port_pl011::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: set_baud_rate_success")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    serial->set_baud_rate_divisor(0xffffffffu, 0xffffffffu);
+
+    uint32_t brd_int = 0, brd_frac = 0;
+    serial->baud_rate_divisor(brd_int, brd_frac);
+    CHECK(brd_int == 0xffffu);
+    CHECK(brd_frac == 0x3fu);
+}
+
+TEST_CASE("serial: set_data_bits_success")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    serial->set_data_bits(serial_port_pl011::char_length_5);
+    CHECK(serial->data_bits() == serial_port_pl011::char_length_5);
+    serial->set_data_bits(serial_port_pl011::char_length_6);
+    CHECK(serial->data_bits() == serial_port_pl011::char_length_6);
+    serial->set_data_bits(serial_port_pl011::char_length_7);
+    CHECK(serial->data_bits() == serial_port_pl011::char_length_7);
+    serial->set_data_bits(serial_port_pl011::char_length_8);
+    CHECK(serial->data_bits() == serial_port_pl011::char_length_8);
+}
+
+TEST_CASE("serial: set_data_bits_success_extra_bits")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    auto bits = serial_port_pl011::DEFAULT_DATA_BITS | ~serial_pl011::uartlcr_h_wlen_mask;
+    serial->set_data_bits(static_cast<serial_port_pl011::data_bits_t>(bits));
+
+    CHECK(serial->data_bits() == serial_port_pl011::DEFAULT_DATA_BITS);
+    CHECK(serial->stop_bits() == serial_port_pl011::DEFAULT_STOP_BITS);
+    CHECK(serial->parity_bits() == serial_port_pl011::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: set_stop_bits_success")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    serial->set_stop_bits(serial_port_pl011::stop_bits_1);
+    CHECK(serial->stop_bits() == serial_port_pl011::stop_bits_1);
+    serial->set_stop_bits(serial_port_pl011::stop_bits_2);
+    CHECK(serial->stop_bits() == serial_port_pl011::stop_bits_2);
+}
+
+TEST_CASE("serial: set_stop_bits_success_extra_bits")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    auto bits = serial_port_pl011::DEFAULT_STOP_BITS | ~serial_pl011::uartlcr_h_stop_mask;
+    serial->set_stop_bits(static_cast<serial_port_pl011::stop_bits_t>(bits));
+
+    CHECK(serial->data_bits() == serial_port_pl011::DEFAULT_DATA_BITS);
+    CHECK(serial->stop_bits() == serial_port_pl011::DEFAULT_STOP_BITS);
+    CHECK(serial->parity_bits() == serial_port_pl011::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: set_parity_bits_success")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    serial->set_parity_bits(serial_port_pl011::parity_none);
+    CHECK(serial->parity_bits() == serial_port_pl011::parity_none);
+    serial->set_parity_bits(serial_port_pl011::parity_odd);
+    CHECK(serial->parity_bits() == serial_port_pl011::parity_odd);
+    serial->set_parity_bits(serial_port_pl011::parity_even);
+    CHECK(serial->parity_bits() == serial_port_pl011::parity_even);
+    serial->set_parity_bits(serial_port_pl011::parity_mark);
+    CHECK(serial->parity_bits() == serial_port_pl011::parity_mark);
+    serial->set_parity_bits(serial_port_pl011::parity_space);
+    CHECK(serial->parity_bits() == serial_port_pl011::parity_space);
+}
+
+TEST_CASE("serial: set_parity_bits_success_extra_bits")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto serial = std::make_unique<serial_port_pl011>();
+
+    auto bits = serial_port_pl011::DEFAULT_PARITY_BITS | ~serial_pl011::uartlcr_h_parity_mask;
+    serial->set_parity_bits(static_cast<serial_port_pl011::parity_bits_t>(bits));
+
+    CHECK(serial->data_bits() == serial_port_pl011::DEFAULT_DATA_BITS);
+    CHECK(serial->stop_bits() == serial_port_pl011::DEFAULT_STOP_BITS);
+    CHECK(serial->parity_bits() == serial_port_pl011::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: write character")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
+
+    auto serial = std::make_unique<serial_port_pl011>();
+    serial->write('c');
+}
+
+TEST_CASE("serial: write string")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
+
+    auto serial = std::make_unique<serial_port_pl011>();
+    serial->write("hello world");
+}
+
+TEST_CASE("serial: write char buffer")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
+
+    auto serial = std::make_unique<serial_port_pl011>();
+    serial->write("hello world", 12);
+}
+
+#endif


### PR DESCRIPTION
This PR genericizes the portio interface to allow the serial driver to work under ARM (which uses MMIO), and adds a new driver for the [PrimeCell UART (PL011)](http://infocenter.arm.com/help/topic/com.arm.doc.ddi0183f/DDI0183.pdf) used in some ARM devices and in the current QEMU setup. The new driver is tested and working under QEMU (though still won't build for ARM without my "aarch64-hack" branch - check that out if you want to see it in action) and could compile and run on a hypothetical x64 system that used this device (so the tests run).

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>