### PR TITLE
Include Path / Library Fix

### DIFF
--- a/bfdummy/src/CMakeLists.txt
+++ b/bfdummy/src/CMakeLists.txt
@@ -20,6 +20,8 @@ cmake_minimum_required(VERSION 3.6)
 project(bfdummy C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project()
+init_project(
+    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+)
 
 add_subdirectory(libs)

--- a/bfdummy/src/main/CMakeLists.txt
+++ b/bfdummy/src/main/CMakeLists.txt
@@ -26,8 +26,8 @@ init_project(
 )
 
 list(APPEND LIBRARIES
-    ${CMAKE_INSTALL_PREFIX}/lib/libdummy_lib1_shared.so
-    ${CMAKE_INSTALL_PREFIX}/lib/libdummy_lib2_shared.so
+    dummy_lib1
+    dummy_lib2
 )
 
 add_vmm_executable(dummy_main

--- a/bfm/src/CMakeLists.txt
+++ b/bfm/src/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND BFM_CXX_FLAGS
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
 init_project(
+    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
     CXX_FLAGS ${BFM_CXX_FLAGS}
 )
 

--- a/bfunwind/src/CMakeLists.txt
+++ b/bfunwind/src/CMakeLists.txt
@@ -21,6 +21,7 @@ project(bfunwind C CXX)
 
 include(${SOURCE_CMAKE_DIR}/project.cmake)
 init_project(
+    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
     TIDY_EXCLUSIONS -cppcoreguidelines-pro*
 )
 


### PR DESCRIPTION
This patch fixes two specific issues with extensions:
- The init_project macro was including <path>/../include which it
shouldn't be because we don't know how an extension will be setup, and
this could accidentially include unintended files.
- The add_vmm_exectuable provided to way to link shared and static
libraries at the same time, and as a result, was cumbersome to use.

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>