### PR TITLE
Updated bfdriver to build under WDK10 and VS 2017

### DIFF
--- a/bfdriver/CMakeLists.txt
+++ b/bfdriver/CMakeLists.txt
@@ -38,5 +38,8 @@ if(${BUILD_TARGET_OS} STREQUAL "Linux")
         DESTINATION ${BUILD_SYSROOT_OS}/lib
     )
 elseif(${BUILD_TARGET_OS} STREQUAL "Windows")
-    # TODO: Install bareflank.sys to ${BUILD_SYSROOT_OS}/lib
+    install(
+        PROGRAMS ${BF_SOURCE_DIR}/bfdriver/src/arch/windows/x64/Debug/bareflank.sys
+        DESTINATION ${BUILD_SYSROOT_OS}/lib
+    )
 endif()

--- a/bfdriver/src/arch/windows/bareflank.sln
+++ b/bfdriver/src/arch/windows/bareflank.sln
@@ -1,3 +1,4 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
 
 #
 # Bareflank Hypervisor
@@ -17,9 +18,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio 15
+VisualStudioVersion = 15.0.27004.2008
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bareflank", "bareflank.vcxproj", "{9299115C-8A76-408B-B25B-BB3571EA196A}"
 EndProject
@@ -38,5 +38,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {5BB3266F-C8ED-491E-8FBD-B31BB90A5319}
 	EndGlobalSection
 EndGlobal

--- a/bfdriver/src/arch/windows/bareflank.vcxproj
+++ b/bfdriver/src/arch/windows/bareflank.vcxproj
@@ -1,22 +1,24 @@
-#
-# Bareflank Hypervisor
-# Copyright (C) 2015 Assured Information Security, Inc.
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Bareflank Hypervisor
+Copyright (C) 2015 Assured Information Security, Inc.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+-->
+
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -59,11 +61,11 @@
   </ImportGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
-    <IncludePath>..\..\..\..\bfsdk\include;..\..\..\..\bfelf_loader\include;..\..\..\include;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\..\..\bfsdk\include;..\..\..\..\bfelf_loader\include;..\..\..\include;.;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <DebuggerFlavor>DbgengKernelDebugger</DebuggerFlavor>
-    <IncludePath>..\..\..\..\bfsdk\include;..\..\..\..\bfelf_loader\include;..\..\..\include;$(IncludePath)</IncludePath>
+    <IncludePath>..\..\..\..\bfsdk\include;..\..\..\..\bfelf_loader\include;..\..\..\include;.;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/bfdriver/src/arch/windows/bareflank.vcxproj.filters
+++ b/bfdriver/src/arch/windows/bareflank.vcxproj.filters
@@ -1,22 +1,24 @@
-#
-# Bareflank Hypervisor
-# Copyright (C) 2015 Assured Information Security, Inc.
-#
-# This library is free software; you can redistribute it and/or
-# modify it under the terms of the GNU Lesser General Public
-# License as published by the Free Software Foundation; either
-# version 2.1 of the License, or (at your option) any later version.
-#
-# This library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-# Lesser General Public License for more details.
-#
-# You should have received a copy of the GNU Lesser General Public
-# License along with this library; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-
 <?xml version="1.0" encoding="utf-8"?>
+
+<!--
+Bareflank Hypervisor
+Copyright (C) 2015 Assured Information Security, Inc.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+-->
+
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Inf Include="bareflank.inf" />
@@ -34,5 +36,12 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\common.c" />
+    <ClCompile Include="device.c" />
+    <ClCompile Include="driver.c" />
+    <ClCompile Include="platform.c" />
+    <ClCompile Include="queue.c" />
+  </ItemGroup>
+  <ItemGroup>
+    <MASM Include="vmcall.asm" />
   </ItemGroup>
 </Project>

--- a/scripts/util/driver_build.sh
+++ b/scripts/util/driver_build.sh
@@ -20,15 +20,9 @@
 # $1 == CMAKE_SOURCE_DIR
 # $2 == CMAKE_INSTALL_PREFIX
 
-msbuild_2015="/cygdrive/c/Program Files (x86)/MSBuild/14.0/bin/msbuild.exe"
 msbuild_2017="/cygdrive/c/Program Files (x86)/Microsoft Visual Studio/2017/Community/MSBuild/15.0/bin/msbuild.exe"
 
 find_msbuild() {
-
-    if [[ -f $msbuild_2015 ]]; then
-        msbuild=$msbuild_2015
-        return
-    fi
 
     if [[ -f $msbuild_2017 ]]; then
         msbuild=$msbuild_2017


### PR DESCRIPTION
This is a partial fix for bug #535. This PR addresses two issues with Windows support:

1) Microsoft pushed out an update to the WDK 10 and Visual Studio 2017 that allows you to build WDK driver from Visual Studio 2017. This means that we can remove the requirement of installing both Visual Studio 2015 and 2017 to build Bareflank (only need VS 2017 now).

2) The Bareflank license was added incorrectly to the Visual Studio project configuration files (.sln, .vcxproj, .vcxproj.filters), preventing msbuild/Visual Studio from building the bfdriver project.

I'm submitting this as a partial fix so that @JWZepf can to spend a little bit of time looking into some other remaining issues related to bug #535. Specifically, the bfdriver unit tests do not pass when built from Cygwin, and the VMM crashes immediately when loaded from Cygwin (likely the same issue showing up in two different forms)