### PR TITLE
Change to relative paths

### DIFF
--- a/bfvmm/include/debug/serial/serial_port_ns16550a.h
+++ b/bfvmm/include/debug/serial/serial_port_ns16550a.h
@@ -25,7 +25,7 @@
 #include <bfconstants.h>
 
 #include <intrinsics.h>
-#include <debug/serial/serial_port_base.h>
+#include "serial_port_base.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/debug/serial/serial_port_pl011.h
+++ b/bfvmm/include/debug/serial/serial_port_pl011.h
@@ -25,7 +25,7 @@
 #include <bfconstants.h>
 
 #include <intrinsics.h>
-#include <debug/serial/serial_port_base.h>
+#include "serial_port_base.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler.h
+++ b/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler.h
@@ -22,11 +22,12 @@
 #include <memory>
 
 #include <intrinsics.h>
-#include <memory_manager/map_ptr_x64.h>
-#include <hve/arch/intel_x64/vmcs/vmcs.h>
 
 #include <bfjson.h>
 #include <bfvmcallinterface.h>
+
+#include "../vmcs/vmcs.h"
+#include "../../../../memory_manager/map_ptr_x64.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler_entry.h
+++ b/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler_entry.h
@@ -19,7 +19,7 @@
 #ifndef EXIT_HANDLER_INTEL_X64_ENTRY_H
 #define EXIT_HANDLER_INTEL_X64_ENTRY_H
 
-#include <hve/arch/intel_x64/exit_handler/exit_handler.h>
+#include "exit_handler.h"
 
 /// Exit Handler
 ///

--- a/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler_support.h
+++ b/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler_support.h
@@ -19,7 +19,7 @@
 #ifndef EXIT_HANDLER_INTEL_X64_SUPPORT_H
 #define EXIT_HANDLER_INTEL_X64_SUPPORT_H
 
-#include <hve/arch/intel_x64/exit_handler/exit_handler.h>
+#include "exit_handler.h"
 
 /// Exit Handler Entry
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs.h
@@ -22,8 +22,8 @@
 #include <bfdelegate.h>
 
 #include <intrinsics.h>
-#include <hve/arch/intel_x64/state_save.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_state.h>
+#include "../state_save.h"
+#include "vmcs_state.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check.h
@@ -19,9 +19,9 @@
 #ifndef VMCS_INTEL_X64_CHECK_H
 #define VMCS_INTEL_X64_CHECK_H
 
-#include <hve/arch/intel_x64/vmcs/vmcs_check_controls.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_check_guest.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_check_host.h>
+#include "vmcs_check_host.h"
+#include "vmcs_check_guest.h"
+#include "vmcs_check_controls.h"
 
 /// Intel x86_64 VMCS Check
 ///
@@ -41,9 +41,9 @@ namespace check
 inline void
 all()
 {
-    vmx_controls_all();
     host_state_all();
     guest_state_all();
+    vmx_controls_all();
 }
 
 }

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_controls.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_controls.h
@@ -22,7 +22,7 @@
 #include <type_traits>
 
 #include <intrinsics.h>
-#include <memory_manager/memory_manager_x64.h>
+#include "../../../../memory_manager/memory_manager_x64.h"
 
 /// Intel x86_64 VMCS Check Controls
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_guest.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_guest.h
@@ -22,7 +22,7 @@
 #include <type_traits>
 
 #include <intrinsics.h>
-#include <memory_manager/memory_manager_x64.h>
+#include "../../../../memory_manager/memory_manager_x64.h"
 
 /// Intel x86_64 VMCS Check Guest
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_host.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_check_host.h
@@ -22,7 +22,7 @@
 #include <type_traits>
 
 #include <intrinsics.h>
-#include <memory_manager/memory_manager_x64.h>
+#include "../../../../memory_manager/memory_manager_x64.h"
 
 /// Intel x86_64 VMCS Check Host
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_launch.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_launch.h
@@ -19,7 +19,7 @@
 #ifndef VMCS_INTEL_X64_LAUNCH_H
 #define VMCS_INTEL_X64_LAUNCH_H
 
-#include <hve/arch/intel_x64/state_save.h>
+#include "../state_save.h"
 
 /// Launch VMCS
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_promote.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_promote.h
@@ -20,7 +20,7 @@
 #define VMCS_INTEL_X64_PROMOTE_H
 
 #include <cstdint>
-#include <hve/arch/intel_x64/state_save.h>
+#include "../state_save.h"
 
 /// Promote VMCS
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_resume.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_resume.h
@@ -19,7 +19,7 @@
 #ifndef VMCS_INTEL_X64_RESUME_H
 #define VMCS_INTEL_X64_RESUME_H
 
-#include <hve/arch/intel_x64/state_save.h>
+#include "../state_save.h"
 
 /// Resume VMCS
 ///

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state.h
@@ -22,8 +22,8 @@
 #include <bftypes.h>
 
 #include <intrinsics.h>
-#include <hve/arch/x64/gdt.h>
-#include <hve/arch/x64/idt.h>
+#include "../../x64/gdt.h"
+#include "../../x64/idt.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state_hvm.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state_hvm.h
@@ -22,7 +22,7 @@
 #include <memory>
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_state.h>
+#include "vmcs_state.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state_vmm.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmcs/vmcs_state_vmm.h
@@ -22,7 +22,7 @@
 #include <memory>
 
 #include <bfdebug.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_state.h>
