### PR TITLE
bfdriver double-compile bug

### DIFF
--- a/scripts/util/driver_build.sh
+++ b/scripts/util/driver_build.sh
@@ -51,7 +51,6 @@ CYGWIN_NT-10.0*)
     ;;
 Linux)
     cd $1/src/arch/linux
-    make clean
     make
     ;;
 *)


### PR DESCRIPTION
Partial fix for [BUG] #553 Double/Infinite Compile. This commit removes
double compilation for the bfdriver component only.

Signed-off-by: JaredWright <jared.wright12@gmail.com>