### PR TITLE
Fix build of newlib on aarch64

### DIFF
--- a/scripts/cmake/depends/newlib.cmake
+++ b/scripts/cmake/depends/newlib.cmake
@@ -30,6 +30,8 @@ if(NOT EXISTS "${BUILD_SYSROOT_VMM}/lib/libc.a" OR NOT EXISTS "${BUILD_SYSROOT_V
         list(APPEND NEWLIB_C_FLAGS
             "-O3"
             "-DNDEBUG"
+            "-no-integrated-as"
+            "-fasm"
         )
     endif()
 


### PR DESCRIPTION
Fix build of newlib on aarch64

newlib on aarch64 uses a few nonstandard features that require special build flags:

- Instruction formats not supported by LLVM's assembler, requiring `-no-integrated-as` to force use of binutils as
- Inline assembly via `asm()` instead of `__asm__()`, not available in clang with `-std=c99` unless `-fasm` is given.

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>

