### PR TITLE
Add files created by Vagrant to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,10 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 build/
+build_ubuntu17_04/
 doc
 doxygen_warnings.txt
+.vagrant
 .astyle_results.txt
 .clang_tidy_results.txt
 .vscode/


### PR DESCRIPTION
When using Vagrant via our `Vagrantfile`, a build directory `build_ubuntu17_04` and an internal Vagrant directory `.vagrant` are included. This commit adds those to `.gitignore` to remove them from the status view and prevent accidental checkins.

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>