### PR TITLE
Add method set_port() to serial drivers

### DIFF
--- a/bfvmm/include/serial/serial_port_base.h
+++ b/bfvmm/include/serial/serial_port_base.h
@@ -79,6 +79,17 @@ public:
     /// @return the serial device's port
     virtual port_type port() const noexcept = 0;
 
+    /// Set Port
+    ///
+    /// Change the peripheral port/base address at runtime.
+    ///
+    /// @param port serial peripheral port or base address
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    virtual void set_port(port_type port) noexcept = 0;
+
     /// Write Character
     ///
     /// Writes a character to the serial device.

--- a/bfvmm/include/serial/serial_port_ns16550a.h
+++ b/bfvmm/include/serial/serial_port_ns16550a.h
@@ -282,6 +282,20 @@ public:
     virtual port_type port() const noexcept override
     { return m_port; }
 
+    /// Set Port
+    ///
+    /// Change the peripheral port/base address at runtime.
+    ///
+    /// @param port serial peripheral port or base address
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    virtual void set_port(port_type port) noexcept override
+    {
+        m_port = port;
+    }
+
     /// Write Character
     ///
     /// Writes a character to the serial device.

--- a/bfvmm/include/serial/serial_port_pl011.h
+++ b/bfvmm/include/serial/serial_port_pl011.h
@@ -336,6 +336,20 @@ public:
     ///
     parity_bits_t parity_bits() const noexcept;
 
+    /// Set Port
+    ///
+    /// Change the peripheral port/base address at runtime.
+    ///
+    /// @param port serial peripheral port or base address
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    virtual void set_port(port_type port) noexcept override
+    {
+        m_port = port;
+    }
+
     /// Port
     ///
     /// @expects none

--- a/bfvmm/src/serial/tests/test_serial_port_base.cpp
+++ b/bfvmm/src/serial/tests/test_serial_port_base.cpp
@@ -79,6 +79,11 @@ public:
         str += c;
     }
 
+    virtual void set_port(port_type port) noexcept override
+    {
+        (void) port;
+    }
+
     using serial_port_base::write;
     using serial_port_base::offset_inb;
     using serial_port_base::offset_ind;
@@ -86,7 +91,17 @@ public:
     using serial_port_base::offset_outd;
 };
 
-TEST_CASE("serial_base: outb, inb, outd, ind")
+TEST_CASE("serial_port_base: tester self-test")
+{
+    serial_port_base_tester tester;
+
+    CHECK(tester.port() == DEFAULT_COM_PORT);
+
+    tester.set_port(DEFAULT_COM_PORT + 1);
+    CHECK(tester.port() == DEFAULT_COM_PORT);
+}
+
+TEST_CASE("serial_port_base: outb, inb, outd, ind")
 {
     MockRepository mocks;
     mock_portio(mocks);
@@ -102,7 +117,7 @@ TEST_CASE("serial_base: outb, inb, outd, ind")
     CHECK(tester.offset_ind(2) == 0x55aa55aa);
 }
 
-TEST_CASE("serial_base: write string")
+TEST_CASE("serial_port_base: write string")
 {
     MockRepository mocks;
     mock_portio(mocks);
@@ -113,7 +128,7 @@ TEST_CASE("serial_base: write string")
     CHECK(tester.str == "hello world");
 }
 
-TEST_CASE("serial_base: write char buffer")
+TEST_CASE("serial_port_base: write char buffer")
 {
     MockRepository mocks;
     mock_portio(mocks);

--- a/bfvmm/src/serial/tests/test_serial_port_ns16550a.cpp
+++ b/bfvmm/src/serial/tests/test_serial_port_ns16550a.cpp
@@ -24,6 +24,7 @@
 #include <serial/serial_port_ns16550a.h>
 #include <hippomocks.h>
 #include <map>
+#include <bfgsl.h>
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
@@ -83,6 +84,20 @@ TEST_CASE("serial: success")
     CHECK((g_ports[DEFAULT_COM_PORT + serial_ns16550a::line_control_reg] & serial_ns16550a::line_control_data_mask) == serial_port_ns16550a::DEFAULT_DATA_BITS);
     CHECK((g_ports[DEFAULT_COM_PORT + serial_ns16550a::line_control_reg] & serial_ns16550a::line_control_stop_mask) == serial_port_ns16550a::DEFAULT_STOP_BITS);
     CHECK((g_ports[DEFAULT_COM_PORT + serial_ns16550a::line_control_reg] & serial_ns16550a::line_control_parity_mask) == serial_port_ns16550a::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: port and set_port")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto const invport = gsl::narrow_cast<serial_port_ns16550a::port_type>(~DEFAULT_COM_PORT & 0xffff);
+
+    serial_port_ns16550a::instance()->set_port(invport);
+    CHECK(serial_port_ns16550a::instance()->port() == invport);
+
+    serial_port_ns16550a::instance()->set_port(DEFAULT_COM_PORT);
+    CHECK(serial_port_ns16550a::instance()->port() == DEFAULT_COM_PORT);
 }
 
 TEST_CASE("serial: set_baud_rate_success")

--- a/bfvmm/src/serial/tests/test_serial_port_pl011.cpp
+++ b/bfvmm/src/serial/tests/test_serial_port_pl011.cpp
@@ -24,6 +24,7 @@
 #include <serial/serial_port_pl011.h>
 #include <hippomocks.h>
 #include <map>
+#include <bfgsl.h>
 
 #ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
@@ -77,6 +78,20 @@ TEST_CASE("serial: success")
     CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_wlen_mask) == serial_port_pl011::DEFAULT_DATA_BITS);
     CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_stop_mask) == serial_port_pl011::DEFAULT_STOP_BITS);
     CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_parity_mask) == serial_port_pl011::DEFAULT_PARITY_BITS);
+}
+
+TEST_CASE("serial: port and set_port")
+{
+    MockRepository mocks;
+    mock_serial(mocks);
+
+    auto const invport = gsl::narrow_cast<serial_port_pl011::port_type>(~DEFAULT_COM_PORT & 0xffff);
+
+    serial_port_pl011::instance()->set_port(invport);
+    CHECK(serial_port_pl011::instance()->port() == invport);
+
+    serial_port_pl011::instance()->set_port(DEFAULT_COM_PORT);
+    CHECK(serial_port_pl011::instance()->port() == DEFAULT_COM_PORT);
 }
 
 TEST_CASE("serial: set_baud_rate_success")


### PR DESCRIPTION
This allows changing the port at runtime, and will be used on aarch64 to support memory-mapped serial. Related: #527

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>