### PR TITLE
[BUG] build system - unnecessary re-compilation

### DIFF
--- a/scripts/cmake/copy_files_if_different.cmake
+++ b/scripts/cmake/copy_files_if_different.cmake
@@ -1,0 +1,43 @@
+#
+# Bareflank Hypervisor
+# Copyright (C) 2015 Assured Information Security, Inc.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+# ------------------------------------------------------------------------------
+# README
+# ------------------------------------------------------------------------------
+
+# This file exists to overcome buggy behaviour when installing files using
+# the built-in cmake function ExternalProject_Add_Step.
+#
+# Usage:
+# ExternalProject_Add_Step(
+#     <external_project_target_name>
+#     <name_of_this_step>
+#     DEPENDEES <target_dependencies>
+#     COMMAND	${CMAKE_COMMAND}
+#         -DGLOB_DIR=${GLOB_DIR}
+#         -DGLOB_EXPR=${GLOB_EXPR}
+#         -DINSTALL_DIR=${INSTALL_DIR}
+#         -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+# )
+
+include(${CMAKE_CURRENT_LIST_DIR}/macros.cmake)
+copy_files_if_different(
+    GLOB_DIR ${GLOB_DIR}
+    GLOB_EXPR ${GLOB_EXPR}
+    INSTALL_DIR ${INSTALL_DIR}
+)

--- a/scripts/cmake/depends/astyle.cmake
+++ b/scripts/cmake/depends/astyle.cmake
@@ -39,11 +39,3 @@ ExternalProject_Add(
     STAMP_DIR           ${BF_BUILD_DEPENDS_DIR}/astyle/stamp
     DEPENDS             bfsdk
 )
-
-# TODO: Install to the appropirate sysroot in the build tree
-# ExternalProject_Add_Step(
-#     astyle
-#     sysroot_install
-#     COMMAND 			${CMAKE_COMMAND} -E copy_directory /path/to/build/artifacts /path/to/appropriate/sysroot
-#     DEPENDEES          	install
-#     )

--- a/scripts/cmake/depends/catch.cmake
+++ b/scripts/cmake/depends/catch.cmake
@@ -38,11 +38,13 @@ ExternalProject_Add(
     STAMP_DIR           ${BF_BUILD_DEPENDS_DIR}/catch/stamp
 )
 
