### PR TITLE
Add bfarch.h to detect architecture and set flags

### DIFF
--- a/bfsdk/CMakeLists.txt
+++ b/bfsdk/CMakeLists.txt
@@ -176,6 +176,7 @@ install(FILES cmake/CMakeToolchain_VMM_38.txt DESTINATION cmake)
 install(FILES cmake/CMakeToolchain_VMM_39.txt DESTINATION cmake)
 install(FILES cmake/CMakeToolchain_VMM_40.txt DESTINATION cmake)
 
+install(FILES include/bfarch.h DESTINATION include)
 install(FILES include/bfaffinity.h DESTINATION include)
 install(FILES include/bfbenchmark.h DESTINATION include)
 install(FILES include/bfbitmanip.h DESTINATION include)

--- a/bfsdk/include/bfarch.h
+++ b/bfsdk/include/bfarch.h
@@ -1,0 +1,44 @@
+/*
+ * Bareflank Hypervisor
+ * Copyright (C) 2017 Assured Information Security, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef BFARCH_H
+#define BFARCH_H
+
+#if defined(_MSC_VER)
+#   if defined(_M_X64) && !defined(BF_ARCH)
+#       define BF_ARCH "x64"
+#       define BF_X64
+#   elif !defined(BF_ARCH)
+#       error "bfarch.h: unsupported architecture"
+#   endif
+#elif defined(__GNUC__) || defined(__clang__)
+#   if defined(__x86_64__) && !defined(BF_ARCH)
+#       define BF_ARCH "x64"
+#       define BF_X64
+#   elif defined(__aarch64__) && !defined(BF_ARCH)
+#       define BF_ARCH "aarch64"
+#       define BF_AARCH64
+#   elif !defined(BF_ARCH)
+#       error "bfarch.h: unsupported architecture"
+#   endif
+#else
+#   error "bfarch.h: cannot detect compiler"
+#endif
+
+#endif


### PR DESCRIPTION
This header tests for predefined macros on both supported compilers to determine the architecture being compiled for. Once detected, it defines two macros:

- `BF_ARCH` — string containing architecture name
- `BF_`*{archname}* — empty macro for `#ifdef` tests

Currently supported combinations are:

- x64 on MSVC (via _MSC_VER and _X64)
- x64 on GCC and clang (via \_\_GNUC__, \_\_clang__, and \_\_x86_64__)
- aarch64 on GCC and clang (via \_\_GNUC__, \_\_clang__, and \_\_aarch64__)

Additionally, this header allows the user or the build system to modify the architecture externally: defining BF_ARCH with -D disables the checks and allows you to force an architecture flag.

**Before accepting this pull request we may need to discuss how to properly document the ability to set a user-defined architecture; I'm not sure how this project handles that.**

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>