### PR TITLE
Pack struct registers_intel_x64_t

### DIFF
--- a/bfsysroot/bfunwind/include/registers_intel_x64.h
+++ b/bfsysroot/bfunwind/include/registers_intel_x64.h
@@ -31,6 +31,8 @@
 // Load / Store Registers
 // -----------------------------------------------------------------------------
 
+#pragma pack(push, 1)
+
 struct registers_intel_x64_t {
     uint64_t rax;
     uint64_t rdx;
@@ -50,6 +52,8 @@ struct registers_intel_x64_t {
     uint64_t r15;
     uint64_t rip;
 };
+
+#pragma pack(pop)
 
 /// __store_registers_intel_x64
 ///


### PR DESCRIPTION
This is required for reliable access via assembly. We get lucky because the compiler is obviously going to align 64-bit members of a struct with nothing else in it to 64 bits on a 64 bit machine, but it's definitely not required to.

Signed-off-by: Chris Pavlina <pavlinac@ainfosec.com>