### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,4 +305,3 @@ https://github.com/ionescu007/SimpleVisor
 
 **HyperPlatform:**  <br>
 https://github.com/tandasat/HyperPlatform
-   


### PR DESCRIPTION
Somehow invalid bytes were added to the end of `README.md`, causing GitHub to render as plaintext.

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>