+#include "vmcs_state.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/memory_manager/map_ptr_x64.h
+++ b/bfvmm/include/memory_manager/map_ptr_x64.h
@@ -29,10 +29,10 @@
 #include <bfexception.h>
 #include <bfupperlower.h>
 
-#include <memory_manager/pat_x64.h>
-#include <memory_manager/mem_attr_x64.h>
-#include <memory_manager/memory_manager_x64.h>
-#include <memory_manager/root_page_table_x64.h>
+#include "pat_x64.h"
+#include "mem_attr_x64.h"
+#include "memory_manager_x64.h"
+#include "root_page_table_x64.h"
 
 #include <intrinsics.h>
 

--- a/bfvmm/include/memory_manager/memory_manager_x64.h
+++ b/bfvmm/include/memory_manager/memory_manager_x64.h
@@ -26,7 +26,7 @@
 #include <bfconstants.h>
 
 #include <intrinsics.h>
-#include <memory_manager/mem_pool.h>
+#include "mem_pool.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/memory_manager/page_table_x64.h
+++ b/bfvmm/include/memory_manager/page_table_x64.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <memory>
 
-#include <memory_manager/page_table_entry_x64.h>
+#include "page_table_entry_x64.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/memory_manager/pat_x64.h
+++ b/bfvmm/include/memory_manager/pat_x64.h
@@ -19,7 +19,7 @@
 #ifndef PAT_X64_H
 #define PAT_X64_H
 
-#include <memory_manager/mem_attr_x64.h>
+#include "mem_attr_x64.h"
 
 /// @cond
 /// *INDENT-OFF*

--- a/bfvmm/include/memory_manager/root_page_table_x64.h
+++ b/bfvmm/include/memory_manager/root_page_table_x64.h
@@ -25,9 +25,9 @@
 #include <mutex>
 #include <vector>
 
-#include <memory_manager/pat_x64.h>
-#include <memory_manager/mem_attr_x64.h>
-#include <memory_manager/page_table_x64.h>
+#include "pat_x64.h"
+#include "mem_attr_x64.h"
+#include "page_table_x64.h"
 
 #include <intrinsics.h>
 

--- a/bfvmm/include/vcpu/arch/intel_x64/vcpu.h
+++ b/bfvmm/include/vcpu/arch/intel_x64/vcpu.h
@@ -19,12 +19,12 @@
 #ifndef VCPU_INTEL_X64_H
 #define VCPU_INTEL_X64_H
 
-#include <vcpu/vcpu.h>
-#include <hve/arch/intel_x64/vmxon/vmxon.h>
-#include <hve/arch/intel_x64/vmcs/vmcs.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_state_vmm.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_state_hvm.h>
-#include <hve/arch/intel_x64/exit_handler/exit_handler.h>
+#include "../../vcpu.h"
+#include "../../../hve/arch/intel_x64/vmxon/vmxon.h"
+#include "../../../hve/arch/intel_x64/vmcs/vmcs.h"
+#include "../../../hve/arch/intel_x64/vmcs/vmcs_state_vmm.h"
+#include "../../../hve/arch/intel_x64/vmcs/vmcs_state_hvm.h"
+#include "../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/vcpu/vcpu_factory.h
+++ b/bfvmm/include/vcpu/vcpu_factory.h
@@ -20,7 +20,7 @@
 #define VCPU_FACTORY_H
 
 #include <memory>
-#include <vcpu/vcpu.h>
+#include "vcpu.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/include/vcpu/vcpu_manager.h
+++ b/bfvmm/include/vcpu/vcpu_manager.h
@@ -22,7 +22,7 @@
 #include <map>
 #include <memory>
 
-#include <vcpu/vcpu_factory.h>
+#include "vcpu_factory.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/src/CMakeLists.txt
+++ b/bfvmm/src/CMakeLists.txt
@@ -29,3 +29,9 @@ add_subdirectory(memory_manager)
 add_subdirectory(hve)
 add_subdirectory(vcpu)
 add_subdirectory(entry)
+
+# ------------------------------------------------------------------------------
+# Install
+# ------------------------------------------------------------------------------
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include DESTINATION include/bfvmm)

--- a/bfvmm/src/debug/CMakeLists.txt
+++ b/bfvmm/src/debug/CMakeLists.txt
@@ -46,9 +46,3 @@ add_static_library(
     DEFINES STATIC_DEBUG
     DEFINES STATIC_INTRINSICS
 )
-
-# ------------------------------------------------------------------------------
-# Install
-# ------------------------------------------------------------------------------
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/debug DESTINATION include/bfvmm/debug)

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -49,9 +49,3 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
-
-# ------------------------------------------------------------------------------
-# Install
-# ------------------------------------------------------------------------------
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/hve DESTINATION include/bfvmm/hve)

--- a/bfvmm/src/memory_manager/CMakeLists.txt
+++ b/bfvmm/src/memory_manager/CMakeLists.txt
@@ -43,9 +43,3 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
-
-# ------------------------------------------------------------------------------
-# Install
-# ------------------------------------------------------------------------------
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/memory_manager DESTINATION include/bfvmm/memory_manager)

--- a/bfvmm/src/vcpu/CMakeLists.txt
+++ b/bfvmm/src/vcpu/CMakeLists.txt
@@ -54,9 +54,3 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
-
-# ------------------------------------------------------------------------------
-# Install
-# ------------------------------------------------------------------------------
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/vcpu DESTINATION include/bfvmm/vcpu)


### PR DESCRIPTION
This patch addresses an issue were attempting to include headers from
bfvmm in extensions results in invalid paths.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/590

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>