### PR TITLE
make format: don't attempt to format deleted files

### DIFF
--- a/bfsdk/scripts/bareflank_astyle_format.sh
+++ b/bfsdk/scripts/bareflank_astyle_format.sh
@@ -43,7 +43,7 @@ fi
 if [[ "$1" == "all" ]]; then
     files=$(ls_not_deleted | grep -Ee "\.(cpp|h|c)$" || true)
 else
-    files=$(git diff --relative --name-only HEAD $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+    files=$(git diff --relative --name-only --diff-filter=d HEAD $PWD | grep -Ee "\.(cpp|h|c)$" || true)
 
     echo "Files undergoing astyle checks:"
     for f in $files; do

--- a/bfsdk/scripts/bareflank_blank_lines.sh
+++ b/bfsdk/scripts/bareflank_blank_lines.sh
@@ -43,7 +43,7 @@ fi
 if [[ "$1" == "all" ]]; then
     files=$(ls_not_deleted | grep -Ee "\.(cpp|h|c)$" || true)
 else
-    files=$(git diff --relative --name-only HEAD $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+    files=$(git diff --relative --name-only --diff-filter=d HEAD $PWD | grep -Ee "\.(cpp|h|c)$" || true)
 
     echo "Files undergoing blank line checks:"
     for f in $files; do
@@ -92,7 +92,7 @@ if [[ -z "$modified" ]]; then
     rm -f "$OUTPUT"
 else
     echo -e "\xe2\x9c\x97 blank line check failed: the following files were formatted:"
-    echo -n "$modified"
+    echo "$modified"
     rm -f "$OUTPUT"
     exit -1
 fi


### PR DESCRIPTION
The astyle and blank line check scripts still had one place where they were trying to check files that had been deleted. This commit fixes that by passing `--diff-filter=d` to `git diff` so that it will omit these files from the listing. A minor output message formatting fix for `bareflank_blank_lines.sh` is also included.