### PR TITLE
Extended APIs configurable path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,7 @@ endif()
 
 if(${BUILD_EXTENDED_APIS})
     add_subproject(
-        SOURCE_DIR ${BF_SOURCE_DIR}/extended_apis
+        SOURCE_DIR ${EXTENDED_APIS_PATH}
         TARGET extended_apis
         TOOLCHAIN ${TOOLCHAIN_PATH_EXTENDED_APIS}
         DEPENDS bfsdk binutils bfvmm
@@ -216,7 +216,7 @@ if(ENABLE_UNITTESTING)
 
     if(${UNITTEST_EXTENDED_APIS})
         add_subproject(
-            SOURCE_DIR ${BF_SOURCE_DIR}/extended_apis/tests
+            SOURCE_DIR ${EXTENDED_APIS_PATH}/tests
             TARGET extended_apis_test
             TOOLCHAIN ${TOOLCHAIN_PATH_UNITTEST}
             DEPENDS bfsdk bfsdk_test bfvmm_test

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -133,6 +133,12 @@ add_config(
     DESCRIPTION "Include the Bareflank Extended APIs in this build"
 )
 
+add_config(
+    CONFIG_NAME EXTENDED_APIS_PATH
+    CONFIG_TYPE PATH
+    DEFAULT_VAL ${BF_SOURCE_DIR}/extended_apis
+    DESCRIPTION "Path to the Bareflank Extended APIs"
+)
 
 if(${CMAKE_VERBOSE_MAKEFILE})
     set(_BUILD_VERBOSE ON CACHE INTERNAL "")


### PR DESCRIPTION
Added a build configuration that allows for a configurable path to build
the extended apis and the extended apis unit tests.

Signed-off-by: JaredWright <jared.wright12@gmail.com>

## Note:

This is such a small PR that I did not open an RFC or a bug report. I can open one if need be, just let me know. The reason for this pull request is that the extended_apis Travis CI builds all require the ability to specify a path from the main hypervisor repo to the extended_apis. After we merge this feature, I will be able to submit pull request for making the extended_apis compatible with the new build system.