### PR TITLE
TravisCI environment downgrade

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@
 #
 language: cpp
 dist: trusty
+group: deprecated-2017Q4
 
 #
 # Build Dependencies


### PR DESCRIPTION
This commit forces the TravisCI environment back to its state before
the last environment upgrade happened. This does not fix compatilibility with
clang 5, but instead provides a temporary workaround for failing CI
builds.

[BUG] #557 - clang 5 vmm link error

Signed-off-by: JaredWright <jared.wright12@gmail.com>