-if(NOT EXISTS ${BUILD_SYSROOT_TEST}/include/catch)
-    ExternalProject_Add_Step(
-        catch
-        catch_sysroot_install
-        COMMAND 			${CMAKE_COMMAND} -E copy_directory ${CATCH_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_TEST}/include
-        DEPENDEES          	install
-    )
-endif()
+ExternalProject_Add_Step(
+    catch
+    catch_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${CATCH_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=*.hpp
+        -DINSTALL_DIR=${BUILD_SYSROOT_TEST}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)

--- a/scripts/cmake/depends/gsl.cmake
+++ b/scripts/cmake/depends/gsl.cmake
@@ -38,20 +38,24 @@ ExternalProject_Add(
     STAMP_DIR           ${BF_BUILD_DEPENDS_DIR}/gsl/stamp
 )
 
-if(NOT EXISTS ${BUILD_SYSROOT_OS}/include/gsl)
-    ExternalProject_Add_Step(
-        gsl
-        gsl_os_sysroot_install
-        COMMAND 			${CMAKE_COMMAND} -E copy_directory ${GSL_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_OS}/include
-        DEPENDEES install
-    )
-endif()
+ExternalProject_Add_Step(
+    gsl
+    gsl_os_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${GSL_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=include/*
+        -DINSTALL_DIR=${BUILD_SYSROOT_OS}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)
 
-if(NOT EXISTS ${BUILD_SYSROOT_VMM}/include/gsl AND ${BUILD_VMM})
-    ExternalProject_Add_Step(
-        gsl
-        gsl_vmm_sysroot_install
-        COMMAND 			${CMAKE_COMMAND} -E copy_directory ${GSL_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_VMM}/include
-        DEPENDEES install
-    )
-endif()
+ExternalProject_Add_Step(
+    gsl
+    gsl_vmm_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${GSL_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=include/*
+        -DINSTALL_DIR=${BUILD_SYSROOT_VMM}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)

--- a/scripts/cmake/depends/hippomocks.cmake
+++ b/scripts/cmake/depends/hippomocks.cmake
@@ -38,11 +38,15 @@ ExternalProject_Add(
     STAMP_DIR           ${BF_BUILD_DEPENDS_DIR}/hippomocks/stamp
 )
 
-if(NOT EXISTS ${BUILD_SYSROOT_TEST}/include/hippomocks.h)
-    ExternalProject_Add_Step(
-        hippomocks
-        hippomocks_sysroot_install
-        COMMAND 			${CMAKE_COMMAND} -E copy_directory ${HIPPOMOCKS_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_TEST}/include
-        DEPENDEES          	install
-    )
-endif()
+set(HIPPOMOCKS_COPY_CMD "COMMAND ${CMAKE_COMMAND} -E copy_if_different")
+
+ExternalProject_Add_Step(
+    hippomocks
+    hippomocks_os_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${HIPPOMOCKS_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=include/*
+        -DINSTALL_DIR=${BUILD_SYSROOT_TEST}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)

--- a/scripts/cmake/depends/json.cmake
+++ b/scripts/cmake/depends/json.cmake
@@ -38,20 +38,24 @@ ExternalProject_Add(
     STAMP_DIR           ${BF_BUILD_DEPENDS_DIR}/json/stamp
 )
 
-if(NOT EXISTS ${BUILD_SYSROOT_OS}/include/nlohmann/json.hpp)
-    ExternalProject_Add_Step(
-        json
-        json_os_sysroot_install
-        COMMAND	${CMAKE_COMMAND} -E copy_directory ${JSON_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_OS}/include
-        DEPENDEES install
-    )
-endif()
+ExternalProject_Add_Step(
+    json
+    json_os_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${JSON_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=*.hpp
+        -DINSTALL_DIR=${BUILD_SYSROOT_OS}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)
 
-if(NOT EXISTS ${BUILD_SYSROOT_VMM}/include/nlohmann/json.hpp AND ${BUILD_VMM})
-    ExternalProject_Add_Step(
-        json
-        json_vmm_sysroot_install
-        COMMAND	${CMAKE_COMMAND} -E copy_directory ${JSON_INTERM_INSTALL_DIR}/include ${BUILD_SYSROOT_VMM}/include
-        DEPENDEES install
-    )
-endif()
+ExternalProject_Add_Step(
+    json
+    json_vmm_sysroot_install
+    DEPENDEES install
+    COMMAND	${CMAKE_COMMAND}
+        -DGLOB_DIR=${JSON_INTERM_INSTALL_DIR}
+        -DGLOB_EXPR=*.hpp
+        -DINSTALL_DIR=${BUILD_SYSROOT_VMM}
+        -P ${BF_SCRIPTS_DIR}/cmake/copy_files_if_different.cmake
+)

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -231,3 +231,19 @@ macro(print_usage)
     message(STATUS "${Yellow}    ${BF_BUILD_COMMAND} info${ColorReset}")
     message(STATUS "")
 endmacro(print_usage)
+
+# Copies all files that match the given recursive GLOB expression (relative to
+# to the given GLOB directory) only if the matched source file has changed.
+# @arg GLOB_EXPR: A cmake GLOB_RECURSE expression to generate a list of files
+#           to be copied
+# @arg GLOB_DIR: The directory that GLOB_EXPR will be calculated relative to
+# @arg INSTALL_DIR: The directory to install all files that matched GLOB_EXPR to
+macro(copy_files_if_different)
+    set(oneVal GLOB_DIR GLOB_EXPR INSTALL_DIR)
+    cmake_parse_arguments(_EP_INSTALL "" "${oneVal}" "" ${ARGN})
+
+    file(GLOB_RECURSE out_files RELATIVE ${_EP_INSTALL_GLOB_DIR} ${_EP_INSTALL_GLOB_DIR}/${_EP_INSTALL_GLOB_EXPR})
+    foreach(file ${out_files})
+        execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different ${_EP_INSTALL_GLOB_DIR}/${file} ${_EP_INSTALL_INSTALL_DIR}/${file})
+    endforeach()
+endmacro(copy_files_if_different)


### PR DESCRIPTION
Bug #534 

Added a macro and utility cmake script to allow installing files with
correct dependency tracking during build commands added with
ExternalProject_Add_Step

Signed-off-by: JaredWright <jared.wright12@gmail.com>