### PR TITLE
Add BFVMM Namespace

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/check/check.h
+++ b/bfvmm/include/hve/arch/intel_x64/check/check.h
@@ -19,9 +19,9 @@
 #ifndef VMCS_INTEL_X64_CHECK_H
 #define VMCS_INTEL_X64_CHECK_H
 
-#include "vmcs_check_host.h"
-#include "vmcs_check_guest.h"
-#include "vmcs_check_controls.h"
+#include "check_vmcs_host_fields.h"
+#include "check_vmcs_guest_fields.h"
+#include "check_vmcs_controls_fields.h"
 
 /// Intel x86_64 VMCS Check
 ///
@@ -31,9 +31,9 @@
 
 // *INDENT-OFF*
 
-namespace intel_x64
+namespace bfvmm
 {
-namespace vmcs
+namespace intel_x64
 {
 namespace check
 {
@@ -41,11 +41,9 @@ namespace check
 inline void
 all()
 {
-    host_state_all();
-    guest_state_all();
     vmx_controls_all();
-}
-
+    host_state_all();
+    guest_state_all();}
 }
 }
 }

--- a/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_controls_fields.h
+++ b/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_controls_fields.h
@@ -30,21 +30,21 @@
 /// section 26.2.1, Vol. 3 of the SDM.
 ///
 
-namespace intel_x64
+namespace bfvmm
 {
-namespace vmcs
+namespace intel_x64
 {
 namespace check
 {
 
 inline auto
 control_reserved_properly_set(
-    x64::msrs::field_type addr, x64::msrs::value_type ctls, const char *name)
+    ::x64::msrs::field_type addr, ::x64::msrs::value_type ctls, const char *name)
 {
-    using namespace vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
 
-    auto allowed0 = ((msrs::get(gsl::narrow_cast<uint32_t>(addr)) >> 0) & 0x00000000FFFFFFFFULL);
-    auto allowed1 = ((msrs::get(gsl::narrow_cast<uint32_t>(addr)) >> 32) & 0x00000000FFFFFFFFULL);
+    auto allowed0 = ((::intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(addr)) >> 0) & 0x00000000FFFFFFFFULL);
+    auto allowed1 = ((::intel_x64::msrs::get(gsl::narrow_cast<uint32_t>(addr)) >> 32) & 0x00000000FFFFFFFFULL);
     auto allowed1_failed = false;
 
     ctls &= 0x00000000FFFFFFFFULL;
@@ -61,7 +61,7 @@ control_reserved_properly_set(
 
     allowed1_failed = (ctls & ~allowed1) != 0ULL;
 
-    if (msrs::ia32_vmx_procbased_ctls2::addr == addr) {
+    if (::intel_x64::msrs::ia32_vmx_procbased_ctls2::addr == addr) {
         allowed1_failed = allowed1_failed && activate_secondary_controls::is_enabled();
     }
 
@@ -79,9 +79,9 @@ control_reserved_properly_set(
 inline void
 control_pin_based_ctls_reserved_properly_set()
 {
-    auto addr = msrs::ia32_vmx_true_pinbased_ctls::addr;
-    auto ctls = vmcs::pin_based_vm_execution_controls::get();
-    auto name = vmcs::pin_based_vm_execution_controls::name;
+    auto addr = ::intel_x64::msrs::ia32_vmx_true_pinbased_ctls::addr;
+    auto ctls = ::intel_x64::vmcs::pin_based_vm_execution_controls::get();
+    auto name = ::intel_x64::vmcs::pin_based_vm_execution_controls::name;
 
     control_reserved_properly_set(addr, ctls, name);
 }
@@ -89,9 +89,9 @@ control_pin_based_ctls_reserved_properly_set()
 inline void
 control_proc_based_ctls_reserved_properly_set()
 {
-    auto addr = msrs::ia32_vmx_true_procbased_ctls::addr;
-    auto ctls = vmcs::primary_processor_based_vm_execution_controls::get();
-    auto name = vmcs::primary_processor_based_vm_execution_controls::name;
+    auto addr = ::intel_x64::msrs::ia32_vmx_true_procbased_ctls::addr;
+    auto ctls = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::get();
+    auto name = ::intel_x64::vmcs::primary_processor_based_vm_execution_controls::name;
 
     control_reserved_properly_set(addr, ctls, name);
 }
@@ -99,13 +99,13 @@ control_proc_based_ctls_reserved_properly_set()
 inline void
 control_proc_based_ctls2_reserved_properly_set()
 {
-    if (!vmcs::secondary_processor_based_vm_execution_controls::exists()) {
+    if (!::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::exists()) {
         throw std::logic_error("the secondary controls field doesn't exist");
     }
 
-    auto addr = msrs::ia32_vmx_procbased_ctls2::addr;
-    auto ctls = vmcs::secondary_processor_based_vm_execution_controls::get();
-    auto name = vmcs::secondary_processor_based_vm_execution_controls::name;
+    auto addr = ::intel_x64::msrs::ia32_vmx_procbased_ctls2::addr;
+    auto ctls = ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::get();
+    auto name = ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::name;
 
     control_reserved_properly_set(addr, ctls, name);
 }
@@ -113,7 +113,7 @@ control_proc_based_ctls2_reserved_properly_set()
 inline void
 control_cr3_count_less_then_4()
 {
-    if (vmcs::cr3_target_count::get() > 4) {
+    if (::intel_x64::vmcs::cr3_target_count::get() > 4) {
         throw std::logic_error("cr3 target count > 4");
     }
 }
@@ -121,12 +121,12 @@ control_cr3_count_less_then_4()
 inline void
 control_io_bitmap_address_bits()
 {
-    if (primary_processor_based_vm_execution_controls::use_io_bitmaps::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::use_io_bitmaps::is_disabled()) {
         return;
     }
 
-    auto addr_a = vmcs::address_of_io_bitmap_a::get();
-    auto addr_b = vmcs::address_of_io_bitmap_b::get();
+    auto addr_a = ::intel_x64::vmcs::address_of_io_bitmap_a::get();
+    auto addr_b = ::intel_x64::vmcs::address_of_io_bitmap_b::get();
 
     if ((addr_a & 0x0000000000000FFF) != 0) {
         throw std::logic_error("io bitmap a addr not page aligned");
@@ -136,11 +136,11 @@ control_io_bitmap_address_bits()
         throw std::logic_error("io bitmap b addr not page aligned");
     }
 
-    if (!x64::is_physical_address_valid(addr_a)) {
+    if (!::x64::is_physical_address_valid(addr_a)) {
         throw std::logic_error("io bitmap a addr too large");
     }
 
-    if (!x64::is_physical_address_valid(addr_b)) {
+    if (!::x64::is_physical_address_valid(addr_b)) {
         throw std::logic_error("io bitmap b addr too large");
     }
 }
@@ -148,17 +148,17 @@ control_io_bitmap_address_bits()
 inline void
 control_msr_bitmap_address_bits()
 {
-    if (primary_processor_based_vm_execution_controls::use_msr_bitmap::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::use_msr_bitmap::is_disabled()) {
         return;
     }
 
-    auto addr = vmcs::address_of_msr_bitmap::get();
+    auto addr = ::intel_x64::vmcs::address_of_msr_bitmap::get();
 
     if ((addr & 0x0000000000000FFF) != 0) {
         throw std::logic_error("msr bitmap addr not page aligned");
     }
 
-    if (!x64::is_physical_address_valid(addr)) {
+    if (!::x64::is_physical_address_valid(addr)) {
         throw std::logic_error("msr bitmap addr too large");
     }
 }
@@ -166,14 +166,14 @@ control_msr_bitmap_address_bits()
 inline void
 control_tpr_shadow_and_virtual_apic()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
     auto secondary_ctls_enabled = activate_secondary_controls::is_enabled();
 
     if (use_tpr_shadow::is_enabled()) {
 
-        auto phys_addr = vmcs::virtual_apic_address::get();
+        auto phys_addr = ::intel_x64::vmcs::virtual_apic_address::get();
 
         if (phys_addr == 0) {
             throw std::logic_error("virtual apic physical addr is NULL");
@@ -183,7 +183,7 @@ control_tpr_shadow_and_virtual_apic()
             throw std::logic_error("virtual apic addr not 4k aligned");
         }
 
-        if (!x64::is_physical_address_valid(phys_addr)) {
+        if (!::x64::is_physical_address_valid(phys_addr)) {
             throw std::logic_error("virtual apic addr too large");
         }
 
@@ -191,7 +191,7 @@ control_tpr_shadow_and_virtual_apic()
             throw std::logic_error("tpr_shadow is enabled, but virtual interrupt delivery is enabled");
         }
 
-        auto tpr_threshold = tpr_threshold::get();
+        auto tpr_threshold = ::intel_x64::vmcs::tpr_threshold::get();
 
         if ((tpr_threshold & 0xFFFFFFF0ULL) != 0) {
             throw std::logic_error("bits 31:4 of the tpr threshold must be 0");
@@ -239,11 +239,11 @@ control_tpr_shadow_and_virtual_apic()
 inline void
 control_nmi_exiting_and_virtual_nmi()
 {
-    if (pin_based_vm_execution_controls::nmi_exiting::is_enabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::nmi_exiting::is_enabled()) {
         return;
     }
 
-    if (pin_based_vm_execution_controls::virtual_nmis::is_enabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::virtual_nmis::is_enabled()) {
         throw std::logic_error("virtual NMI must be 0 if NMI exiting is 0");
     }
 }
@@ -251,11 +251,11 @@ control_nmi_exiting_and_virtual_nmi()
 inline void
 control_virtual_nmi_and_nmi_window()
 {
-    if (pin_based_vm_execution_controls::virtual_nmis::is_enabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::virtual_nmis::is_enabled()) {
         return;
     }
 
-    if (primary_processor_based_vm_execution_controls::nmi_window_exiting::is_enabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::nmi_window_exiting::is_enabled()) {
         throw std::logic_error("NMI window exiting must be 0 if virtual NMI is 0");
     }
 }
@@ -263,15 +263,15 @@ control_virtual_nmi_and_nmi_window()
 inline void
 control_virtual_apic_address_bits()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::is_disabled_if_exists()) {
         return;
     }
 
-    auto phys_addr = vmcs::apic_access_address::get_if_exists();
+    auto phys_addr = ::intel_x64::vmcs::apic_access_address::get_if_exists();
 
     if (phys_addr == 0) {
         throw std::logic_error("apic access physical addr is NULL");
@@ -281,7 +281,7 @@ control_virtual_apic_address_bits()
         throw std::logic_error("apic access addr not 4k aligned");
     }
 
-    if (!x64::is_physical_address_valid(phys_addr)) {
+    if (!::x64::is_physical_address_valid(phys_addr)) {
         throw std::logic_error("apic access addr too large");
     }
 }
@@ -289,15 +289,15 @@ control_virtual_apic_address_bits()
 inline void
 control_x2apic_mode_and_virtual_apic_access()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::virtualize_x2apic_mode::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::virtualize_x2apic_mode::is_disabled_if_exists()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::is_enabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::virtualize_apic_accesses::is_enabled_if_exists()) {
         throw std::logic_error("apic accesses must be 0 if x2 apic mode is 1");
     }
 }
@@ -305,15 +305,15 @@ control_x2apic_mode_and_virtual_apic_access()
 inline void
 control_virtual_interrupt_and_external_interrupt()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::is_disabled_if_exists()) {
         return;
     }
 
-    if (pin_based_vm_execution_controls::external_interrupt_exiting::is_disabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::external_interrupt_exiting::is_disabled()) {
         throw std::logic_error("external_interrupt_exiting must be 1 "
                                "if virtual_interrupt_delivery is 1");
     }
@@ -322,40 +322,40 @@ control_virtual_interrupt_and_external_interrupt()
 inline void
 control_process_posted_interrupt_checks()
 {
-    if (pin_based_vm_execution_controls::process_posted_interrupts::is_disabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::process_posted_interrupts::is_disabled()) {
         return;
     }
 
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         throw std::logic_error("virtual interrupt delivery must be 1 "
                                "if posted interrupts is 1");
     }
 
-    if (secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::virtual_interrupt_delivery::is_disabled_if_exists()) {
         throw std::logic_error("virtual interrupt delivery must be 1 "
                                "if posted interrupts is 1");
     }
 
-    if (vm_exit_controls::acknowledge_interrupt_on_exit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::acknowledge_interrupt_on_exit::is_disabled()) {
         throw std::logic_error("ack interrupt on exit must be 1 "
                                "if posted interrupts is 1");
     }
 
-    auto vector = posted_interrupt_notification_vector::get();
+    auto vector = ::intel_x64::vmcs::posted_interrupt_notification_vector::get();
 
     if ((vector & 0x000000000000FF00ULL) != 0) {
         throw std::logic_error("bits 15:8 of the notification vector must "
                                "be 0 if posted interrupts is 1");
     }
 
-    auto addr = vmcs::posted_interrupt_descriptor_address::get();
+    auto addr = ::intel_x64::vmcs::posted_interrupt_descriptor_address::get();
 
     if ((addr & 0x000000000000003FULL) != 0) {
         throw std::logic_error("bits 5:0 of the interrupt descriptor addr "
                                "must be 0 if posted interrupts is 1");
     }
 
-    if (!x64::is_physical_address_valid(addr)) {
+    if (!::x64::is_physical_address_valid(addr)) {
         throw std::logic_error("interrupt descriptor addr too large");
     }
 }
@@ -363,15 +363,15 @@ control_process_posted_interrupt_checks()
 inline void
 control_vpid_checks()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_vpid::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_vpid::is_disabled_if_exists()) {
         return;
     }
 
-    if (virtual_processor_identifier::get_if_exists() == 0) {
+    if (::intel_x64::vmcs::virtual_processor_identifier::get_if_exists() == 0) {
         throw std::logic_error("vpid cannot equal 0");
     }
 }
@@ -379,18 +379,18 @@ control_vpid_checks()
 inline void
 control_enable_ept_checks()
 {
-    using namespace msrs::ia32_vmx_ept_vpid_cap;
-    using namespace vmcs::ept_pointer;
+    using namespace ::intel_x64::msrs::ia32_vmx_ept_vpid_cap;
+    using namespace ::intel_x64::vmcs::ept_pointer;
 
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
         return;
     }
 
-    auto mem_type = vmcs::ept_pointer::memory_type::get_if_exists();
+    auto mem_type = ::intel_x64::vmcs::ept_pointer::memory_type::get_if_exists();
 
     if (mem_type == memory_type::uncacheable && memory_type_uncacheable_supported::is_disabled()) {
         throw std::logic_error("hardware does not support ept memory type: uncachable");
@@ -412,7 +412,7 @@ control_enable_ept_checks()
         throw std::logic_error("hardware does not support dirty / accessed flags for ept");
     }
 
-    if (ept_pointer::reserved::get_if_exists() != 0) {
+    if (::intel_x64::vmcs::ept_pointer::reserved::get_if_exists() != 0) {
         throw std::logic_error("bits 11:7 and 63:48 of the eptp must be 0");
     }
 }
@@ -420,21 +420,21 @@ control_enable_ept_checks()
 inline void
 control_enable_pml_checks()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_pml::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_pml::is_disabled_if_exists()) {
         return;
     }
 
-    auto pml_addr = vmcs::pml_address::get_if_exists();
+    auto pml_addr = ::intel_x64::vmcs::pml_address::get_if_exists();
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
         throw std::logic_error("ept must be enabled if pml is enabled");
     }
 
-    if (!x64::is_physical_address_valid(pml_addr)) {
+    if (!::x64::is_physical_address_valid(pml_addr)) {
         throw std::logic_error("pml address must be a valid physical address");
     }
 
@@ -446,15 +446,15 @@ control_enable_pml_checks()
 inline void
 control_unrestricted_guests()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::unrestricted_guest::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::unrestricted_guest::is_disabled_if_exists()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
         throw std::logic_error("enable ept must be 1 if unrestricted guest is 1");
     }
 }
@@ -462,37 +462,37 @@ control_unrestricted_guests()
 inline void
 control_enable_vm_functions()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_vm_functions::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_vm_functions::is_disabled_if_exists()) {
         return;
     }
 
-    if (!vmcs::vm_function_controls::exists()) {
+    if (!::intel_x64::vmcs::vm_function_controls::exists()) {
         return;
     }
 
-    if ((~msrs::ia32_vmx_vmfunc::get() & vmcs::vm_function_controls::get()) != 0) {
+    if ((~::intel_x64::msrs::ia32_vmx_vmfunc::get() & ::intel_x64::vmcs::vm_function_controls::get()) != 0) {
         throw std::logic_error("unsupported vm function control bit set");
     }
 
-    if (vmcs::vm_function_controls::eptp_switching::is_disabled()) {
+    if (::intel_x64::vmcs::vm_function_controls::eptp_switching::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
         throw std::logic_error("enable ept must be 1 if eptp switching is 1");
     }
 
-    auto eptp_list = vmcs::eptp_list_address::get_if_exists();
+    auto eptp_list = ::intel_x64::vmcs::eptp_list_address::get_if_exists();
 
     if ((eptp_list & 0x0000000000000FFFU) != 0) {
         throw std::logic_error("bits 11:0 must be 0 for eptp list address");
     }
 
-    if (!x64::is_physical_address_valid(eptp_list)) {
+    if (!::x64::is_physical_address_valid(eptp_list)) {
         throw std::logic_error("eptp list address addr too large");
     }
 }
@@ -500,16 +500,16 @@ control_enable_vm_functions()
 inline void
 control_enable_vmcs_shadowing()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::vmcs_shadowing::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::vmcs_shadowing::is_disabled_if_exists()) {
         return;
     }
 
-    auto vmcs_vmread_bitmap_address = vmread_bitmap_address::get_if_exists();
-    auto vmcs_vmwrite_bitmap_address = vmwrite_bitmap_address::get_if_exists();
+    auto vmcs_vmread_bitmap_address = ::intel_x64::vmcs::vmread_bitmap_address::get_if_exists();
+    auto vmcs_vmwrite_bitmap_address = ::intel_x64::vmcs::vmwrite_bitmap_address::get_if_exists();
 
     if ((vmcs_vmread_bitmap_address & 0x0000000000000FFF) != 0) {
         throw std::logic_error("bits 11:0 must be 0 for the vmcs read bitmap address");
@@ -519,11 +519,11 @@ control_enable_vmcs_shadowing()
         throw std::logic_error("bits 11:0 must be 0 for the vmcs write bitmap address");
     }
 
-    if (!x64::is_physical_address_valid(vmcs_vmread_bitmap_address)) {
+    if (!::x64::is_physical_address_valid(vmcs_vmread_bitmap_address)) {
         throw std::logic_error("vmcs read bitmap address addr too large");
     }
 
-    if (!x64::is_physical_address_valid(vmcs_vmwrite_bitmap_address)) {
+    if (!::x64::is_physical_address_valid(vmcs_vmwrite_bitmap_address)) {
         throw std::logic_error("vmcs write bitmap address addr too large");
     }
 }
@@ -531,22 +531,22 @@ control_enable_vmcs_shadowing()
 inline void
 control_enable_ept_violation_checks()
 {
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::ept_violation_ve::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::ept_violation_ve::is_disabled_if_exists()) {
         return;
     }
 
     auto vmcs_virt_except_info_address =
-        virtualization_exception_information_address::get_if_exists();
+        ::intel_x64::vmcs::virtualization_exception_information_address::get_if_exists();
 
     if ((vmcs_virt_except_info_address & 0x0000000000000FFF) != 0) {
         throw std::logic_error("bits 11:0 must be 0 for the vmcs virt except info address");
     }
 
-    if (!x64::is_physical_address_valid(vmcs_virt_except_info_address)) {
+    if (!::x64::is_physical_address_valid(vmcs_virt_except_info_address)) {
         throw std::logic_error("vmcs virt except info address addr too large");
     }
 }
@@ -554,9 +554,9 @@ control_enable_ept_violation_checks()
 inline void
 control_vm_exit_ctls_reserved_properly_set()
 {
-    auto addr = msrs::ia32_vmx_true_exit_ctls::addr;
-    auto ctls = vmcs::vm_exit_controls::get();
-    auto name = vmcs::vm_exit_controls::name;
+    auto addr = ::intel_x64::msrs::ia32_vmx_true_exit_ctls::addr;
+    auto ctls = ::intel_x64::vmcs::vm_exit_controls::get();
+    auto name = ::intel_x64::vmcs::vm_exit_controls::name;
 
     control_reserved_properly_set(addr, ctls, name);
 }
@@ -564,11 +564,11 @@ control_vm_exit_ctls_reserved_properly_set()
 inline void
 control_activate_and_save_preemption_timer_must_be_0()
 {
-    if (pin_based_vm_execution_controls::activate_vmx_preemption_timer::is_enabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::activate_vmx_preemption_timer::is_enabled()) {
         return;
     }
 
-    if (vm_exit_controls::save_vmx_preemption_timer_value::is_enabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::save_vmx_preemption_timer_value::is_enabled()) {
         throw std::logic_error("save vmx preemption timer must be 0 "
                                "if activate vmx preemption timer is 0");
     }
@@ -577,25 +577,25 @@ control_activate_and_save_preemption_timer_must_be_0()
 inline void
 control_exit_msr_store_address()
 {
-    auto msr_store_count = vm_exit_msr_store_count::get();
+    auto msr_store_count = ::intel_x64::vmcs::vm_exit_msr_store_count::get();
 
     if (msr_store_count == 0) {
         return;
     }
 
-    auto msr_store_addr = vmcs::vm_exit_msr_store_address::get();
+    auto msr_store_addr = ::intel_x64::vmcs::vm_exit_msr_store_address::get();
 
     if ((msr_store_addr & 0x000000000000000F) != 0) {
         throw std::logic_error("bits 3:0 must be 0 for the exit msr store address");
     }
 
-    if (!x64::is_physical_address_valid(msr_store_addr)) {
+    if (!::x64::is_physical_address_valid(msr_store_addr)) {
         throw std::logic_error("exit msr store addr too large");
     }
 
     auto msr_store_addr_end = msr_store_addr + (msr_store_count * 16) - 1;
 
-    if (!x64::is_physical_address_valid(msr_store_addr_end)) {
+    if (!::x64::is_physical_address_valid(msr_store_addr_end)) {
         throw std::logic_error("end of exit msr store area too large");
     }
 }
@@ -603,25 +603,25 @@ control_exit_msr_store_address()
 inline void
 control_exit_msr_load_address()
 {
-    auto msr_load_count = vm_exit_msr_load_count::get();
+    auto msr_load_count = ::intel_x64::vmcs::vm_exit_msr_load_count::get();
 
     if (msr_load_count == 0) {
         return;
     }
 
-    auto msr_load_addr = vmcs::vm_exit_msr_load_address::get();
+    auto msr_load_addr = ::intel_x64::vmcs::vm_exit_msr_load_address::get();
 
     if ((msr_load_addr & 0x000000000000000F) != 0) {
         throw std::logic_error("bits 3:0 must be 0 for the exit msr load address");
     }
 
-    if (!x64::is_physical_address_valid(msr_load_addr)) {
+    if (!::x64::is_physical_address_valid(msr_load_addr)) {
         throw std::logic_error("exit msr load addr too large");
     }
 
     auto msr_load_addr_end = msr_load_addr + (msr_load_count * 16) - 1;
 
-    if (!x64::is_physical_address_valid(msr_load_addr_end)) {
+    if (!::x64::is_physical_address_valid(msr_load_addr_end)) {
         throw std::logic_error("end of exit msr load area too large");
     }
 }
@@ -629,9 +629,9 @@ control_exit_msr_load_address()
 inline void
 control_vm_entry_ctls_reserved_properly_set()
 {
-    auto addr = msrs::ia32_vmx_true_entry_ctls::addr;
-    auto ctls = vm_entry_controls::get();
-    auto name = vm_entry_controls::name;
+    auto addr = ::intel_x64::msrs::ia32_vmx_true_entry_ctls::addr;
+    auto ctls = ::intel_x64::vmcs::vm_entry_controls::get();
+    auto name = ::intel_x64::vmcs::vm_entry_controls::name;
 
     control_reserved_properly_set(addr, ctls, name);
 }
@@ -639,15 +639,15 @@ control_vm_entry_ctls_reserved_properly_set()
 inline void
 control_event_injection_type_vector_checks()
 {
-    using namespace vm_entry_interruption_information;
-    using namespace msrs::ia32_vmx_true_procbased_ctls;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
+    using namespace ::intel_x64::msrs::ia32_vmx_true_procbased_ctls;
 
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    auto vector = vm_entry_interruption_information::vector::get();
-    auto type = vm_entry_interruption_information::interruption_type::get();
+    auto vector = ::intel_x64::vmcs::vm_entry_interruption_information::vector::get();
+    auto type = ::intel_x64::vmcs::vm_entry_interruption_information::interruption_type::get();
 
     if (type == interruption_type::reserved) {
         throw std::logic_error("interrupt information field type of 1 is reserved");
@@ -677,19 +677,19 @@ control_event_injection_type_vector_checks()
 inline void
 control_event_injection_delivery_ec_checks()
 {
-    using namespace vm_entry_interruption_information;
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    auto type = vm_entry_interruption_information::interruption_type::get();
-    auto vector = vm_entry_interruption_information::vector::get();
+    auto type = ::intel_x64::vmcs::vm_entry_interruption_information::interruption_type::get();
+    auto vector = ::intel_x64::vmcs::vm_entry_interruption_information::vector::get();
 
     if (unrestricted_guest::is_enabled() && activate_secondary_controls::is_enabled()) {
-        if (guest_cr0::protection_enable::is_disabled() && deliver_error_code_bit::is_enabled()) {
+        if (::intel_x64::vmcs::guest_cr0::protection_enable::is_disabled() && deliver_error_code_bit::is_enabled()) {
             throw std::logic_error("unrestricted guest must be 0 or PE must "
                                    "be enabled in cr0 if deliver_error_code_bit is set");
         }
@@ -725,11 +725,11 @@ control_event_injection_delivery_ec_checks()
 inline void
 control_event_injection_reserved_bits_checks()
 {
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    if (vm_entry_interruption_information::reserved::get() != 0) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::reserved::get() != 0) {
         throw std::logic_error("reserved bits of the interrupt info field must be 0");
     }
 }
@@ -737,15 +737,15 @@ control_event_injection_reserved_bits_checks()
 inline void
 control_event_injection_ec_checks()
 {
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    if (vm_entry_interruption_information::deliver_error_code_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::deliver_error_code_bit::is_disabled()) {
         return;
     }
 
-    if ((vm_entry_exception_error_code::get() & 0x00000000FFFF8000ULL) != 0) {
+    if ((::intel_x64::vmcs::vm_entry_exception_error_code::get() & 0x00000000FFFF8000ULL) != 0) {
         throw std::logic_error("bits 31:15 of the exception error code field must be 0 "
                                "if deliver error code bit is set in the interrupt info field");
     }
@@ -754,14 +754,14 @@ control_event_injection_ec_checks()
 inline void
 control_event_injection_instr_length_checks()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    auto type = vm_entry_interruption_information::interruption_type::get();
-    auto instruction_length = vm_entry_instruction_length::get();
+    auto type = ::intel_x64::vmcs::vm_entry_interruption_information::interruption_type::get();
+    auto instruction_length = ::intel_x64::vmcs::vm_entry_instruction_length::get();
 
     switch (type) {
         case interruption_type::software_interrupt:
@@ -774,7 +774,7 @@ control_event_injection_instr_length_checks()
     }
 
     if (instruction_length == 0 &&
-        msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::is_disabled()) {
+        ::intel_x64::msrs::ia32_vmx_misc::injection_with_instruction_length_of_zero::is_disabled()) {
         throw std::logic_error("instruction length must be greater than zero");
     }
 
@@ -786,25 +786,25 @@ control_event_injection_instr_length_checks()
 inline void
 control_entry_msr_load_address()
 {
-    auto msr_load_count = vm_entry_msr_load_count::get();
+    auto msr_load_count = ::intel_x64::vmcs::vm_entry_msr_load_count::get();
 
     if (msr_load_count == 0) {
         return;
     }
 
-    auto msr_load_addr = vmcs::vm_entry_msr_load_address::get();
+    auto msr_load_addr = ::intel_x64::vmcs::vm_entry_msr_load_address::get();
 
     if ((msr_load_addr & 0x000000000000000F) != 0) {
         throw std::logic_error("bits 3:0 must be 0 for the entry msr load address");
     }
 
-    if (!x64::is_physical_address_valid(msr_load_addr)) {
+    if (!::x64::is_physical_address_valid(msr_load_addr)) {
         throw std::logic_error("entry msr load addr too large");
     }
 
     auto msr_load_addr_end = msr_load_addr + (msr_load_count * 16) - 1;
 
-    if (!x64::is_physical_address_valid(msr_load_addr_end)) {
+    if (!::x64::is_physical_address_valid(msr_load_addr_end)) {
         throw std::logic_error("end of entry msr load area too large");
     }
 }

--- a/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_guest_fields.h
+++ b/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_guest_fields.h
@@ -30,9 +30,9 @@
 /// section 26.3, Vol. 3 of the SDM.
 ///
 
-namespace intel_x64
+namespace bfvmm
 {
-namespace vmcs
+namespace intel_x64
 {
 namespace check
 {
@@ -40,12 +40,12 @@ namespace check
 inline void
 guest_cr0_for_unsupported_bits()
 {
-    auto cr0 = guest_cr0::get();
-    auto ia32_vmx_cr0_fixed0 = msrs::ia32_vmx_cr0_fixed0::get();
-    auto ia32_vmx_cr0_fixed1 = msrs::ia32_vmx_cr0_fixed1::get();
+    auto cr0 = ::intel_x64::vmcs::guest_cr0::get();
+    auto ia32_vmx_cr0_fixed0 = ::intel_x64::msrs::ia32_vmx_cr0_fixed0::get();
+    auto ia32_vmx_cr0_fixed1 = ::intel_x64::msrs::ia32_vmx_cr0_fixed1::get();
 
-    if (secondary_processor_based_vm_execution_controls::unrestricted_guest::is_enabled_if_exists()) {
-        ia32_vmx_cr0_fixed0 &= ~(intel_x64::cr0::paging::mask | intel_x64::cr0::protection_enable::mask);
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::unrestricted_guest::is_enabled_if_exists()) {
+        ia32_vmx_cr0_fixed0 &= ~(::intel_x64::cr0::paging::mask | ::intel_x64::cr0::protection_enable::mask);
     }
 
     if (0 != ((~cr0 & ia32_vmx_cr0_fixed0) | (cr0 & ~ia32_vmx_cr0_fixed1))) {
@@ -63,11 +63,11 @@ guest_cr0_for_unsupported_bits()
 inline void
 guest_cr0_verify_paging_enabled()
 {
-    if (guest_cr0::paging::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr0::paging::is_disabled()) {
         return;
     }
 
-    if (guest_cr0::protection_enable::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr0::protection_enable::is_disabled()) {
         throw std::logic_error("PE must be enabled in cr0 if PG is enabled");
     }
 }
@@ -75,9 +75,9 @@ guest_cr0_verify_paging_enabled()
 inline void
 guest_cr4_for_unsupported_bits()
 {
-    auto cr4 = guest_cr4::get();
-    auto ia32_vmx_cr4_fixed0 = msrs::ia32_vmx_cr4_fixed0::get();
-    auto ia32_vmx_cr4_fixed1 = msrs::ia32_vmx_cr4_fixed1::get();
+    auto cr4 = ::intel_x64::vmcs::guest_cr4::get();
+    auto ia32_vmx_cr4_fixed0 = ::intel_x64::msrs::ia32_vmx_cr4_fixed0::get();
+    auto ia32_vmx_cr4_fixed1 = ::intel_x64::msrs::ia32_vmx_cr4_fixed1::get();
 
     if (0 != ((~cr4 & ia32_vmx_cr4_fixed0) | (cr4 & ~ia32_vmx_cr4_fixed1))) {
         bfdebug_transaction(0, [&](std::string * msg) {
@@ -94,11 +94,11 @@ guest_cr4_for_unsupported_bits()
 inline void
 guest_load_debug_controls_verify_reserved()
 {
-    if (vm_entry_controls::load_debug_controls::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_debug_controls::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_ia32_debugctl::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ia32_debugctl::reserved::get() != 0) {
         throw std::logic_error("debug ctrl msr reserved bits must be 0");
     }
 }
@@ -106,35 +106,35 @@ guest_load_debug_controls_verify_reserved()
 inline void
 guest_verify_ia_32e_mode_enabled()
 {
-    if (vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
         return;
     }
 
-    if (guest_cr0::paging::is_disabled()) {
-        throw std::logic_error("paging must be enabled if ia 32e guest mode is enabled");
+    if (::intel_x64::vmcs::guest_cr0::paging::is_disabled()) {
+        throw std::logic_error("paging must be enabled if ia 32e ::intel_x64::vmcs::guest mode is enabled");
     }
 
-    if (guest_cr4::physical_address_extensions::is_disabled()) {
-        throw std::logic_error("pae must be enabled if ia 32e guest mode is enabled");
+    if (::intel_x64::vmcs::guest_cr4::physical_address_extensions::is_disabled()) {
+        throw std::logic_error("pae must be enabled if ia 32e ::intel_x64::vmcs::guest mode is enabled");
     }
 }
 
 inline void
 guest_verify_ia_32e_mode_disabled()
 {
-    if (vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
         return;
     }
 
-    if (guest_cr4::pcid_enable_bit::is_enabled()) {
-        throw std::logic_error("pcide in cr4 must be disabled if ia 32e guest mode is disabled");
+    if (::intel_x64::vmcs::guest_cr4::pcid_enable_bit::is_enabled()) {
+        throw std::logic_error("pcide in cr4 must be disabled if ia 32e ::intel_x64::vmcs::guest mode is disabled");
     }
 }
 
 inline void
 guest_cr3_for_unsupported_bits()
 {
-    if (!x64::is_physical_address_valid(guest_cr3::get())) {
+    if (!x64::is_physical_address_valid(::intel_x64::vmcs::guest_cr3::get())) {
         throw std::logic_error("guest cr3 too large");
     }
 }
@@ -142,11 +142,11 @@ guest_cr3_for_unsupported_bits()
 inline void
 guest_load_debug_controls_verify_dr7()
 {
-    if (vm_entry_controls::load_debug_controls::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_debug_controls::is_disabled()) {
         return;
     }
 
-    auto dr7 = vmcs::guest_dr7::get();
+    auto dr7 = ::intel_x64::vmcs::guest_dr7::get();
 
     if ((dr7 & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("bits 63:32 of dr7 must be 0 if load debug controls is 1");
@@ -156,7 +156,7 @@ guest_load_debug_controls_verify_dr7()
 inline void
 guest_ia32_sysenter_esp_canonical_address()
 {
-    if (!x64::is_address_canonical(vmcs::guest_ia32_sysenter_esp::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_ia32_sysenter_esp::get())) {
         throw std::logic_error("guest sysenter esp must be canonical");
     }
 }
@@ -164,7 +164,7 @@ guest_ia32_sysenter_esp_canonical_address()
 inline void
 guest_ia32_sysenter_eip_canonical_address()
 {
-    if (!x64::is_address_canonical(vmcs::guest_ia32_sysenter_eip::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_ia32_sysenter_eip::get())) {
         throw std::logic_error("guest sysenter eip must be canonical");
     }
 }
@@ -172,11 +172,11 @@ guest_ia32_sysenter_eip_canonical_address()
 inline void
 guest_verify_load_ia32_perf_global_ctrl()
 {
-    if (vm_entry_controls::load_ia32_perf_global_ctrl::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_ia32_perf_global_ctrl::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_ia32_perf_global_ctrl::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ia32_perf_global_ctrl::reserved::get() != 0) {
         throw std::logic_error("perf global ctrl msr reserved bits must be 0");
     }
 }
@@ -184,39 +184,39 @@ guest_verify_load_ia32_perf_global_ctrl()
 inline void
 guest_verify_load_ia32_pat()
 {
-    if (vm_entry_controls::load_ia32_pat::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_ia32_pat::is_disabled()) {
         return;
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa0::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa0::memory_type::get())) {
         throw std::logic_error("pat0 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa1::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa1::memory_type::get())) {
         throw std::logic_error("pat1 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa2::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa2::memory_type::get())) {
         throw std::logic_error("pat2 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa3::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa3::memory_type::get())) {
         throw std::logic_error("pat3 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa4::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa4::memory_type::get())) {
         throw std::logic_error("pat4 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa5::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa5::memory_type::get())) {
         throw std::logic_error("pat5 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa6::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa6::memory_type::get())) {
         throw std::logic_error("pat6 has a reserved memory type");
     }
 
-    if (memory_type_reserved(guest_ia32_pat::pa7::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::guest_ia32_pat::pa7::memory_type::get())) {
         throw std::logic_error("pat7 has a reserved memory type");
     }
 }
@@ -224,27 +224,27 @@ guest_verify_load_ia32_pat()
 inline void
 guest_verify_load_ia32_efer()
 {
-    if (vm_entry_controls::load_ia32_efer::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_ia32_efer::is_disabled()) {
         return;
     }
 
-    if (guest_ia32_efer::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ia32_efer::reserved::get() != 0) {
         throw std::logic_error("ia32 efer msr reserved buts must be 0 if "
                                "load ia32 efer entry is enabled");
     }
 
-    auto lma = guest_ia32_efer::lma::is_enabled();
-    auto lme = guest_ia32_efer::lme::is_enabled();
+    auto lma = ::intel_x64::vmcs::guest_ia32_efer::lma::is_enabled();
+    auto lme = ::intel_x64::vmcs::guest_ia32_efer::lme::is_enabled();
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_disabled() && lma) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_disabled() && lma) {
         throw std::logic_error("ia 32e mode is 0, but efer.lma is 1");
     }
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_enabled() && !lma) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled() && !lma) {
         throw std::logic_error("ia 32e mode is 1, but efer.lma is 0");
     }
 
-    if (guest_cr0::paging::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr0::paging::is_disabled()) {
         return;
     }
 
@@ -260,11 +260,11 @@ guest_verify_load_ia32_efer()
 inline void
 guest_verify_load_ia32_bndcfgs()
 {
-    if (vm_entry_controls::load_ia32_bndcfgs::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::load_ia32_bndcfgs::is_disabled()) {
         return;
     }
 
-    auto bndcfgs = vmcs::guest_ia32_bndcfgs::get();
+    auto bndcfgs = ::intel_x64::vmcs::guest_ia32_bndcfgs::get();
 
     if ((bndcfgs & 0x0000000000000FFC) != 0) {
         throw std::logic_error("ia32 bndcfgs msr reserved bits must be 0 if "
@@ -282,7 +282,7 @@ guest_verify_load_ia32_bndcfgs()
 inline void
 guest_tr_ti_bit_equals_0()
 {
-    if (guest_tr_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_tr_selector::ti::is_enabled()) {
         throw std::logic_error("guest tr's ti flag must be zero");
     }
 }
@@ -290,11 +290,11 @@ guest_tr_ti_bit_equals_0()
 inline void
 guest_ldtr_ti_bit_equals_0()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ldtr_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_selector::ti::is_enabled()) {
         throw std::logic_error("guest ldtr's ti flag must be zero");
     }
 }
@@ -302,10 +302,10 @@ guest_ldtr_ti_bit_equals_0()
 inline void
 guest_ss_and_cs_rpl_are_the_same()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -313,7 +313,7 @@ guest_ss_and_cs_rpl_are_the_same()
         return;
     }
 
-    if (guest_ss_selector::rpl::get() != guest_cs_selector::rpl::get()) {
+    if (::intel_x64::vmcs::guest_ss_selector::rpl::get() != ::intel_x64::vmcs::guest_cs_selector::rpl::get()) {
         throw std::logic_error("ss and cs rpl must be the same");
     }
 }
@@ -321,13 +321,13 @@ guest_ss_and_cs_rpl_are_the_same()
 inline void
 guest_cs_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto cs = guest_cs_selector::get();
+    auto cs = ::intel_x64::vmcs::guest_cs_selector::get();
 
-    if ((cs << 4) != vmcs::guest_cs_base::get()) {
+    if ((cs << 4) != ::intel_x64::vmcs::guest_cs_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, cs base must be cs shifted 4 bits");
     }
 }
@@ -335,13 +335,13 @@ guest_cs_base_is_shifted()
 inline void
 guest_ss_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto ss = guest_ss_selector::get();
+    auto ss = ::intel_x64::vmcs::guest_ss_selector::get();
 
-    if ((ss << 4) != vmcs::guest_ss_base::get()) {
+    if ((ss << 4) != ::intel_x64::vmcs::guest_ss_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, ss base must be ss shifted 4 bits");
     }
 }
@@ -349,13 +349,13 @@ guest_ss_base_is_shifted()
 inline void
 guest_ds_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto ds = guest_ds_selector::get();
+    auto ds = ::intel_x64::vmcs::guest_ds_selector::get();
 
-    if ((ds << 4) != vmcs::guest_ds_base::get()) {
+    if ((ds << 4) != ::intel_x64::vmcs::guest_ds_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, ds base must be ds shifted 4 bits");
     }
 }
@@ -363,13 +363,13 @@ guest_ds_base_is_shifted()
 inline void
 guest_es_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto es = guest_es_selector::get();
+    auto es = ::intel_x64::vmcs::guest_es_selector::get();
 
-    if ((es << 4) != vmcs::guest_es_base::get()) {
+    if ((es << 4) != ::intel_x64::vmcs::guest_es_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, es base must be es shifted 4 bits");
     }
 }
@@ -377,13 +377,13 @@ guest_es_base_is_shifted()
 inline void
 guest_fs_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto fs = guest_fs_selector::get();
+    auto fs = ::intel_x64::vmcs::guest_fs_selector::get();
 
-    if ((fs << 4) != vmcs::guest_fs_base::get()) {
+    if ((fs << 4) != ::intel_x64::vmcs::guest_fs_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, fs base must be fs shifted 4 bits");
     }
 }
@@ -391,13 +391,13 @@ guest_fs_base_is_shifted()
 inline void
 guest_gs_base_is_shifted()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto gs = guest_gs_selector::get();
+    auto gs = ::intel_x64::vmcs::guest_gs_selector::get();
 
-    if ((gs << 4) != vmcs::guest_gs_base::get()) {
+    if ((gs << 4) != ::intel_x64::vmcs::guest_gs_base::get()) {
         throw std::logic_error("if virtual 8086 mode is enabled, gs base must be gs shift 4 bits");
     }
 }
@@ -405,7 +405,7 @@ guest_gs_base_is_shifted()
 inline void
 guest_tr_base_is_canonical()
 {
-    if (!x64::is_address_canonical(vmcs::guest_tr_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_tr_base::get())) {
         throw std::logic_error("guest tr base non-canonical");
     }
 }
@@ -413,7 +413,7 @@ guest_tr_base_is_canonical()
 inline void
 guest_fs_base_is_canonical()
 {
-    if (!x64::is_address_canonical(vmcs::guest_fs_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_fs_base::get())) {
         throw std::logic_error("guest fs base non-canonical");
     }
 }
@@ -421,7 +421,7 @@ guest_fs_base_is_canonical()
 inline void
 guest_gs_base_is_canonical()
 {
-    if (!x64::is_address_canonical(vmcs::guest_gs_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_gs_base::get())) {
         throw std::logic_error("guest gs base non-canonical");
     }
 }
@@ -429,11 +429,11 @@ guest_gs_base_is_canonical()
 inline void
 guest_ldtr_base_is_canonical()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (!x64::is_address_canonical(vmcs::guest_ldtr_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_ldtr_base::get())) {
         throw std::logic_error("guest ldtr base non-canonical");
     }
 }
@@ -441,7 +441,7 @@ guest_ldtr_base_is_canonical()
 inline void
 guest_cs_base_upper_dword_0()
 {
-    if ((vmcs::guest_cs_base::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::guest_cs_base::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("guest cs base bits 63:32 must be 0");
     }
 }
@@ -449,11 +449,11 @@ guest_cs_base_upper_dword_0()
 inline void
 guest_ss_base_upper_dword_0()
 {
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((vmcs::guest_ss_base::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::guest_ss_base::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("guest ss base bits 63:32 must be 0");
     }
 }
@@ -461,11 +461,11 @@ guest_ss_base_upper_dword_0()
 inline void
 guest_ds_base_upper_dword_0()
 {
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((vmcs::guest_ds_base::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::guest_ds_base::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("guest ds base bits 63:32 must be 0");
     }
 }
@@ -473,11 +473,11 @@ guest_ds_base_upper_dword_0()
 inline void
 guest_es_base_upper_dword_0()
 {
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((vmcs::guest_es_base::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::guest_es_base::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("guest es base bits 63:32 must be 0");
     }
 }
@@ -485,11 +485,11 @@ guest_es_base_upper_dword_0()
 inline void
 guest_cs_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto cs_limit = vmcs::guest_cs_limit::get();
+    auto cs_limit = ::intel_x64::vmcs::guest_cs_limit::get();
 
     if (cs_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, cs limit must be 0xFFFF");
@@ -499,11 +499,11 @@ guest_cs_limit()
 inline void
 guest_ss_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto ss_limit = vmcs::guest_ss_limit::get();
+    auto ss_limit = ::intel_x64::vmcs::guest_ss_limit::get();
 
     if (ss_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, ss limit must be 0xFFFF");
@@ -513,11 +513,11 @@ guest_ss_limit()
 inline void
 guest_ds_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto ds_limit = vmcs::guest_ds_limit::get();
+    auto ds_limit = ::intel_x64::vmcs::guest_ds_limit::get();
 
     if (ds_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, ds limit must be 0xFFFF");
@@ -527,11 +527,11 @@ guest_ds_limit()
 inline void
 guest_es_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto es_limit = vmcs::guest_es_limit::get();
+    auto es_limit = ::intel_x64::vmcs::guest_es_limit::get();
 
     if (es_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, es limit must be 0xFFFF");
@@ -541,11 +541,11 @@ guest_es_limit()
 inline void
 guest_gs_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto gs_limit = vmcs::guest_gs_limit::get();
+    auto gs_limit = ::intel_x64::vmcs::guest_gs_limit::get();
 
     if (gs_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, gs limit must be 0xFFFF");
@@ -555,11 +555,11 @@ guest_gs_limit()
 inline void
 guest_fs_limit()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    auto fs_limit = vmcs::guest_fs_limit::get();
+    auto fs_limit = ::intel_x64::vmcs::guest_fs_limit::get();
 
     if (fs_limit != 0x000000000000FFFF) {
         throw std::logic_error("if virtual 8086 mode is enabled, fs limit must be 0xFFFF");
@@ -569,11 +569,11 @@ guest_fs_limit()
 inline void
 guest_v8086_cs_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, cs access rights must be 0x00F3");
     }
 }
@@ -581,11 +581,11 @@ guest_v8086_cs_access_rights()
 inline void
 guest_v8086_ss_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, ss access rights must be 0x00F3");
     }
 }
@@ -593,11 +593,11 @@ guest_v8086_ss_access_rights()
 inline void
 guest_v8086_ds_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, ds access rights must be 0x00F3");
     }
 }
@@ -605,11 +605,11 @@ guest_v8086_ds_access_rights()
 inline void
 guest_v8086_es_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_es_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_es_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, es access rights must be 0x00F3");
     }
 }
@@ -617,11 +617,11 @@ guest_v8086_es_access_rights()
 inline void
 guest_v8086_fs_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, fs access rights must be 0x00F3");
     }
 }
@@ -629,11 +629,11 @@ guest_v8086_fs_access_rights()
 inline void
 guest_v8086_gs_access_rights()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_disabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::get() != 0x00000000000000F3) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::get() != 0x00000000000000F3) {
         throw std::logic_error("if virtual 8086 mode is enabled, gs access rights must be 0x00F3");
     }
 }
@@ -641,15 +641,15 @@ guest_v8086_gs_access_rights()
 inline void
 guest_cs_access_rights_type()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    switch (guest_cs_access_rights::type::get()) {
-        case x64::access_rights::type::read_write_accessed:
+    switch (::intel_x64::vmcs::guest_cs_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write_accessed:
             if (activate_secondary_controls::is_disabled()) {
                 break;
             }
@@ -658,10 +658,10 @@ guest_cs_access_rights_type()
                 break;
             }
 
-        case x64::access_rights::type::execute_only_accessed:
-        case x64::access_rights::type::read_execute_accessed:
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+        case ::x64::access_rights::type::execute_only_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
@@ -669,23 +669,23 @@ guest_cs_access_rights_type()
     }
 
     throw std::logic_error("guest cs type must be 9, 11, 13, 15, or "
-                           "3 (if unrestricted guest support is enabled)");
+                           "3 (if unrestricted ::intel_x64::vmcs::guest support is enabled)");
 }
 
 inline void
 guest_ss_access_rights_type()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_ss_access_rights::type::get()) {
-        case x64::access_rights::type::read_write_accessed:
-        case x64::access_rights::type::read_write_expand_down_accessed:
+    switch (::intel_x64::vmcs::guest_ss_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write_accessed:
+        case ::x64::access_rights::type::read_write_expand_down_accessed:
             return;
 
         default:
@@ -698,21 +698,21 @@ guest_ss_access_rights_type()
 inline void
 guest_ds_access_rights_type()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_ds_access_rights::type::get()) {
-        case x64::access_rights::type::read_only_accessed:
-        case x64::access_rights::type::read_write_accessed:
-        case x64::access_rights::type::read_only_expand_down_accessed:
-        case x64::access_rights::type::read_write_expand_down_accessed:
-        case x64::access_rights::type::read_execute_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_ds_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_only_accessed:
+        case ::x64::access_rights::type::read_write_accessed:
+        case ::x64::access_rights::type::read_only_expand_down_accessed:
+        case ::x64::access_rights::type::read_write_expand_down_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
@@ -725,21 +725,21 @@ guest_ds_access_rights_type()
 inline void
 guest_es_access_rights_type()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_es_access_rights::type::get()) {
-        case x64::access_rights::type::read_only_accessed:
-        case x64::access_rights::type::read_write_accessed:
-        case x64::access_rights::type::read_only_expand_down_accessed:
-        case x64::access_rights::type::read_write_expand_down_accessed:
-        case x64::access_rights::type::read_execute_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_es_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_only_accessed:
+        case ::x64::access_rights::type::read_write_accessed:
+        case ::x64::access_rights::type::read_only_expand_down_accessed:
+        case ::x64::access_rights::type::read_write_expand_down_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
@@ -752,21 +752,21 @@ guest_es_access_rights_type()
 inline void
 guest_fs_access_rights_type()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_fs_access_rights::type::get()) {
-        case x64::access_rights::type::read_only_accessed:
-        case x64::access_rights::type::read_write_accessed:
-        case x64::access_rights::type::read_only_expand_down_accessed:
-        case x64::access_rights::type::read_write_expand_down_accessed:
-        case x64::access_rights::type::read_execute_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_fs_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_only_accessed:
+        case ::x64::access_rights::type::read_write_accessed:
+        case ::x64::access_rights::type::read_only_expand_down_accessed:
+        case ::x64::access_rights::type::read_write_expand_down_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
@@ -779,21 +779,21 @@ guest_fs_access_rights_type()
 inline void
 guest_gs_access_rights_type()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_gs_access_rights::type::get()) {
-        case x64::access_rights::type::read_only_accessed:
-        case x64::access_rights::type::read_write_accessed:
-        case x64::access_rights::type::read_only_expand_down_accessed:
-        case x64::access_rights::type::read_write_expand_down_accessed:
-        case x64::access_rights::type::read_execute_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_gs_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_only_accessed:
+        case ::x64::access_rights::type::read_write_accessed:
+        case ::x64::access_rights::type::read_only_expand_down_accessed:
+        case ::x64::access_rights::type::read_write_expand_down_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
@@ -806,11 +806,11 @@ guest_gs_access_rights_type()
 inline void
 guest_cs_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::s::is_disabled()) {
         throw std::logic_error("cs must be a code/data descriptor. S should equal 1");
     }
 }
@@ -818,15 +818,15 @@ guest_cs_is_not_a_system_descriptor()
 inline void
 guest_ss_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::s::is_disabled()) {
         throw std::logic_error("ss must be a code/data descriptor. S should equal 1");
     }
 }
@@ -834,15 +834,15 @@ guest_ss_is_not_a_system_descriptor()
 inline void
 guest_ds_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::s::is_disabled()) {
         throw std::logic_error("ds must be a code/data descriptor. S should equal 1");
     }
 }
@@ -850,15 +850,15 @@ guest_ds_is_not_a_system_descriptor()
 inline void
 guest_es_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::s::is_disabled()) {
         throw std::logic_error("es must be a code/data descriptor. S should equal 1");
     }
 }
@@ -866,15 +866,15 @@ guest_es_is_not_a_system_descriptor()
 inline void
 guest_fs_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::s::is_disabled()) {
         throw std::logic_error("fs must be a code/data descriptor. S should equal 1");
     }
 }
@@ -882,15 +882,15 @@ guest_fs_is_not_a_system_descriptor()
 inline void
 guest_gs_is_not_a_system_descriptor()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::s::is_disabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::s::is_disabled()) {
         throw std::logic_error("gs must be a code/data descriptor. S should equal 1");
     }
 }
@@ -898,19 +898,19 @@ guest_gs_is_not_a_system_descriptor()
 inline void
 guest_cs_type_not_equal_3()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    switch (guest_cs_access_rights::type::get()) {
-        case x64::access_rights::type::read_write_accessed:
+    switch (::intel_x64::vmcs::guest_cs_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write_accessed:
             break;
 
         default:
             return;
     }
 
-    if (guest_cs_access_rights::dpl::get() != 0) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::dpl::get() != 0) {
         throw std::logic_error("cs dpl must be 0 if type == 3");
     }
 }
@@ -918,15 +918,15 @@ guest_cs_type_not_equal_3()
 inline void
 guest_cs_dpl_adheres_to_ss_dpl()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    switch (guest_cs_access_rights::type::get()) {
-        case x64::access_rights::type::execute_only_accessed:
-        case x64::access_rights::type::read_execute_accessed: {
-            auto cs_dpl = guest_cs_access_rights::dpl::get();
-            auto ss_dpl = guest_ss_access_rights::dpl::get();
+    switch (::intel_x64::vmcs::guest_cs_access_rights::type::get()) {
+        case ::x64::access_rights::type::execute_only_accessed:
+        case ::x64::access_rights::type::read_execute_accessed: {
+            auto cs_dpl = ::intel_x64::vmcs::guest_cs_access_rights::dpl::get();
+            auto ss_dpl = ::intel_x64::vmcs::guest_ss_access_rights::dpl::get();
 
             if (cs_dpl != ss_dpl) {
                 throw std::logic_error("if cs access rights type is 9, 11 cs dpl must equal ss dpl");
@@ -935,10 +935,10 @@ guest_cs_dpl_adheres_to_ss_dpl()
             break;
         }
 
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming_accessed: {
-            auto cs_dpl = guest_cs_access_rights::dpl::get();
-            auto ss_dpl = guest_ss_access_rights::dpl::get();
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming_accessed: {
+            auto cs_dpl = ::intel_x64::vmcs::guest_cs_access_rights::dpl::get();
+            auto ss_dpl = ::intel_x64::vmcs::guest_ss_access_rights::dpl::get();
 
             if (cs_dpl > ss_dpl) {
                 throw std::logic_error("if cs access rights type is 13, 15 cs dpl must not be greater than ss dpl");
@@ -955,10 +955,10 @@ guest_cs_dpl_adheres_to_ss_dpl()
 inline void
 guest_ss_dpl_must_equal_rpl()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -966,32 +966,32 @@ guest_ss_dpl_must_equal_rpl()
         return;
     }
 
-    auto ss_rpl = guest_ss_selector::rpl::get();
-    auto ss_dpl = guest_ss_access_rights::dpl::get();
+    auto ss_rpl = ::intel_x64::vmcs::guest_ss_selector::rpl::get();
+    auto ss_dpl = ::intel_x64::vmcs::guest_ss_access_rights::dpl::get();
 
     if (ss_dpl != ss_rpl) {
-        throw std::logic_error("if unrestricted guest mode is disabled ss dpl must equal ss rpl");
+        throw std::logic_error("if unrestricted ::intel_x64::vmcs::guest mode is disabled ss dpl must equal ss rpl");
     }
 }
 
 inline void
 guest_ss_dpl_must_equal_zero()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    switch (guest_cs_access_rights::type::get()) {
-        case x64::access_rights::type::read_write_accessed:
+    switch (::intel_x64::vmcs::guest_cs_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write_accessed:
             break;
 
         default:
-            if (guest_cr0::protection_enable::is_enabled()) {
+            if (::intel_x64::vmcs::guest_cr0::protection_enable::is_enabled()) {
                 return;
             }
     }
 
-    if (guest_ss_access_rights::dpl::get() != 0) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::dpl::get() != 0) {
         throw std::logic_error("if cs type is 3 or protected mode is disabled, ss DPL must be 0");
     }
 }
@@ -999,10 +999,10 @@ guest_ss_dpl_must_equal_zero()
 inline void
 guest_ds_dpl()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -1010,26 +1010,26 @@ guest_ds_dpl()
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_ds_access_rights::type::get()) {
-        case x64::access_rights::type::execute_only_conforming:
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_ds_access_rights::type::get()) {
+        case ::x64::access_rights::type::execute_only_conforming:
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
             break;
     }
 
-    auto ds_rpl = guest_ds_selector::rpl::get();
-    auto ds_dpl = guest_ds_access_rights::dpl::get();
+    auto ds_rpl = ::intel_x64::vmcs::guest_ds_selector::rpl::get();
+    auto ds_dpl = ::intel_x64::vmcs::guest_ds_access_rights::dpl::get();
 
     if (ds_dpl < ds_rpl) {
-        throw std::logic_error("if unrestricted guest mode is disabled, "
+        throw std::logic_error("if unrestricted ::intel_x64::vmcs::guest mode is disabled, "
                                "and ds is usable, and the access rights "
                                "type is in the range 0-11, dpl cannot be "
                                "less than rpl");
@@ -1039,10 +1039,10 @@ guest_ds_dpl()
 inline void
 guest_es_dpl()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -1050,26 +1050,26 @@ guest_es_dpl()
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_es_access_rights::type::get()) {
-        case x64::access_rights::type::execute_only_conforming:
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_es_access_rights::type::get()) {
+        case ::x64::access_rights::type::execute_only_conforming:
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
             break;
     }
 
-    auto es_rpl = guest_es_selector::rpl::get();
-    auto es_dpl = guest_es_access_rights::dpl::get();
+    auto es_rpl = ::intel_x64::vmcs::guest_es_selector::rpl::get();
+    auto es_dpl = ::intel_x64::vmcs::guest_es_access_rights::dpl::get();
 
     if (es_dpl < es_rpl) {
-        throw std::logic_error("if unrestricted guest mode is disabled, "
+        throw std::logic_error("if unrestricted ::intel_x64::vmcs::guest mode is disabled, "
                                "and es is usable, and the access rights "
                                "type is in the range 0-11, dpl cannot be "
                                "less than rpl");
@@ -1079,10 +1079,10 @@ guest_es_dpl()
 inline void
 guest_fs_dpl()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -1090,26 +1090,26 @@ guest_fs_dpl()
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_fs_access_rights::type::get()) {
-        case x64::access_rights::type::execute_only_conforming:
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_fs_access_rights::type::get()) {
+        case ::x64::access_rights::type::execute_only_conforming:
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
             break;
     }
 
-    auto fs_rpl = guest_fs_selector::rpl::get();
-    auto fs_dpl = guest_fs_access_rights::dpl::get();
+    auto fs_rpl = ::intel_x64::vmcs::guest_fs_selector::rpl::get();
+    auto fs_dpl = ::intel_x64::vmcs::guest_fs_access_rights::dpl::get();
 
     if (fs_dpl < fs_rpl) {
-        throw std::logic_error("if unrestricted guest mode is disabled, "
+        throw std::logic_error("if unrestricted ::intel_x64::vmcs::guest mode is disabled, "
                                "and fs is usable, and the access rights "
                                "type is in the range 0-11, dpl cannot be "
                                "less than rpl");
@@ -1119,10 +1119,10 @@ guest_fs_dpl()
 inline void
 guest_gs_dpl()
 {
-    using namespace primary_processor_based_vm_execution_controls;
-    using namespace secondary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::primary_processor_based_vm_execution_controls;
+    using namespace ::intel_x64::vmcs::secondary_processor_based_vm_execution_controls;
 
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
@@ -1130,26 +1130,26 @@ guest_gs_dpl()
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_gs_access_rights::type::get()) {
-        case x64::access_rights::type::execute_only_conforming:
-        case x64::access_rights::type::execute_only_conforming_accessed:
-        case x64::access_rights::type::read_execute_conforming:
-        case x64::access_rights::type::read_execute_conforming_accessed:
+    switch (::intel_x64::vmcs::guest_gs_access_rights::type::get()) {
+        case ::x64::access_rights::type::execute_only_conforming:
+        case ::x64::access_rights::type::execute_only_conforming_accessed:
+        case ::x64::access_rights::type::read_execute_conforming:
+        case ::x64::access_rights::type::read_execute_conforming_accessed:
             return;
 
         default:
             break;
     }
 
-    auto gs_rpl = guest_gs_selector::rpl::get();
-    auto gs_dpl = guest_gs_access_rights::dpl::get();
+    auto gs_rpl = ::intel_x64::vmcs::guest_gs_selector::rpl::get();
+    auto gs_dpl = ::intel_x64::vmcs::guest_gs_access_rights::dpl::get();
 
     if (gs_dpl < gs_rpl) {
-        throw std::logic_error("if unrestricted guest mode is disabled, "
+        throw std::logic_error("if unrestricted ::intel_x64::vmcs::guest mode is disabled, "
                                "and gs is usable, and the access rights "
                                "type is in the range 0-11, dpl cannot be "
                                "less than rpl");
@@ -1159,11 +1159,11 @@ guest_gs_dpl()
 inline void
 guest_cs_must_be_present()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::present::is_disabled()) {
         throw std::logic_error("cs access rights present flag must be 1 ");
     }
 }
@@ -1171,15 +1171,15 @@ guest_cs_must_be_present()
 inline void
 guest_ss_must_be_present_if_usable()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::present::is_disabled()) {
         throw std::logic_error("ss access rights present flag must be 1 if ss is usable");
     }
 }
@@ -1187,15 +1187,15 @@ guest_ss_must_be_present_if_usable()
 inline void
 guest_ds_must_be_present_if_usable()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::present::is_disabled()) {
         throw std::logic_error("ds access rights present flag must be 1 if ds is usable");
     }
 }
@@ -1203,15 +1203,15 @@ guest_ds_must_be_present_if_usable()
 inline void
 guest_es_must_be_present_if_usable()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::present::is_disabled()) {
         throw std::logic_error("es access rights present flag must be 1 if es is usable");
     }
 }
@@ -1219,15 +1219,15 @@ guest_es_must_be_present_if_usable()
 inline void
 guest_fs_must_be_present_if_usable()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::present::is_disabled()) {
         throw std::logic_error("fs access rights present flag must be 1 if fs is usable");
     }
 }
@@ -1235,15 +1235,15 @@ guest_fs_must_be_present_if_usable()
 inline void
 guest_gs_must_be_present_if_usable()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::present::is_disabled()) {
         throw std::logic_error("gs access rights present flag must be 1 if gs is usable");
     }
 }
@@ -1251,11 +1251,11 @@ guest_gs_must_be_present_if_usable()
 inline void
 guest_cs_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::reserved::get() != 0) {
         throw std::logic_error("cs access rights reserved bits must be 0 ");
     }
 }
@@ -1263,15 +1263,15 @@ guest_cs_access_rights_reserved_must_be_0()
 inline void
 guest_ss_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::reserved::get() != 0) {
         throw std::logic_error("ss access rights reserved bits must be 0 if ss is usable");
     }
 }
@@ -1279,15 +1279,15 @@ guest_ss_access_rights_reserved_must_be_0()
 inline void
 guest_ds_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::reserved::get() != 0) {
         throw std::logic_error("ds access rights reserved bits must be 0 if ds is usable");
     }
 }
@@ -1295,15 +1295,15 @@ guest_ds_access_rights_reserved_must_be_0()
 inline void
 guest_es_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_es_access_rights::reserved::get() != 0) {
         throw std::logic_error("es access rights reserved bits must be 0 if es is usable");
     }
 }
@@ -1311,15 +1311,15 @@ guest_es_access_rights_reserved_must_be_0()
 inline void
 guest_fs_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::reserved::get() != 0) {
         throw std::logic_error("fs access rights reserved bits must be 0 if fs is usable");
     }
 }
@@ -1327,15 +1327,15 @@ guest_fs_access_rights_reserved_must_be_0()
 inline void
 guest_gs_access_rights_reserved_must_be_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::reserved::get() != 0) {
         throw std::logic_error("gs access rights reserved bits must be 0 if gs is usable");
     }
 }
@@ -1343,32 +1343,32 @@ guest_gs_access_rights_reserved_must_be_0()
 inline void
 guest_cs_db_must_be_0_if_l_equals_1()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::l::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cs_access_rights::l::is_disabled()) {
         return;
     }
 
-    if (guest_cs_access_rights::db::is_enabled()) {
-        throw std::logic_error("d/b for guest cs must be 0 if in ia 32e mode and l == 1");
+    if (::intel_x64::vmcs::guest_cs_access_rights::db::is_enabled()) {
+        throw std::logic_error("d/b for ::intel_x64::vmcs::guest cs must be 0 if in ia 32e mode and l == 1");
     }
 }
 
 inline void
 guest_cs_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto cs_limit = vmcs::guest_cs_limit::get();
-    auto g = guest_cs_access_rights::granularity::is_enabled();
+    auto cs_limit = ::intel_x64::vmcs::guest_cs_limit::get();
+    auto g = ::intel_x64::vmcs::guest_cs_access_rights::granularity::is_enabled();
 
     if ((cs_limit & 0x00000FFF) != 0x00000FFF && g) {
         throw std::logic_error("guest cs granularity must be 0 if any bit 11:0 is 0");
@@ -1382,14 +1382,14 @@ guest_cs_granularity()
 inline void
 guest_ss_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto ss_limit = vmcs::guest_ss_limit::get();
-    auto g = guest_ss_access_rights::granularity::is_enabled();
+    auto ss_limit = ::intel_x64::vmcs::guest_ss_limit::get();
+    auto g = ::intel_x64::vmcs::guest_ss_access_rights::granularity::is_enabled();
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
@@ -1405,14 +1405,14 @@ guest_ss_granularity()
 inline void
 guest_ds_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto ds_limit = vmcs::guest_ds_limit::get();
-    auto g = guest_ds_access_rights::granularity::is_enabled();
+    auto ds_limit = ::intel_x64::vmcs::guest_ds_limit::get();
+    auto g = ::intel_x64::vmcs::guest_ds_access_rights::granularity::is_enabled();
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
@@ -1428,14 +1428,14 @@ guest_ds_granularity()
 inline void
 guest_es_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto es_limit = vmcs::guest_es_limit::get();
-    auto g = guest_es_access_rights::granularity::is_enabled();
+    auto es_limit = ::intel_x64::vmcs::guest_es_limit::get();
+    auto g = ::intel_x64::vmcs::guest_es_access_rights::granularity::is_enabled();
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
@@ -1451,14 +1451,14 @@ guest_es_granularity()
 inline void
 guest_fs_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto fs_limit = vmcs::guest_fs_limit::get();
-    auto g = guest_fs_access_rights::granularity::is_enabled();
+    auto fs_limit = ::intel_x64::vmcs::guest_fs_limit::get();
+    auto g = ::intel_x64::vmcs::guest_fs_access_rights::granularity::is_enabled();
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
@@ -1474,14 +1474,14 @@ guest_fs_granularity()
 inline void
 guest_gs_granularity()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    auto gs_limit = vmcs::guest_gs_limit::get();
-    auto g = guest_gs_access_rights::granularity::is_enabled();
+    auto gs_limit = ::intel_x64::vmcs::guest_gs_limit::get();
+    auto g = ::intel_x64::vmcs::guest_gs_access_rights::granularity::is_enabled();
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
@@ -1497,11 +1497,11 @@ guest_gs_granularity()
 inline void
 guest_cs_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if ((guest_cs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_cs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest cs access rights bits 31:17 must be 0");
     }
 }
@@ -1509,15 +1509,15 @@ guest_cs_access_rights_remaining_reserved_bit_0()
 inline void
 guest_ss_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ss_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((guest_ss_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_ss_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest ss access rights bits 31:17 must be 0");
     }
 }
@@ -1525,15 +1525,15 @@ guest_ss_access_rights_remaining_reserved_bit_0()
 inline void
 guest_ds_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_ds_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ds_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((guest_ds_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_ds_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest ds access rights bits 31:17 must be 0");
     }
 }
@@ -1541,15 +1541,15 @@ guest_ds_access_rights_remaining_reserved_bit_0()
 inline void
 guest_es_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_es_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_es_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((guest_es_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_es_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest es access rights bits 31:17 must be 0");
     }
 }
@@ -1557,15 +1557,15 @@ guest_es_access_rights_remaining_reserved_bit_0()
 inline void
 guest_fs_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_fs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_fs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((guest_fs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_fs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest fs access rights bits 31:17 must be 0");
     }
 }
@@ -1573,15 +1573,15 @@ guest_fs_access_rights_remaining_reserved_bit_0()
 inline void
 guest_gs_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         return;
     }
 
-    if (guest_gs_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_gs_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if ((guest_gs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
+    if ((::intel_x64::vmcs::guest_gs_access_rights::get() & 0xFFFE0000ULL) != 0ULL) {
         throw std::logic_error("guest gs access rights bits 31:17 must be 0");
     }
 }
@@ -1589,15 +1589,15 @@ guest_gs_access_rights_remaining_reserved_bit_0()
 inline void
 guest_tr_type_must_be_11()
 {
-    switch (guest_tr_access_rights::type::get()) {
-        case x64::access_rights::type::read_write_accessed:
-            if (vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    switch (::intel_x64::vmcs::guest_tr_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write_accessed:
+            if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
                 throw std::logic_error("tr type cannot be 3 if ia_32e_mode_guest is enabled");
             }
 
             return;
 
-        case x64::access_rights::type::read_execute_accessed:
+        case ::x64::access_rights::type::read_execute_accessed:
             return;
 
         default:
@@ -1608,7 +1608,7 @@ guest_tr_type_must_be_11()
 inline void
 guest_tr_must_be_a_system_descriptor()
 {
-    if (guest_tr_access_rights::s::is_enabled()) {
+    if (::intel_x64::vmcs::guest_tr_access_rights::s::is_enabled()) {
         throw std::logic_error("tr must be a system descriptor. S should equal 0");
     }
 }
@@ -1616,7 +1616,7 @@ guest_tr_must_be_a_system_descriptor()
 inline void
 guest_tr_must_be_present()
 {
-    if (guest_tr_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_tr_access_rights::present::is_disabled()) {
         throw std::logic_error("tr access rights present flag must be 1 ");
     }
 }
@@ -1624,7 +1624,7 @@ guest_tr_must_be_present()
 inline void
 guest_tr_access_rights_reserved_must_be_0()
 {
-    if (guest_tr_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_tr_access_rights::reserved::get() != 0) {
         throw std::logic_error("tr access rights bits 11:8 must be 0");
     }
 }
@@ -1632,8 +1632,8 @@ guest_tr_access_rights_reserved_must_be_0()
 inline void
 guest_tr_granularity()
 {
-    auto tr_limit = vmcs::guest_tr_limit::get();
-    auto g = guest_tr_access_rights::granularity::is_enabled();
+    auto tr_limit = ::intel_x64::vmcs::guest_tr_limit::get();
+    auto g = ::intel_x64::vmcs::guest_tr_access_rights::granularity::is_enabled();
 
     if ((tr_limit & 0x00000FFF) != 0x00000FFF && g) {
         throw std::logic_error("guest tr granularity must be 0 if any bit 11:0 is 0");
@@ -1647,7 +1647,7 @@ guest_tr_granularity()
 inline void
 guest_tr_must_be_usable()
 {
-    if (guest_tr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_tr_access_rights::unusable::is_enabled()) {
         throw std::logic_error("tr must be usable");
     }
 }
@@ -1655,7 +1655,7 @@ guest_tr_must_be_usable()
 inline void
 guest_tr_access_rights_remaining_reserved_bit_0()
 {
-    if (vmcs::guest_tr_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_tr_access_rights::reserved::get() != 0) {
         throw std::logic_error("guest tr access rights bits 31:17 must be 0");
     }
 }
@@ -1663,12 +1663,12 @@ guest_tr_access_rights_remaining_reserved_bit_0()
 inline void
 guest_ldtr_type_must_be_2()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    switch (guest_ldtr_access_rights::type::get()) {
-        case x64::access_rights::type::read_write:
+    switch (::intel_x64::vmcs::guest_ldtr_access_rights::type::get()) {
+        case ::x64::access_rights::type::read_write:
             break;
 
         default:
@@ -1679,11 +1679,11 @@ guest_ldtr_type_must_be_2()
 inline void
 guest_ldtr_must_be_a_system_descriptor()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ldtr_access_rights::s::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::s::is_enabled()) {
         throw std::logic_error("ldtr must be a system descriptor. S should equal 0");
     }
 }
@@ -1691,11 +1691,11 @@ guest_ldtr_must_be_a_system_descriptor()
 inline void
 guest_ldtr_must_be_present()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ldtr_access_rights::present::is_disabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::present::is_disabled()) {
         throw std::logic_error("ldtr access rights present flag must be 1 if ldtr is usable");
     }
 }
@@ -1703,11 +1703,11 @@ guest_ldtr_must_be_present()
 inline void
 guest_ldtr_access_rights_reserved_must_be_0()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    if (guest_ldtr_access_rights::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::reserved::get() != 0) {
         throw std::logic_error("ldtr access rights bits 11:8 must be 0");
     }
 }
@@ -1715,12 +1715,12 @@ guest_ldtr_access_rights_reserved_must_be_0()
 inline void
 guest_ldtr_granularity()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    auto ldtr_limit = vmcs::guest_ldtr_limit::get();
-    auto g = guest_ldtr_access_rights::granularity::is_enabled();
+    auto ldtr_limit = ::intel_x64::vmcs::guest_ldtr_limit::get();
+    auto g = ::intel_x64::vmcs::guest_ldtr_access_rights::granularity::is_enabled();
 
     if ((ldtr_limit & 0x00000FFF) != 0x00000FFF && g) {
         throw std::logic_error("guest ldtr granularity must be 0 if any bit 11:0 is 0");
@@ -1734,11 +1734,11 @@ guest_ldtr_granularity()
 inline void
 guest_ldtr_access_rights_remaining_reserved_bit_0()
 {
-    if (guest_ldtr_access_rights::unusable::is_enabled()) {
+    if (::intel_x64::vmcs::guest_ldtr_access_rights::unusable::is_enabled()) {
         return;
     }
 
-    auto ldtr_access = vmcs::guest_ldtr_access_rights::get();
+    auto ldtr_access = ::intel_x64::vmcs::guest_ldtr_access_rights::get();
 
     if ((ldtr_access & 0xFFFE0000) != 0) {
         throw std::logic_error("guest ldtr access rights bits 31:17 must be 0 if ldtr is usable");
@@ -1748,7 +1748,7 @@ guest_ldtr_access_rights_remaining_reserved_bit_0()
 inline void
 guest_gdtr_base_must_be_canonical()
 {
-    if (!x64::is_address_canonical(vmcs::guest_gdtr_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_gdtr_base::get())) {
         throw std::logic_error("gdtr base is non-canonical");
     }
 }
@@ -1756,7 +1756,7 @@ guest_gdtr_base_must_be_canonical()
 inline void
 guest_idtr_base_must_be_canonical()
 {
-    if (!x64::is_address_canonical(vmcs::guest_idtr_base::get())) {
+    if (!x64::is_address_canonical(::intel_x64::vmcs::guest_idtr_base::get())) {
         throw std::logic_error("idtr base is non-canonical");
     }
 }
@@ -1764,7 +1764,7 @@ guest_idtr_base_must_be_canonical()
 inline void
 guest_gdtr_limit_reserved_bits()
 {
-    auto gdtr_limit = vmcs::guest_gdtr_limit::get();
+    auto gdtr_limit = ::intel_x64::vmcs::guest_gdtr_limit::get();
 
     if ((gdtr_limit & 0xFFFF0000) != 0) {
         throw std::logic_error("gdtr limit bits 31:16 must be 0");
@@ -1774,7 +1774,7 @@ guest_gdtr_limit_reserved_bits()
 inline void
 guest_idtr_limit_reserved_bits()
 {
-    auto idtr_limit = vmcs::guest_idtr_limit::get();
+    auto idtr_limit = ::intel_x64::vmcs::guest_idtr_limit::get();
 
     if ((idtr_limit & 0xFFFF0000) != 0) {
         throw std::logic_error("idtr limit bits 31:16 must be 0");
@@ -1784,13 +1784,13 @@ guest_idtr_limit_reserved_bits()
 inline void
 guest_rip_upper_bits()
 {
-    auto cs_l = guest_cs_access_rights::l::is_enabled();
+    auto cs_l = ::intel_x64::vmcs::guest_cs_access_rights::l::is_enabled();
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_enabled() && cs_l) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled() && cs_l) {
         return;
     }
 
-    if ((vmcs::guest_rip::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::guest_rip::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("rip bits 61:32 must 0 if IA 32e mode is disabled or cs L is disabled");
     }
 }
@@ -1798,9 +1798,9 @@ guest_rip_upper_bits()
 inline void
 guest_rip_valid_addr()
 {
-    auto cs_l = guest_cs_access_rights::l::is_enabled();
+    auto cs_l = ::intel_x64::vmcs::guest_cs_access_rights::l::is_enabled();
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_disabled()) {
         return;
     }
 
@@ -1808,7 +1808,7 @@ guest_rip_valid_addr()
         return;
     }
 
-    if (!x64::is_linear_address_valid(vmcs::guest_rip::get())) {
+    if (!x64::is_linear_address_valid(::intel_x64::vmcs::guest_rip::get())) {
         throw std::logic_error("rip bits must be canonical");
     }
 }
@@ -1816,11 +1816,11 @@ guest_rip_valid_addr()
 inline void
 guest_rflags_reserved_bits()
 {
-    if (guest_rflags::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_rflags::reserved::get() != 0) {
         throw std::logic_error("reserved bits in rflags must be 0");
     }
 
-    if (guest_rflags::always_enabled::get() == 0) {
+    if (::intel_x64::vmcs::guest_rflags::always_enabled::get() == 0) {
         throw std::logic_error("always enabled bits in rflags must be 1");
     }
 }
@@ -1828,12 +1828,12 @@ guest_rflags_reserved_bits()
 inline void
 guest_rflags_vm_bit()
 {
-    if (vm_entry_controls::ia_32e_mode_guest::is_disabled() &&
-        guest_cr0::protection_enable::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_disabled() &&
+        ::intel_x64::vmcs::guest_cr0::protection_enable::is_enabled()) {
         return;
     }
 
-    if (guest_rflags::virtual_8086_mode::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::virtual_8086_mode::is_enabled()) {
         throw std::logic_error("rflags VM must be 0 if ia 32e mode is 1 or PE is 0");
     }
 }
@@ -1841,7 +1841,7 @@ guest_rflags_vm_bit()
 inline void
 guest_rflag_interrupt_enable()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
@@ -1851,7 +1851,7 @@ guest_rflag_interrupt_enable()
         return;
     }
 
-    if (guest_rflags::interrupt_enable_flag::is_disabled()) {
+    if (::intel_x64::vmcs::guest_rflags::interrupt_enable_flag::is_disabled()) {
         throw std::logic_error("rflags IF must be 1 if the valid bit is 1 and interrupt type is external");
     }
 }
@@ -1859,7 +1859,7 @@ guest_rflag_interrupt_enable()
 inline void
 guest_valid_activity_state()
 {
-    if (vmcs::guest_activity_state::get() > 3) {
+    if (::intel_x64::vmcs::guest_activity_state::get() > 3) {
         throw std::logic_error("activity state must be 0 - 3");
     }
 }
@@ -1867,11 +1867,11 @@ guest_valid_activity_state()
 inline void
 guest_activity_state_not_hlt_when_dpl_not_0()
 {
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::hlt) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::hlt) {
         return;
     }
 
-    if (guest_ss_access_rights::dpl::get() != 0) {
+    if (::intel_x64::vmcs::guest_ss_access_rights::dpl::get() != 0) {
         throw std::logic_error("ss.dpl must be 0 if activity state is HLT");
     }
 }
@@ -1879,16 +1879,16 @@ guest_activity_state_not_hlt_when_dpl_not_0()
 inline void
 guest_must_be_active_if_injecting_blocking_state()
 {
-    if (vmcs::guest_activity_state::get() == vmcs::guest_activity_state::active) {
+    if (::intel_x64::vmcs::guest_activity_state::get() == ::intel_x64::vmcs::guest_activity_state::active) {
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
         throw std::logic_error("activity state must be active if "
                                "interruptibility state is sti");
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
         throw std::logic_error("activity state must be active if "
                                "interruptibility state is mov-ss");
     }
@@ -1897,13 +1897,13 @@ guest_must_be_active_if_injecting_blocking_state()
 inline void
 guest_hlt_valid_interrupts()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::hlt) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::hlt) {
         return;
     }
 
@@ -1916,18 +1916,18 @@ guest_hlt_valid_interrupts()
             return;
 
         case interruption_type::hardware_exception:
-            if (vector == x64::interrupt::debug_exception) {
+            if (vector == ::x64::interrupt::debug_exception) {
                 return;
             }
 
-            if (vector == x64::interrupt::machine_check) {
+            if (vector == ::x64::interrupt::machine_check) {
                 return;
             }
 
             break;
 
         case interruption_type::other_event:
-            if (vector == x64::interrupt::divide_error) {
+            if (vector == ::x64::interrupt::divide_error) {
                 return;
             }
 
@@ -1937,19 +1937,19 @@ guest_hlt_valid_interrupts()
             break;
     }
 
-    throw std::logic_error("invalid interruption combination for guest hlt");
+    throw std::logic_error("invalid interruption combination for ::intel_x64::vmcs::guest hlt");
 }
 
 inline void
 guest_shutdown_valid_interrupts()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::shutdown) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::shutdown) {
         return;
     }
 
@@ -1961,7 +1961,7 @@ guest_shutdown_valid_interrupts()
             return;
 
         case interruption_type::hardware_exception:
-            if (vector == x64::interrupt::machine_check) {
+            if (vector == ::x64::interrupt::machine_check) {
                 return;
             }
 
@@ -1971,17 +1971,17 @@ guest_shutdown_valid_interrupts()
             break;
     }
 
-    throw std::logic_error("invalid interruption combination for guest shutdown");
+    throw std::logic_error("invalid interruption combination for ::intel_x64::vmcs::guest shutdown");
 }
 
 inline void
 guest_sipi_valid_interrupts()
 {
-    if (vm_entry_interruption_information::valid_bit::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_interruption_information::valid_bit::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::wait_for_sipi) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::wait_for_sipi) {
         return;
     }
 
@@ -1991,11 +1991,11 @@ guest_sipi_valid_interrupts()
 inline void
 guest_valid_activity_state_and_smm()
 {
-    if (vm_entry_controls::entry_to_smm::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::entry_to_smm::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_activity_state::get() != vmcs::guest_activity_state::wait_for_sipi) {
+    if (::intel_x64::vmcs::guest_activity_state::get() != ::intel_x64::vmcs::guest_activity_state::wait_for_sipi) {
         return;
     }
 
@@ -2005,7 +2005,7 @@ guest_valid_activity_state_and_smm()
 inline void
 guest_interruptibility_state_reserved()
 {
-    if (vmcs::guest_interruptibility_state::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::reserved::get() != 0) {
         throw std::logic_error("interruptibility state reserved bits 31:5 must be 0");
     }
 }
@@ -2013,8 +2013,8 @@ guest_interruptibility_state_reserved()
 inline void
 guest_interruptibility_state_sti_mov_ss()
 {
-    auto sti = vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled();
-    auto mov_ss = vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled();
+    auto sti = ::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled();
+    auto mov_ss = ::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled();
 
     if (sti && mov_ss) {
         throw std::logic_error("interruptibility state sti and mov ss cannot both be 1");
@@ -2025,11 +2025,11 @@ guest_interruptibility_state_sti_mov_ss()
 inline void
 guest_interruptibility_state_sti()
 {
-    if (guest_rflags::interrupt_enable_flag::is_enabled()) {
+    if (::intel_x64::vmcs::guest_rflags::interrupt_enable_flag::is_enabled()) {
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
         throw std::logic_error("interruptibility state sti must be 0 if rflags interrupt enabled is 0");
     }
 }
@@ -2037,7 +2037,7 @@ guest_interruptibility_state_sti()
 inline void
 guest_interruptibility_state_external_interrupt()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
@@ -2047,12 +2047,12 @@ guest_interruptibility_state_external_interrupt()
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
         throw std::logic_error("interruptibility state sti must be 0 if "
                                "interrupt type is external and valid");
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
         throw std::logic_error("interruptibility state mov_ss must be 0 if "
                                "interrupt type is external and valid");
     }
@@ -2061,7 +2061,7 @@ guest_interruptibility_state_external_interrupt()
 inline void
 guest_interruptibility_state_nmi()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
@@ -2071,7 +2071,7 @@ guest_interruptibility_state_nmi()
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
         throw std::logic_error("valid interrupt type must not be nmi if "
                                "interruptibility state is mov-ss");
     }
@@ -2085,11 +2085,11 @@ guest_interruptibility_not_in_smm()
 inline void
 guest_interruptibility_entry_to_smm()
 {
-    if (vm_entry_controls::entry_to_smm::is_disabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::entry_to_smm::is_disabled()) {
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_smi::is_disabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_smi::is_disabled()) {
         throw std::logic_error("interruptibility state smi must be enabled "
                                "if entry to smm is enabled");
     }
@@ -2098,7 +2098,7 @@ guest_interruptibility_entry_to_smm()
 inline void
 guest_interruptibility_state_sti_and_nmi()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
     if (valid_bit::is_disabled()) {
         return;
@@ -2108,7 +2108,7 @@ guest_interruptibility_state_sti_and_nmi()
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled()) {
         throw std::logic_error("some processors require sti to be 0 if "
                                "the interruption type is nmi");
     }
@@ -2117,9 +2117,9 @@ guest_interruptibility_state_sti_and_nmi()
 inline void
 guest_interruptibility_state_virtual_nmi()
 {
-    using namespace vm_entry_interruption_information;
+    using namespace ::intel_x64::vmcs::vm_entry_interruption_information;
 
-    if (pin_based_vm_execution_controls::virtual_nmis::is_disabled()) {
+    if (::intel_x64::vmcs::pin_based_vm_execution_controls::virtual_nmis::is_disabled()) {
         return;
     }
 
@@ -2131,7 +2131,7 @@ guest_interruptibility_state_virtual_nmi()
         return;
     }
 
-    if (vmcs::guest_interruptibility_state::blocking_by_nmi::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_nmi::is_enabled()) {
         throw std::logic_error("if virtual nmi is enabled, and the interruption "
                                "type is NMI, blocking by nmi must be disabled");
     }
@@ -2140,16 +2140,16 @@ guest_interruptibility_state_virtual_nmi()
 inline void
 guest_interruptibility_state_enclave_interrupt()
 {
-    if (guest_interruptibility_state::enclave_interruption::is_disabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::enclave_interruption::is_disabled()) {
         return;
     }
 
-    if (guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
         throw std::logic_error("blocking by mov ss is enabled but enclave interrupt is "
                                "also enabled in interruptibility state");
     }
 
-    if (intel_x64::cpuid::extended_feature_flags::subleaf0::ebx::sgx::is_disabled()) {
+    if (::intel_x64::cpuid::extended_feature_flags::subleaf0::ebx::sgx::is_disabled()) {
         throw std::logic_error("enclave interrupt is 1 in interruptibility state "
                                "but the processor does not support sgx");
     }
@@ -2158,7 +2158,7 @@ guest_interruptibility_state_enclave_interrupt()
 inline void
 guest_pending_debug_exceptions_reserved()
 {
-    if (vmcs::guest_pending_debug_exceptions::reserved::get() != 0) {
+    if (::intel_x64::vmcs::guest_pending_debug_exceptions::reserved::get() != 0) {
         throw std::logic_error("pending debug exception reserved bits must be 0");
     }
 }
@@ -2166,17 +2166,17 @@ guest_pending_debug_exceptions_reserved()
 inline void
 guest_pending_debug_exceptions_dbg_ctl()
 {
-    auto sti = vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled();
-    auto mov_ss = vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled();
-    auto activity_state = vmcs::guest_activity_state::get();
+    auto sti = ::intel_x64::vmcs::guest_interruptibility_state::blocking_by_sti::is_enabled();
+    auto mov_ss = ::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled();
+    auto activity_state = ::intel_x64::vmcs::guest_activity_state::get();
 
-    if (!sti && !mov_ss && activity_state != vmcs::guest_activity_state::hlt) {
+    if (!sti && !mov_ss && activity_state != ::intel_x64::vmcs::guest_activity_state::hlt) {
         return;
     }
 
-    auto bs = vmcs::guest_pending_debug_exceptions::bs::is_enabled();
-    auto tf = vmcs::guest_rflags::trap_flag::is_enabled();
-    auto btf = vmcs::guest_ia32_debugctl::btf::is_enabled();
+    auto bs = ::intel_x64::vmcs::guest_pending_debug_exceptions::bs::is_enabled();
+    auto tf = ::intel_x64::vmcs::guest_rflags::trap_flag::is_enabled();
+    auto btf = ::intel_x64::vmcs::guest_ia32_debugctl::btf::is_enabled();
 
     if (!bs && tf && !btf) {
         throw std::logic_error("pending debug exception bs must be 1 if "
@@ -2192,25 +2192,25 @@ guest_pending_debug_exceptions_dbg_ctl()
 inline void
 guest_pending_debug_exceptions_rtm()
 {
-    if (guest_pending_debug_exceptions::rtm::is_disabled()) {
+    if (::intel_x64::vmcs::guest_pending_debug_exceptions::rtm::is_disabled()) {
         return;
     }
 
-    if ((guest_pending_debug_exceptions::get() & 0xFFFFFFFFFFFEAFFF) != 0) {
+    if ((::intel_x64::vmcs::guest_pending_debug_exceptions::get() & 0xFFFFFFFFFFFEAFFF) != 0) {
         throw std::logic_error("pending debug exception reserved bits and bits 3:0 "
                                "must be 0 if rtm is 1");
     }
 
-    if (guest_pending_debug_exceptions::enabled_breakpoint::is_disabled()) {
+    if (::intel_x64::vmcs::guest_pending_debug_exceptions::enabled_breakpoint::is_disabled()) {
         throw std::logic_error("pending debug exception bit 12 must be 1 if rtm is 1");
     }
 
-    if (intel_x64::cpuid::extended_feature_flags::subleaf0::ebx::rtm::is_disabled()) {
+    if (::intel_x64::cpuid::extended_feature_flags::subleaf0::ebx::rtm::is_disabled()) {
         throw std::logic_error("rtm is set in pending debug exception but "
                                "rtm is unsupported by the processor");
     }
 
-    if (guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
+    if (::intel_x64::vmcs::guest_interruptibility_state::blocking_by_mov_ss::is_enabled()) {
         throw std::logic_error("interruptibility-state field indicates blocking by mov ss"
                                " but rtm is set in pending debug exceptions field");
     }
@@ -2219,7 +2219,7 @@ guest_pending_debug_exceptions_rtm()
 inline void
 guest_vmcs_link_pointer_bits_11_0()
 {
-    auto vmcs_link_pointer = vmcs::vmcs_link_pointer::get();
+    auto vmcs_link_pointer = ::intel_x64::vmcs::vmcs_link_pointer::get();
 
     if (vmcs_link_pointer == 0xFFFFFFFFFFFFFFFF) {
         return;
@@ -2233,7 +2233,7 @@ guest_vmcs_link_pointer_bits_11_0()
 inline void
 guest_vmcs_link_pointer_valid_addr()
 {
-    auto vmcs_link_pointer = vmcs::vmcs_link_pointer::get();
+    auto vmcs_link_pointer = ::intel_x64::vmcs::vmcs_link_pointer::get();
 
     if (vmcs_link_pointer == 0xFFFFFFFFFFFFFFFF) {
         return;
@@ -2247,7 +2247,7 @@ guest_vmcs_link_pointer_valid_addr()
 inline void
 guest_vmcs_link_pointer_first_word()
 {
-    auto vmcs_link_pointer = vmcs::vmcs_link_pointer::get();
+    auto vmcs_link_pointer = ::intel_x64::vmcs::vmcs_link_pointer::get();
 
     if (vmcs_link_pointer == 0xFFFFFFFFFFFFFFFF) {
         return;
@@ -2262,15 +2262,15 @@ guest_vmcs_link_pointer_first_word()
     auto revision_id = *static_cast<uint32_t *>(vmcs) & 0x7FFFFFFF;
     auto vmcs_shadow = *static_cast<uint32_t *>(vmcs) & 0x80000000;
 
-    if (revision_id != msrs::ia32_vmx_basic::revision_id::get()) {
+    if (revision_id != ::intel_x64::msrs::ia32_vmx_basic::revision_id::get()) {
         throw std::logic_error("shadow vmcs must contain CPU's revision id");
     }
 
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::vmcs_shadowing::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::vmcs_shadowing::is_disabled_if_exists()) {
         return;
     }
 
@@ -2292,42 +2292,42 @@ guest_vmcs_link_pointer_in_smm()
 inline void
 guest_valid_pdpte_with_ept_disabled()
 {
-    if (guest_cr0::paging::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr0::paging::is_disabled()) {
         return;
     }
 
-    if (guest_cr4::physical_address_extensions::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr4::physical_address_extensions::is_disabled()) {
         return;
     }
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_enabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_enabled_if_exists()) {
         return;
     }
 
-    auto cr3 = vmcs::guest_cr3::get();
+    auto cr3 = ::intel_x64::vmcs::guest_cr3::get();
     auto virt_pdpt = static_cast<uint64_t *>(g_mm->physint_to_virtptr(cr3 & 0xFFFFFFE0ULL));
 
     if (virt_pdpt == nullptr) {
         throw std::logic_error("pdpt address is null");
     }
 
-    if ((virt_pdpt[0] & x64::pdpte::reserved::mask()) != 0U) {
+    if ((virt_pdpt[0] & ::x64::pdpte::reserved::mask()) != 0U) {
         throw std::logic_error("pdpte0 reserved bits set with ept disabled and pae paging enabled");
     }
 
-    if ((virt_pdpt[1] & x64::pdpte::reserved::mask()) != 0U) {
+    if ((virt_pdpt[1] & ::x64::pdpte::reserved::mask()) != 0U) {
         throw std::logic_error("pdpte1 reserved bits set with ept disabled and pae paging enabled");
     }
 
-    if ((virt_pdpt[2] & x64::pdpte::reserved::mask()) != 0U) {
+    if ((virt_pdpt[2] & ::x64::pdpte::reserved::mask()) != 0U) {
         throw std::logic_error("pdpte2 reserved bits set with ept disabled and pae paging enabled");
     }
 
-    if ((virt_pdpt[3] & x64::pdpte::reserved::mask()) != 0U) {
+    if ((virt_pdpt[3] & ::x64::pdpte::reserved::mask()) != 0U) {
         throw std::logic_error("pdpte3 reserved bits set with ept disabled and pae paging enabled");
     }
 }
@@ -2335,39 +2335,39 @@ guest_valid_pdpte_with_ept_disabled()
 inline void
 guest_valid_pdpte_with_ept_enabled()
 {
-    if (guest_cr0::paging::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr0::paging::is_disabled()) {
         return;
     }
 
-    if (guest_cr4::physical_address_extensions::is_disabled()) {
+    if (::intel_x64::vmcs::guest_cr4::physical_address_extensions::is_disabled()) {
         return;
     }
 
-    if (vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
         return;
     }
 
-    if (primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
+    if (::intel_x64::vmcs::primary_processor_based_vm_execution_controls::activate_secondary_controls::is_disabled()) {
         return;
     }
 
-    if (secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
+    if (::intel_x64::vmcs::secondary_processor_based_vm_execution_controls::enable_ept::is_disabled_if_exists()) {
         return;
     }
 
-    if (vmcs::guest_pdpte0::reserved::get() != 0U) {
+    if (::intel_x64::vmcs::guest_pdpte0::reserved::get() != 0U) {
         throw std::logic_error("pdpte0 reserved bits set with ept and pae paging enabled");
     }
 
-    if (vmcs::guest_pdpte1::reserved::get() != 0U) {
+    if (::intel_x64::vmcs::guest_pdpte1::reserved::get() != 0U) {
         throw std::logic_error("pdpte1 reserved bits set with ept and pae paging enabled");
     }
 
-    if (vmcs::guest_pdpte2::reserved::get() != 0U) {
+    if (::intel_x64::vmcs::guest_pdpte2::reserved::get() != 0U) {
         throw std::logic_error("pdpte2 reserved bits set with ept and pae paging enabled");
     }
 
-    if (vmcs::guest_pdpte3::reserved::get() != 0U) {
+    if (::intel_x64::vmcs::guest_pdpte3::reserved::get() != 0U) {
         throw std::logic_error("ppdpte3 reserved bits set with ept and pae paging enabled");
     }
 }

--- a/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_host_fields.h
+++ b/bfvmm/include/hve/arch/intel_x64/check/check_vmcs_host_fields.h
@@ -30,9 +30,9 @@
 /// section 26.2.2, Vol. 3 of the SDM.
 ///
 
-namespace intel_x64
+namespace bfvmm
 {
-namespace vmcs
+namespace intel_x64
 {
 namespace check
 {
@@ -40,9 +40,9 @@ namespace check
 inline void
 host_cr0_for_unsupported_bits()
 {
-    auto cr0 = vmcs::host_cr0::get();
-    auto ia32_vmx_cr0_fixed0 = msrs::ia32_vmx_cr0_fixed0::get();
-    auto ia32_vmx_cr0_fixed1 = msrs::ia32_vmx_cr0_fixed1::get();
+    auto cr0 = ::intel_x64::vmcs::host_cr0::get();
+    auto ia32_vmx_cr0_fixed0 = ::intel_x64::msrs::ia32_vmx_cr0_fixed0::get();
+    auto ia32_vmx_cr0_fixed1 = ::intel_x64::msrs::ia32_vmx_cr0_fixed1::get();
 
     if (0 != ((~cr0 & ia32_vmx_cr0_fixed0) | (cr0 & ~ia32_vmx_cr0_fixed1))) {
         bfdebug_transaction(0, [&](std::string * msg) {
@@ -59,9 +59,9 @@ host_cr0_for_unsupported_bits()
 inline void
 host_cr4_for_unsupported_bits()
 {
-    auto cr4 = vmcs::host_cr4::get();
-    auto ia32_vmx_cr4_fixed0 = msrs::ia32_vmx_cr4_fixed0::get();
-    auto ia32_vmx_cr4_fixed1 = msrs::ia32_vmx_cr4_fixed1::get();
+    auto cr4 = ::intel_x64::vmcs::host_cr4::get();
+    auto ia32_vmx_cr4_fixed0 = ::intel_x64::msrs::ia32_vmx_cr4_fixed0::get();
+    auto ia32_vmx_cr4_fixed1 = ::intel_x64::msrs::ia32_vmx_cr4_fixed1::get();
 
     if (0 != ((~cr4 & ia32_vmx_cr4_fixed0) | (cr4 & ~ia32_vmx_cr4_fixed1))) {
         bfdebug_transaction(0, [&](std::string * msg) {
@@ -78,7 +78,7 @@ host_cr4_for_unsupported_bits()
 inline void
 host_cr3_for_unsupported_bits()
 {
-    if (!x64::is_physical_address_valid(vmcs::host_cr3::get())) {
+    if (!::x64::is_physical_address_valid(::intel_x64::vmcs::host_cr3::get())) {
         throw std::logic_error("host cr3 too large");
     }
 }
@@ -86,7 +86,7 @@ host_cr3_for_unsupported_bits()
 inline void
 host_ia32_sysenter_esp_canonical_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_ia32_sysenter_esp::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_ia32_sysenter_esp::get())) {
         throw std::logic_error("host sysenter esp must be canonical");
     }
 }
@@ -94,7 +94,7 @@ host_ia32_sysenter_esp_canonical_address()
 inline void
 host_ia32_sysenter_eip_canonical_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_ia32_sysenter_eip::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_ia32_sysenter_eip::get())) {
         throw std::logic_error("host sysenter eip must be canonical");
     }
 }
@@ -102,11 +102,11 @@ host_ia32_sysenter_eip_canonical_address()
 inline void
 host_verify_load_ia32_perf_global_ctrl()
 {
-    if (vmcs::vm_exit_controls::load_ia32_perf_global_ctrl::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::load_ia32_perf_global_ctrl::is_disabled()) {
         return;
     }
 
-    if (vmcs::host_ia32_perf_global_ctrl::reserved::get() != 0) {
+    if (::intel_x64::vmcs::host_ia32_perf_global_ctrl::reserved::get() != 0) {
         throw std::logic_error("host perf global ctrl msr reserved bits must be 0");
     }
 }
@@ -114,39 +114,39 @@ host_verify_load_ia32_perf_global_ctrl()
 inline void
 host_verify_load_ia32_pat()
 {
-    if (vmcs::vm_exit_controls::load_ia32_pat::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::load_ia32_pat::is_disabled()) {
         return;
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa0::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa0::memory_type::get())) {
         throw std::logic_error("pat0 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa1::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa1::memory_type::get())) {
         throw std::logic_error("pat1 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa2::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa2::memory_type::get())) {
         throw std::logic_error("pat2 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa3::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa3::memory_type::get())) {
         throw std::logic_error("pat3 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa4::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa4::memory_type::get())) {
         throw std::logic_error("pat4 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa5::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa5::memory_type::get())) {
         throw std::logic_error("pat5 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa6::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa6::memory_type::get())) {
         throw std::logic_error("pat6 has a reserved memory type");
     }
 
-    if (memory_type_reserved(host_ia32_pat::pa7::memory_type::get())) {
+    if (::intel_x64::vmcs::memory_type_reserved(::intel_x64::vmcs::host_ia32_pat::pa7::memory_type::get())) {
         throw std::logic_error("pat7 has a reserved memory type");
     }
 }
@@ -154,27 +154,27 @@ host_verify_load_ia32_pat()
 inline void
 host_verify_load_ia32_efer()
 {
-    if (vmcs::vm_exit_controls::load_ia32_efer::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::load_ia32_efer::is_disabled()) {
         return;
     }
 
-    if (vmcs::host_ia32_efer::reserved::get() != 0) {
+    if (::intel_x64::vmcs::host_ia32_efer::reserved::get() != 0) {
         throw std::logic_error("host_ia32_efer reserved bits must be 0 if "
                                "load_ia32_efer exit control is enabled");
     }
 
-    auto lma = vmcs::host_ia32_efer::lma::is_enabled();
-    auto lme = vmcs::host_ia32_efer::lme::is_enabled();
+    auto lma = ::intel_x64::vmcs::host_ia32_efer::lma::is_enabled();
+    auto lme = ::intel_x64::vmcs::host_ia32_efer::lme::is_enabled();
 
-    if (vmcs::vm_exit_controls::host_address_space_size::is_disabled() && lma) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_disabled() && lma) {
         throw std::logic_error("host addr space is 0, but efer.lma is 1");
     }
 
-    if (vmcs::vm_exit_controls::host_address_space_size::is_enabled() && !lma) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_enabled() && !lma) {
         throw std::logic_error("host addr space is 1, but efer.lma is 0");
     }
 
-    if (vmcs::host_cr0::paging::is_disabled()) {
+    if (::intel_x64::vmcs::host_cr0::paging::is_disabled()) {
         return;
     }
 
@@ -190,11 +190,11 @@ host_verify_load_ia32_efer()
 inline void
 host_es_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_es_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_es_selector::ti::is_enabled()) {
         throw std::logic_error("host es ti flag must be 0");
     }
 
-    if (vmcs::host_es_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_es_selector::rpl::get() != 0) {
         throw std::logic_error("host es rpl flag must be 0");
     }
 }
@@ -202,11 +202,11 @@ host_es_selector_rpl_ti_equal_zero()
 inline void
 host_cs_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_cs_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_cs_selector::ti::is_enabled()) {
         throw std::logic_error("host cs ti flag must be 0");
     }
 
-    if (vmcs::host_cs_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_cs_selector::rpl::get() != 0) {
         throw std::logic_error("host cs rpl flag must be 0");
     }
 }
@@ -214,11 +214,11 @@ host_cs_selector_rpl_ti_equal_zero()
 inline void
 host_ss_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_ss_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_ss_selector::ti::is_enabled()) {
         throw std::logic_error("host ss ti flag must be 0");
     }
 
-    if (vmcs::host_ss_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_ss_selector::rpl::get() != 0) {
         throw std::logic_error("host ss rpl flag must be 0");
     }
 }
@@ -226,11 +226,11 @@ host_ss_selector_rpl_ti_equal_zero()
 inline void
 host_ds_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_ds_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_ds_selector::ti::is_enabled()) {
         throw std::logic_error("host ds ti flag must be 0");
     }
 
-    if (vmcs::host_ds_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_ds_selector::rpl::get() != 0) {
         throw std::logic_error("host ds rpl flag must be 0");
     }
 }
@@ -238,11 +238,11 @@ host_ds_selector_rpl_ti_equal_zero()
 inline void
 host_fs_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_fs_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_fs_selector::ti::is_enabled()) {
         throw std::logic_error("host fs ti flag must be 0");
     }
 
-    if (vmcs::host_fs_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_fs_selector::rpl::get() != 0) {
         throw std::logic_error("host fs rpl flag must be 0");
     }
 }
@@ -250,11 +250,11 @@ host_fs_selector_rpl_ti_equal_zero()
 inline void
 host_gs_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_gs_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_gs_selector::ti::is_enabled()) {
         throw std::logic_error("host gs ti flag must be 0");
     }
 
-    if (vmcs::host_gs_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_gs_selector::rpl::get() != 0) {
         throw std::logic_error("host gs rpl flag must be 0");
     }
 }
@@ -262,11 +262,11 @@ host_gs_selector_rpl_ti_equal_zero()
 inline void
 host_tr_selector_rpl_ti_equal_zero()
 {
-    if (vmcs::host_tr_selector::ti::is_enabled()) {
+    if (::intel_x64::vmcs::host_tr_selector::ti::is_enabled()) {
         throw std::logic_error("host tr ti flag must be 0");
     }
 
-    if (vmcs::host_tr_selector::rpl::get() != 0) {
+    if (::intel_x64::vmcs::host_tr_selector::rpl::get() != 0) {
         throw std::logic_error("host tr rpl flag must be 0");
     }
 }
@@ -274,7 +274,7 @@ host_tr_selector_rpl_ti_equal_zero()
 inline void
 host_cs_not_equal_zero()
 {
-    if (vmcs::host_cs_selector::get() == 0) {
+    if (::intel_x64::vmcs::host_cs_selector::get() == 0) {
         throw std::logic_error("host cs cannot equal 0");
     }
 }
@@ -282,7 +282,7 @@ host_cs_not_equal_zero()
 inline void
 host_tr_not_equal_zero()
 {
-    if (vmcs::host_tr_selector::get() == 0) {
+    if (::intel_x64::vmcs::host_tr_selector::get() == 0) {
         throw std::logic_error("host tr cannot equal 0");
     }
 }
@@ -290,11 +290,11 @@ host_tr_not_equal_zero()
 inline void
 host_ss_not_equal_zero()
 {
-    if (vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
         return;
     }
 
-    if (vmcs::host_ss_selector::get() == 0) {
+    if (::intel_x64::vmcs::host_ss_selector::get() == 0) {
         throw std::logic_error("host ss cannot equal 0");
     }
 }
@@ -302,7 +302,7 @@ host_ss_not_equal_zero()
 inline void
 host_fs_canonical_base_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_fs_base::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_fs_base::get())) {
         throw std::logic_error("host fs base must be canonical");
     }
 }
@@ -310,7 +310,7 @@ host_fs_canonical_base_address()
 inline void
 host_gs_canonical_base_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_gs_base::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_gs_base::get())) {
         throw std::logic_error("host gs base must be canonical");
     }
 }
@@ -318,7 +318,7 @@ host_gs_canonical_base_address()
 inline void
 host_gdtr_canonical_base_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_gdtr_base::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_gdtr_base::get())) {
         throw std::logic_error("host gdtr base must be canonical");
     }
 }
@@ -326,7 +326,7 @@ host_gdtr_canonical_base_address()
 inline void
 host_idtr_canonical_base_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_idtr_base::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_idtr_base::get())) {
         throw std::logic_error("host idtr base must be canonical");
     }
 }
@@ -334,7 +334,7 @@ host_idtr_canonical_base_address()
 inline void
 host_tr_canonical_base_address()
 {
-    if (!x64::is_address_canonical(vmcs::host_tr_base::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_tr_base::get())) {
         throw std::logic_error("host tr base must be canonical");
     }
 }
@@ -342,15 +342,15 @@ host_tr_canonical_base_address()
 inline void
 host_if_outside_ia32e_mode()
 {
-    if (msrs::ia32_efer::lma::is_enabled()) {
+    if (::intel_x64::msrs::ia32_efer::lma::is_enabled()) {
         return;
     }
 
-    if (vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
         throw std::logic_error("ia 32e mode must be 0 if efer.lma == 0");
     }
 
-    if (vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
         throw std::logic_error("host addr space must be 0 if efer.lma == 0");
     }
 }
@@ -358,11 +358,11 @@ host_if_outside_ia32e_mode()
 inline void
 host_address_space_size_exit_ctl_is_set()
 {
-    if (!msrs::ia32_efer::lma::is_enabled()) {
+    if (!::intel_x64::msrs::ia32_efer::lma::is_enabled()) {
         return;
     }
 
-    if (vmcs::vm_exit_controls::host_address_space_size::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_disabled()) {
         throw std::logic_error("host addr space must be 1 if efer.lma == 1");
     }
 }
@@ -370,19 +370,19 @@ host_address_space_size_exit_ctl_is_set()
 inline void
 host_address_space_disabled()
 {
-    if (vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_enabled()) {
         return;
     }
 
-    if (vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
+    if (::intel_x64::vmcs::vm_entry_controls::ia_32e_mode_guest::is_enabled()) {
         throw std::logic_error("ia 32e mode must be disabled if host addr space is disabled");
     }
 
-    if (vmcs::host_cr4::pcid_enable_bit::is_enabled()) {
+    if (::intel_x64::vmcs::host_cr4::pcid_enable_bit::is_enabled()) {
         throw std::logic_error("cr4 pcide must be disabled if host addr space is disabled");
     }
 
-    if ((vmcs::host_rip::get() & 0xFFFFFFFF00000000) != 0) {
+    if ((::intel_x64::vmcs::host_rip::get() & 0xFFFFFFFF00000000) != 0) {
         throw std::logic_error("rip bits 63:32 must be 0 if host addr space is disabled");
     }
 }
@@ -390,15 +390,15 @@ host_address_space_disabled()
 inline void
 host_address_space_enabled()
 {
-    if (vmcs::vm_exit_controls::host_address_space_size::is_disabled()) {
+    if (::intel_x64::vmcs::vm_exit_controls::host_address_space_size::is_disabled()) {
         return;
     }
 
-    if (vmcs::host_cr4::physical_address_extensions::is_disabled()) {
+    if (::intel_x64::vmcs::host_cr4::physical_address_extensions::is_disabled()) {
         throw std::logic_error("cr4 pae must be enabled if host addr space is enabled");
     }
 
-    if (!x64::is_address_canonical(vmcs::host_rip::get())) {
+    if (!::x64::is_address_canonical(::intel_x64::vmcs::host_rip::get())) {
         throw std::logic_error("host rip must be canonical");
     }
 }

--- a/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -22,7 +22,7 @@
 #include <bfexception.h>
 #include <bferrorcodes.h>
 
-#include <hve/arch/intel_x64/vmcs/vmcs_check.h>
+#include <hve/arch/intel_x64/check/check.h>
 #include <hve/arch/intel_x64/exit_handler/exit_handler.h>
 #include <hve/arch/intel_x64/exit_handler/exit_handler_entry.h>
 #include <hve/arch/intel_x64/exit_handler/exit_handler_support.h>
@@ -372,7 +372,7 @@ exit_handler_intel_x64::unimplemented_handler() noexcept
     if (vmcs::exit_reason::vm_entry_failure::is_enabled()) {
 
         guard_exceptions([&] {
-            vmcs::check::all();
+            bfvmm::intel_x64::check::all();
         });
 
         guard_exceptions([&] {

--- a/bfvmm/src/hve/arch/intel_x64/vmcs/vmcs.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmcs/vmcs.cpp
@@ -27,7 +27,8 @@
 #include <hve/arch/intel_x64/vmcs/vmcs_launch.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_resume.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_promote.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_check.h>
+
+#include <hve/arch/intel_x64/check/check.h>
 
 #include <intrinsics.h>
 
@@ -96,7 +97,7 @@ vmcs_intel_x64::launch(host_state_t host_state, guest_state_t guest_state)
     });
 
     auto ___ = gsl::on_failure([&] {
-        vmcs::check::all();
+        bfvmm::intel_x64::check::all();
     });
 
     if (guest_state->is_guest()) {

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -34,6 +34,21 @@ do_test(test_idt
     ${ARGN}
 )
 
+do_test(test_check_vmcs_controls_fields
+    SOURCES arch/intel_x64/check/test_check_vmcs_controls_fields.cpp
+    ${ARGN}
+)
+
+do_test(test_check_vmcs_guest_fields
+    SOURCES arch/intel_x64/check/test_check_vmcs_guest_fields.cpp
+    ${ARGN}
+)
+
+do_test(test_check_vmcs_host_fields
+    SOURCES arch/intel_x64/check/test_check_vmcs_host_fields.cpp
+    ${ARGN}
+)
+
 do_test(test_exit_handler
     SOURCES arch/intel_x64/exit_handler/test_exit_handler.cpp
     ${ARGN}
@@ -41,21 +56,6 @@ do_test(test_exit_handler
 
 do_test(test_exit_handler_entry
     SOURCES arch/intel_x64/exit_handler/test_exit_handler_entry.cpp
-    ${ARGN}
-)
-
-do_test(test_vmcs_check_controls
-    SOURCES arch/intel_x64/vmcs/test_vmcs_check_controls.cpp
-    ${ARGN}
-)
-
-do_test(test_vmcs_check_guest
-    SOURCES arch/intel_x64/vmcs/test_vmcs_check_guest.cpp
-    ${ARGN}
-)
-
-do_test(test_vmcs_check_host
-    SOURCES arch/intel_x64/vmcs/test_vmcs_check_host.cpp
     ${ARGN}
 )
 

--- a/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_controls_fields.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_controls_fields.cpp
@@ -1237,7 +1237,7 @@ TEST_CASE("check_control_vmx_controls_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vmx_controls_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::vmx_controls_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::vmx_controls_all);
 }
 
 TEST_CASE("check_control_vm_execution_control_fields_all")
@@ -1245,7 +1245,7 @@ TEST_CASE("check_control_vm_execution_control_fields_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vm_execution_control_fields_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vm_execution_control_fields_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vm_execution_control_fields_all);
 }
 
 TEST_CASE("check_control_vm_exit_control_fields_all")
@@ -1253,7 +1253,7 @@ TEST_CASE("check_control_vm_exit_control_fields_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vm_exit_control_fields_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vm_exit_control_fields_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vm_exit_control_fields_all);
 }
 
 TEST_CASE("check_control_vm_entry_control_fields_all")
@@ -1261,7 +1261,7 @@ TEST_CASE("check_control_vm_entry_control_fields_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vm_entry_control_fields_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vm_entry_control_fields_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vm_entry_control_fields_all);
 }
 
 TEST_CASE("check_control_pin_based_ctls_reserved_properly_set")
@@ -1269,7 +1269,7 @@ TEST_CASE("check_control_pin_based_ctls_reserved_properly_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_pin_based_ctls_reserved_properly_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_pin_based_ctls_reserved_properly_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_pin_based_ctls_reserved_properly_set);
 }
 
 TEST_CASE("check_control_proc_based_ctls_reserved_properly_set")
@@ -1277,7 +1277,7 @@ TEST_CASE("check_control_proc_based_ctls_reserved_properly_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_proc_based_ctls_reserved_properly_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_proc_based_ctls_reserved_properly_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_proc_based_ctls_reserved_properly_set);
 }
 
 TEST_CASE("check_control_proc_based_ctls2_reserved_properly_set")
@@ -1285,7 +1285,7 @@ TEST_CASE("check_control_proc_based_ctls2_reserved_properly_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_proc_based_ctls2_reserved_properly_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_proc_based_ctls2_reserved_properly_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_proc_based_ctls2_reserved_properly_set);
 }
 
 TEST_CASE("check_control_cr3_count_less_than_4")
@@ -1293,7 +1293,7 @@ TEST_CASE("check_control_cr3_count_less_than_4")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_cr3_count_less_than_4_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_cr3_count_less_then_4);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_cr3_count_less_then_4);
 }
 
 TEST_CASE("check_control_io_bitmap_address_bits")
@@ -1301,7 +1301,7 @@ TEST_CASE("check_control_io_bitmap_address_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_io_bitmap_address_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_io_bitmap_address_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_io_bitmap_address_bits);
 }
 
 TEST_CASE("check_control_msr_bitmap_address_bits")
@@ -1309,7 +1309,7 @@ TEST_CASE("check_control_msr_bitmap_address_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_msr_bitmap_address_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_msr_bitmap_address_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_msr_bitmap_address_bits);
 }
 
 TEST_CASE("check_control_tpr_shadow_and_virtual_apic")
@@ -1317,7 +1317,7 @@ TEST_CASE("check_control_tpr_shadow_and_virtual_apic")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_tpr_shadow_and_virtual_apic_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_tpr_shadow_and_virtual_apic);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_tpr_shadow_and_virtual_apic);
 }
 
 TEST_CASE("check_control_nmi_exiting_and_virtual_nmi")
@@ -1325,7 +1325,7 @@ TEST_CASE("check_control_nmi_exiting_and_virtual_nmi")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_nmi_exiting_and_virtual_nmi_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_nmi_exiting_and_virtual_nmi);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_nmi_exiting_and_virtual_nmi);
 }
 
 TEST_CASE("check_control_virtual_nmi_and_nmi_window")
@@ -1333,7 +1333,7 @@ TEST_CASE("check_control_virtual_nmi_and_nmi_window")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_virtual_nmi_and_nmi_window_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_virtual_nmi_and_nmi_window);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_virtual_nmi_and_nmi_window);
 }
 
 TEST_CASE("check_control_virtual_apic_address_bits")
@@ -1341,7 +1341,7 @@ TEST_CASE("check_control_virtual_apic_address_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_virtual_apic_address_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_virtual_apic_address_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_virtual_apic_address_bits);
 }
 
 TEST_CASE("check_control_x2apic_mode_and_virtual_apic_access")
@@ -1349,7 +1349,7 @@ TEST_CASE("check_control_x2apic_mode_and_virtual_apic_access")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_x2apic_mode_and_virtual_apic_access_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_x2apic_mode_and_virtual_apic_access);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_x2apic_mode_and_virtual_apic_access);
 }
 
 TEST_CASE("check_control_virtual_interrupt_and_external_interrupt")
@@ -1357,7 +1357,7 @@ TEST_CASE("check_control_virtual_interrupt_and_external_interrupt")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_virtual_interrupt_and_external_interrupt_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_virtual_interrupt_and_external_interrupt);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_virtual_interrupt_and_external_interrupt);
 }
 
 TEST_CASE("check_control_process_posted_interrupt_checks")
@@ -1365,7 +1365,7 @@ TEST_CASE("check_control_process_posted_interrupt_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_process_posted_interrupt_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_process_posted_interrupt_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_process_posted_interrupt_checks);
 }
 
 TEST_CASE("check_control_vpid_checks")
@@ -1373,7 +1373,7 @@ TEST_CASE("check_control_vpid_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vpid_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vpid_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vpid_checks);
 }
 
 TEST_CASE("check_control_enable_ept_checks")
@@ -1381,7 +1381,7 @@ TEST_CASE("check_control_enable_ept_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_enable_ept_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_enable_ept_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_enable_ept_checks);
 }
 
 TEST_CASE("check_control_enable_pml_checks")
@@ -1389,7 +1389,7 @@ TEST_CASE("check_control_enable_pml_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_enable_pml_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_enable_pml_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_enable_pml_checks);
 }
 
 TEST_CASE("check_control_unrestricted_guests")
@@ -1397,7 +1397,7 @@ TEST_CASE("check_control_unrestricted_guests")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_unrestricted_guests_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_unrestricted_guests);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_unrestricted_guests);
 }
 
 TEST_CASE("check_control_enable_vm_functions")
@@ -1405,7 +1405,7 @@ TEST_CASE("check_control_enable_vm_functions")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_enable_vm_functions_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_enable_vm_functions);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_enable_vm_functions);
 }
 
 TEST_CASE("check_control_enable_vmcs_shadowing")
@@ -1413,7 +1413,7 @@ TEST_CASE("check_control_enable_vmcs_shadowing")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_enable_vmcs_shadowing_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_enable_vmcs_shadowing);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_enable_vmcs_shadowing);
 }
 
 TEST_CASE("check_control_enable_ept_violation_checks")
@@ -1421,7 +1421,7 @@ TEST_CASE("check_control_enable_ept_violation_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_enable_ept_violation_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_enable_ept_violation_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_enable_ept_violation_checks);
 }
 
 TEST_CASE("check_control_vm_exit_ctls_reserved_properly_set")
@@ -1429,7 +1429,7 @@ TEST_CASE("check_control_vm_exit_ctls_reserved_properly_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vm_exit_ctls_reserved_properly_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vm_exit_ctls_reserved_properly_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vm_exit_ctls_reserved_properly_set);
 }
 
 TEST_CASE("check_control_activate_and_save_preemption_timer_must_be_0")
@@ -1437,7 +1437,7 @@ TEST_CASE("check_control_activate_and_save_preemption_timer_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_activate_and_save_preemption_timer_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_activate_and_save_preemption_timer_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_activate_and_save_preemption_timer_must_be_0);
 }
 
 TEST_CASE("check_control_exit_msr_store_address")
@@ -1445,7 +1445,7 @@ TEST_CASE("check_control_exit_msr_store_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_exit_msr_store_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_exit_msr_store_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_exit_msr_store_address);
 }
 
 TEST_CASE("check_control_exit_msr_load_address")
@@ -1453,7 +1453,7 @@ TEST_CASE("check_control_exit_msr_load_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_exit_msr_load_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_exit_msr_load_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_exit_msr_load_address);
 }
 
 TEST_CASE("check_control_vm_entry_ctls_reserved_properly_set")
@@ -1461,7 +1461,7 @@ TEST_CASE("check_control_vm_entry_ctls_reserved_properly_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_vm_entry_ctls_reserved_properly_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_vm_entry_ctls_reserved_properly_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_vm_entry_ctls_reserved_properly_set);
 }
 
 TEST_CASE("check_control_event_injection_type_vector_checks")
@@ -1469,7 +1469,7 @@ TEST_CASE("check_control_event_injection_type_vector_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_event_injection_type_vector_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_event_injection_type_vector_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_event_injection_type_vector_checks);
 }
 
 TEST_CASE("check_control_event_injection_delivery_ec_checks")
@@ -1477,7 +1477,7 @@ TEST_CASE("check_control_event_injection_delivery_ec_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_event_injection_delivery_ec_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_event_injection_delivery_ec_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_event_injection_delivery_ec_checks);
 }
 
 TEST_CASE("check_control_event_injection_reserved_bits_checks")
@@ -1485,7 +1485,7 @@ TEST_CASE("check_control_event_injection_reserved_bits_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_event_injection_reserved_bits_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_event_injection_reserved_bits_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_event_injection_reserved_bits_checks);
 }
 
 TEST_CASE("check_control_event_injection_ec_checks")
@@ -1493,7 +1493,7 @@ TEST_CASE("check_control_event_injection_ec_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_event_injection_ec_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_event_injection_ec_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_event_injection_ec_checks);
 }
 
 TEST_CASE("check_control_event_injection_instr_length_checks")
@@ -1501,7 +1501,7 @@ TEST_CASE("check_control_event_injection_instr_length_checks")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_event_injection_instr_length_checks_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_event_injection_instr_length_checks);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_event_injection_instr_length_checks);
 }
 
 TEST_CASE("check_control_entry_msr_load_address")
@@ -1509,7 +1509,7 @@ TEST_CASE("check_control_entry_msr_load_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_control_entry_msr_load_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::control_entry_msr_load_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::control_entry_msr_load_address);
 }
 
 TEST_CASE("check_control_reserved_properly_set")
@@ -1524,7 +1524,7 @@ TEST_CASE("check_control_reserved_properly_set")
     auto ctls = vm_entry_controls::get();
     auto name = vm_entry_controls::name;
 
-    CHECK_NOTHROW(check::control_reserved_properly_set(msr_addr, ctls, name));
+    CHECK_NOTHROW(bfvmm::intel_x64::check::control_reserved_properly_set(msr_addr, ctls, name));
 }
 
 TEST_CASE("check_memory_type_reserved")

--- a/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_guest_fields.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_guest_fields.cpp
@@ -3389,7 +3389,7 @@ TEST_CASE("check_guest_state_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_state_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_state_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_state_all);
 }
 
 TEST_CASE("check_guest_control_registers_debug_registers_and_msrs_all")
@@ -3397,7 +3397,7 @@ TEST_CASE("check_guest_control_registers_debug_registers_and_msrs_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_control_registers_debug_registers_and_msrs_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_control_registers_debug_registers_and_msrs_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_control_registers_debug_registers_and_msrs_all);
 }
 
 TEST_CASE("check_guest_segment_registers_all")
@@ -3405,7 +3405,7 @@ TEST_CASE("check_guest_segment_registers_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_segment_registers_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_segment_registers_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_segment_registers_all);
 }
 
 TEST_CASE("check_guest_descriptor_table_registers_all")
@@ -3413,7 +3413,7 @@ TEST_CASE("check_guest_descriptor_table_registers_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_descriptor_table_registers_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_descriptor_table_registers_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_descriptor_table_registers_all);
 }
 
 TEST_CASE("check_guest_rip_and_rflags_all")
@@ -3421,7 +3421,7 @@ TEST_CASE("check_guest_rip_and_rflags_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rip_and_rflags_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rip_and_rflags_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rip_and_rflags_all);
 }
 
 TEST_CASE("check_guest_non_register_state_all")
@@ -3429,7 +3429,7 @@ TEST_CASE("check_guest_non_register_state_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_non_register_state_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_non_register_state_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_non_register_state_all);
 }
 
 TEST_CASE("check_guest_pdptes_all")
@@ -3437,7 +3437,7 @@ TEST_CASE("check_guest_pdptes_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_pdptes_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_pdptes_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_pdptes_all);
 }
 
 TEST_CASE("check_guest_cr0_for_unsupported_bits")
@@ -3445,7 +3445,7 @@ TEST_CASE("check_guest_cr0_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cr0_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cr0_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cr0_for_unsupported_bits);
 }
 
 TEST_CASE("check_guest_cr0_verify_paging_enabled")
@@ -3453,7 +3453,7 @@ TEST_CASE("check_guest_cr0_verify_paging_enabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cr0_verify_paging_enabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cr0_verify_paging_enabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cr0_verify_paging_enabled);
 }
 
 TEST_CASE("check_guest_cr4_for_unsupported_bits")
@@ -3461,7 +3461,7 @@ TEST_CASE("check_guest_cr4_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cr4_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cr4_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cr4_for_unsupported_bits);
 }
 
 TEST_CASE("check_guest_load_debug_controls_verify_reserved")
@@ -3470,7 +3470,7 @@ TEST_CASE("check_guest_load_debug_controls_verify_reserved")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_load_debug_controls_verify_reserved_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_load_debug_controls_verify_reserved);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_load_debug_controls_verify_reserved);
 }
 
 TEST_CASE("check_guest_verify_ia_32e_mode_enabled")
@@ -3478,7 +3478,7 @@ TEST_CASE("check_guest_verify_ia_32e_mode_enabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_ia_32e_mode_enabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_ia_32e_mode_enabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_ia_32e_mode_enabled);
 }
 
 TEST_CASE("check_guest_verify_ia_32e_mode_disabled")
@@ -3486,7 +3486,7 @@ TEST_CASE("check_guest_verify_ia_32e_mode_disabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_ia_32e_mode_disabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_ia_32e_mode_disabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_ia_32e_mode_disabled);
 }
 
 TEST_CASE("check_guest_cr3_for_unsupported_bits")
@@ -3494,7 +3494,7 @@ TEST_CASE("check_guest_cr3_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cr3_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cr3_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cr3_for_unsupported_bits);
 }
 
 TEST_CASE("check_guest_load_debug_controls_verify_dr7")
@@ -3502,7 +3502,7 @@ TEST_CASE("check_guest_load_debug_controls_verify_dr7")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_load_debug_controls_verify_dr7_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_load_debug_controls_verify_dr7);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_load_debug_controls_verify_dr7);
 }
 
 TEST_CASE("check_guest_ia32_sysenter_esp_canonical_address")
@@ -3510,7 +3510,7 @@ TEST_CASE("check_guest_ia32_sysenter_esp_canonical_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ia32_sysenter_esp_canonical_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ia32_sysenter_esp_canonical_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ia32_sysenter_esp_canonical_address);
 }
 
 TEST_CASE("check_guest_ia32_sysenter_eip_canonical_address")
@@ -3518,7 +3518,7 @@ TEST_CASE("check_guest_ia32_sysenter_eip_canonical_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ia32_sysenter_eip_canonical_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ia32_sysenter_eip_canonical_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ia32_sysenter_eip_canonical_address);
 }
 
 TEST_CASE("check_guest_verify_load_ia32_perf_global_ctrl")
@@ -3526,7 +3526,7 @@ TEST_CASE("check_guest_verify_load_ia32_perf_global_ctrl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_load_ia32_perf_global_ctrl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_load_ia32_perf_global_ctrl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_load_ia32_perf_global_ctrl);
 }
 
 TEST_CASE("check_guest_verify_load_ia32_pat")
@@ -3534,7 +3534,7 @@ TEST_CASE("check_guest_verify_load_ia32_pat")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_load_ia32_pat_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_load_ia32_pat);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_load_ia32_pat);
 }
 
 TEST_CASE("check_guest_verify_load_ia32_efer")
@@ -3542,7 +3542,7 @@ TEST_CASE("check_guest_verify_load_ia32_efer")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_load_ia32_efer_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_load_ia32_efer);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_load_ia32_efer);
 }
 
 TEST_CASE("check_guest_verify_load_ia32_bndcfgs")
@@ -3550,7 +3550,7 @@ TEST_CASE("check_guest_verify_load_ia32_bndcfgs")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_verify_load_ia32_bndcfgs_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_verify_load_ia32_bndcfgs);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_verify_load_ia32_bndcfgs);
 }
 
 TEST_CASE("check_guest_tr_ti_bit_equals_0")
@@ -3558,7 +3558,7 @@ TEST_CASE("check_guest_tr_ti_bit_equals_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_ti_bit_equals_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_ti_bit_equals_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_ti_bit_equals_0);
 }
 
 TEST_CASE("check_guest_ldtr_ti_bit_equals_0")
@@ -3566,7 +3566,7 @@ TEST_CASE("check_guest_ldtr_ti_bit_equals_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_ti_bit_equals_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_ti_bit_equals_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_ti_bit_equals_0);
 }
 
 TEST_CASE("check_guest_ss_and_cs_rpl_are_the_same")
@@ -3574,7 +3574,7 @@ TEST_CASE("check_guest_ss_and_cs_rpl_are_the_same")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_and_cs_rpl_are_the_same_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_and_cs_rpl_are_the_same);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_and_cs_rpl_are_the_same);
 }
 
 TEST_CASE("check_guest_cs_base_is_shifted")
@@ -3582,7 +3582,7 @@ TEST_CASE("check_guest_cs_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_base_is_shifted);
 }
 
 TEST_CASE("check_guest_ss_base_is_shifted")
@@ -3590,7 +3590,7 @@ TEST_CASE("check_guest_ss_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_base_is_shifted);
 }
 
 TEST_CASE("check_guest_ds_base_is_shifted")
@@ -3598,7 +3598,7 @@ TEST_CASE("check_guest_ds_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_base_is_shifted);
 }
 
 TEST_CASE("check_guest_es_base_is_shifted")
@@ -3606,7 +3606,7 @@ TEST_CASE("check_guest_es_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_base_is_shifted);
 }
 
 TEST_CASE("check_guest_fs_base_is_shifted")
@@ -3614,7 +3614,7 @@ TEST_CASE("check_guest_fs_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_base_is_shifted);
 }
 
 TEST_CASE("check_guest_gs_base_is_shifted")
@@ -3622,7 +3622,7 @@ TEST_CASE("check_guest_gs_base_is_shifted")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_base_is_shifted_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_base_is_shifted);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_base_is_shifted);
 }
 
 TEST_CASE("check_guest_tr_base_is_canonical")
@@ -3630,7 +3630,7 @@ TEST_CASE("check_guest_tr_base_is_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_base_is_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_base_is_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_base_is_canonical);
 }
 
 TEST_CASE("check_guest_fs_base_is_canonical")
@@ -3638,7 +3638,7 @@ TEST_CASE("check_guest_fs_base_is_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_base_is_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_base_is_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_base_is_canonical);
 }
 
 TEST_CASE("check_guest_gs_base_is_canonical")
@@ -3646,7 +3646,7 @@ TEST_CASE("check_guest_gs_base_is_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_base_is_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_base_is_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_base_is_canonical);
 }
 
 TEST_CASE("check_guest_ldtr_base_is_canonical")
@@ -3654,7 +3654,7 @@ TEST_CASE("check_guest_ldtr_base_is_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_base_is_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_base_is_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_base_is_canonical);
 }
 
 TEST_CASE("check_guest_cs_base_upper_dword_0")
@@ -3662,7 +3662,7 @@ TEST_CASE("check_guest_cs_base_upper_dword_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_base_upper_dword_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_base_upper_dword_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_base_upper_dword_0);
 }
 
 TEST_CASE("check_guest_ss_base_upper_dword_0")
@@ -3670,7 +3670,7 @@ TEST_CASE("check_guest_ss_base_upper_dword_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_base_upper_dword_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_base_upper_dword_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_base_upper_dword_0);
 }
 
 TEST_CASE("check_guest_ds_base_upper_dword_0")
@@ -3678,7 +3678,7 @@ TEST_CASE("check_guest_ds_base_upper_dword_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_base_upper_dword_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_base_upper_dword_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_base_upper_dword_0);
 }
 
 TEST_CASE("check_guest_es_base_upper_dword_0")
@@ -3686,7 +3686,7 @@ TEST_CASE("check_guest_es_base_upper_dword_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_base_upper_dword_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_base_upper_dword_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_base_upper_dword_0);
 }
 
 TEST_CASE("check_guest_cs_limit")
@@ -3694,7 +3694,7 @@ TEST_CASE("check_guest_cs_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_limit);
 }
 
 TEST_CASE("check_guest_ss_limit")
@@ -3702,7 +3702,7 @@ TEST_CASE("check_guest_ss_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_limit);
 }
 
 TEST_CASE("check_guest_ds_limit")
@@ -3710,7 +3710,7 @@ TEST_CASE("check_guest_ds_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_limit);
 }
 
 TEST_CASE("check_guest_es_limit")
@@ -3718,7 +3718,7 @@ TEST_CASE("check_guest_es_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_limit);
 }
 
 TEST_CASE("check_guest_gs_limit")
@@ -3726,7 +3726,7 @@ TEST_CASE("check_guest_gs_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_limit);
 }
 
 TEST_CASE("check_guest_fs_limit")
@@ -3734,7 +3734,7 @@ TEST_CASE("check_guest_fs_limit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_limit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_limit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_limit);
 }
 
 TEST_CASE("check_guest_v8086_cs_access_rights")
@@ -3742,7 +3742,7 @@ TEST_CASE("check_guest_v8086_cs_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_cs_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_cs_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_cs_access_rights);
 }
 
 TEST_CASE("check_guest_v8086_ss_access_rights")
@@ -3750,7 +3750,7 @@ TEST_CASE("check_guest_v8086_ss_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_ss_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_ss_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_ss_access_rights);
 }
 
 TEST_CASE("check_guest_v8086_ds_access_rights")
@@ -3758,7 +3758,7 @@ TEST_CASE("check_guest_v8086_ds_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_ds_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_ds_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_ds_access_rights);
 }
 
 TEST_CASE("check_guest_v8086_es_access_rights")
@@ -3766,7 +3766,7 @@ TEST_CASE("check_guest_v8086_es_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_es_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_es_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_es_access_rights);
 }
 
 TEST_CASE("check_guest_v8086_fs_access_rights")
@@ -3774,7 +3774,7 @@ TEST_CASE("check_guest_v8086_fs_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_fs_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_fs_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_fs_access_rights);
 }
 
 TEST_CASE("check_guest_v8086_gs_access_rights")
@@ -3782,7 +3782,7 @@ TEST_CASE("check_guest_v8086_gs_access_rights")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_v8086_gs_access_rights_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_v8086_gs_access_rights);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_v8086_gs_access_rights);
 }
 
 TEST_CASE("check_guest_cs_access_rights_type")
@@ -3790,7 +3790,7 @@ TEST_CASE("check_guest_cs_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_access_rights_type);
 }
 
 TEST_CASE("check_guest_ss_access_rights_type")
@@ -3798,7 +3798,7 @@ TEST_CASE("check_guest_ss_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_access_rights_type);
 }
 
 TEST_CASE("check_guest_ds_access_rights_type")
@@ -3806,7 +3806,7 @@ TEST_CASE("check_guest_ds_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_access_rights_type);
 }
 
 TEST_CASE("check_guest_es_access_rights_type")
@@ -3814,7 +3814,7 @@ TEST_CASE("check_guest_es_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_access_rights_type);
 }
 
 TEST_CASE("check_guest_fs_access_rights_type")
@@ -3822,7 +3822,7 @@ TEST_CASE("check_guest_fs_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_access_rights_type);
 }
 
 TEST_CASE("check_guest_gs_access_rights_type")
@@ -3830,7 +3830,7 @@ TEST_CASE("check_guest_gs_access_rights_type")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_access_rights_type_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_access_rights_type);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_access_rights_type);
 }
 
 TEST_CASE("check_guest_cs_is_not_a_system_descriptor")
@@ -3838,7 +3838,7 @@ TEST_CASE("check_guest_cs_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_ss_is_not_a_system_descriptor")
@@ -3846,7 +3846,7 @@ TEST_CASE("check_guest_ss_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_ds_is_not_a_system_descriptor")
@@ -3854,7 +3854,7 @@ TEST_CASE("check_guest_ds_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_es_is_not_a_system_descriptor")
@@ -3862,7 +3862,7 @@ TEST_CASE("check_guest_es_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_fs_is_not_a_system_descriptor")
@@ -3870,7 +3870,7 @@ TEST_CASE("check_guest_fs_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_gs_is_not_a_system_descriptor")
@@ -3878,7 +3878,7 @@ TEST_CASE("check_guest_gs_is_not_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_is_not_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_is_not_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_is_not_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_cs_type_not_equal_3")
@@ -3886,7 +3886,7 @@ TEST_CASE("check_guest_cs_type_not_equal_3")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_type_not_equal_3_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_type_not_equal_3);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_type_not_equal_3);
 }
 
 TEST_CASE("check_guest_cs_dpl_adheres_to_ss_dpl")
@@ -3894,7 +3894,7 @@ TEST_CASE("check_guest_cs_dpl_adheres_to_ss_dpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_dpl_adheres_to_ss_dpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_dpl_adheres_to_ss_dpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_dpl_adheres_to_ss_dpl);
 }
 
 TEST_CASE("check_guest_ss_dpl_must_equal_rpl")
@@ -3902,7 +3902,7 @@ TEST_CASE("check_guest_ss_dpl_must_equal_rpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_dpl_must_equal_rpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_dpl_must_equal_rpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_dpl_must_equal_rpl);
 }
 
 TEST_CASE("check_guest_ss_dpl_must_equal_zero")
@@ -3910,7 +3910,7 @@ TEST_CASE("check_guest_ss_dpl_must_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_dpl_must_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_dpl_must_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_dpl_must_equal_zero);
 }
 
 TEST_CASE("check_guest_ds_dpl")
@@ -3918,7 +3918,7 @@ TEST_CASE("check_guest_ds_dpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_dpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_dpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_dpl);
 }
 
 TEST_CASE("check_guest_es_dpl")
@@ -3926,7 +3926,7 @@ TEST_CASE("check_guest_es_dpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_dpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_dpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_dpl);
 }
 
 TEST_CASE("check_guest_fs_dpl")
@@ -3934,7 +3934,7 @@ TEST_CASE("check_guest_fs_dpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_dpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_dpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_dpl);
 }
 
 TEST_CASE("check_guest_gs_dpl")
@@ -3942,7 +3942,7 @@ TEST_CASE("check_guest_gs_dpl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_dpl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_dpl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_dpl);
 }
 
 TEST_CASE("check_guest_cs_must_be_present")
@@ -3950,7 +3950,7 @@ TEST_CASE("check_guest_cs_must_be_present")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_must_be_present_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_must_be_present);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_must_be_present);
 }
 
 TEST_CASE("check_guest_ss_must_be_present_if_usable")
@@ -3958,7 +3958,7 @@ TEST_CASE("check_guest_ss_must_be_present_if_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_must_be_present_if_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_must_be_present_if_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_must_be_present_if_usable);
 }
 
 TEST_CASE("check_guest_ds_must_be_present_if_usable")
@@ -3966,7 +3966,7 @@ TEST_CASE("check_guest_ds_must_be_present_if_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_must_be_present_if_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_must_be_present_if_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_must_be_present_if_usable);
 }
 
 TEST_CASE("check_guest_es_must_be_present_if_usable")
@@ -3974,7 +3974,7 @@ TEST_CASE("check_guest_es_must_be_present_if_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_must_be_present_if_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_must_be_present_if_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_must_be_present_if_usable);
 }
 
 TEST_CASE("check_guest_fs_must_be_present_if_usable")
@@ -3982,7 +3982,7 @@ TEST_CASE("check_guest_fs_must_be_present_if_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_must_be_present_if_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_must_be_present_if_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_must_be_present_if_usable);
 }
 
 TEST_CASE("check_guest_gs_must_be_present_if_usable")
@@ -3990,7 +3990,7 @@ TEST_CASE("check_guest_gs_must_be_present_if_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_must_be_present_if_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_must_be_present_if_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_must_be_present_if_usable);
 }
 
 TEST_CASE("check_guest_cs_access_rights_reserved_must_be_0")
@@ -3998,7 +3998,7 @@ TEST_CASE("check_guest_cs_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_ss_access_rights_reserved_must_be_0")
@@ -4006,7 +4006,7 @@ TEST_CASE("check_guest_ss_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_ds_access_rights_reserved_must_be_0")
@@ -4014,7 +4014,7 @@ TEST_CASE("check_guest_ds_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_es_access_rights_reserved_must_be_0")
@@ -4022,7 +4022,7 @@ TEST_CASE("check_guest_es_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_fs_access_rights_reserved_must_be_0")
@@ -4030,7 +4030,7 @@ TEST_CASE("check_guest_fs_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_gs_access_rights_reserved_must_be_0")
@@ -4038,7 +4038,7 @@ TEST_CASE("check_guest_gs_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_cs_db_must_be_0_if_l_equals_1")
@@ -4046,7 +4046,7 @@ TEST_CASE("check_guest_cs_db_must_be_0_if_l_equals_1")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_db_must_be_0_if_l_equals_1_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_db_must_be_0_if_l_equals_1);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_db_must_be_0_if_l_equals_1);
 }
 
 TEST_CASE("check_guest_cs_granularity")
@@ -4054,7 +4054,7 @@ TEST_CASE("check_guest_cs_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_granularity);
 }
 
 TEST_CASE("check_guest_ss_granularity")
@@ -4062,7 +4062,7 @@ TEST_CASE("check_guest_ss_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_granularity);
 }
 
 TEST_CASE("check_guest_ds_granularity")
@@ -4070,7 +4070,7 @@ TEST_CASE("check_guest_ds_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_granularity);
 }
 
 TEST_CASE("check_guest_es_granularity")
@@ -4078,7 +4078,7 @@ TEST_CASE("check_guest_es_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_granularity);
 }
 
 TEST_CASE("check_guest_fs_granularity")
@@ -4086,7 +4086,7 @@ TEST_CASE("check_guest_fs_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_granularity);
 }
 
 TEST_CASE("check_guest_gs_granularity")
@@ -4094,7 +4094,7 @@ TEST_CASE("check_guest_gs_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_granularity);
 }
 
 TEST_CASE("check_guest_cs_access_rights_remaining_reserved_bit_0")
@@ -4102,7 +4102,7 @@ TEST_CASE("check_guest_cs_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_cs_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_cs_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_cs_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_ss_access_rights_remaining_reserved_bit_0")
@@ -4110,7 +4110,7 @@ TEST_CASE("check_guest_ss_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ss_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ss_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ss_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_ds_access_rights_remaining_reserved_bit_0")
@@ -4118,7 +4118,7 @@ TEST_CASE("check_guest_ds_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ds_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ds_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ds_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_es_access_rights_remaining_reserved_bit_0")
@@ -4126,7 +4126,7 @@ TEST_CASE("check_guest_es_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_es_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_es_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_es_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_fs_access_rights_remaining_reserved_bit_0")
@@ -4134,7 +4134,7 @@ TEST_CASE("check_guest_fs_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_fs_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_fs_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_fs_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_gs_access_rights_remaining_reserved_bit_0")
@@ -4142,7 +4142,7 @@ TEST_CASE("check_guest_gs_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gs_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gs_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gs_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_tr_type_must_be_11")
@@ -4150,7 +4150,7 @@ TEST_CASE("check_guest_tr_type_must_be_11")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_type_must_be_11_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_type_must_be_11);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_type_must_be_11);
 }
 
 TEST_CASE("check_guest_tr_must_be_a_system_descriptor")
@@ -4158,7 +4158,7 @@ TEST_CASE("check_guest_tr_must_be_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_must_be_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_must_be_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_must_be_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_tr_must_be_present")
@@ -4166,7 +4166,7 @@ TEST_CASE("check_guest_tr_must_be_present")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_must_be_present_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_must_be_present);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_must_be_present);
 }
 
 TEST_CASE("check_guest_tr_access_rights_reserved_must_be_0")
@@ -4174,7 +4174,7 @@ TEST_CASE("check_guest_tr_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_tr_granularity")
@@ -4182,7 +4182,7 @@ TEST_CASE("check_guest_tr_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_granularity);
 }
 
 TEST_CASE("check_guest_tr_must_be_usable")
@@ -4190,7 +4190,7 @@ TEST_CASE("check_guest_tr_must_be_usable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_must_be_usable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_must_be_usable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_must_be_usable);
 }
 
 TEST_CASE("check_guest_tr_access_rights_remaining_reserved_bit_0")
@@ -4198,7 +4198,7 @@ TEST_CASE("check_guest_tr_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_tr_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_tr_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_tr_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_ldtr_type_must_be_2")
@@ -4206,7 +4206,7 @@ TEST_CASE("check_guest_ldtr_type_must_be_2")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_type_must_be_2_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_type_must_be_2);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_type_must_be_2);
 }
 
 TEST_CASE("check_guest_ldtr_must_be_a_system_descriptor")
@@ -4214,7 +4214,7 @@ TEST_CASE("check_guest_ldtr_must_be_a_system_descriptor")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_must_be_a_system_descriptor_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_must_be_a_system_descriptor);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_must_be_a_system_descriptor);
 }
 
 TEST_CASE("check_guest_ldtr_must_be_present")
@@ -4222,7 +4222,7 @@ TEST_CASE("check_guest_ldtr_must_be_present")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_must_be_present_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_must_be_present);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_must_be_present);
 }
 
 TEST_CASE("check_guest_ldtr_access_rights_reserved_must_be_0")
@@ -4230,7 +4230,7 @@ TEST_CASE("check_guest_ldtr_access_rights_reserved_must_be_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_access_rights_reserved_must_be_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_access_rights_reserved_must_be_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_access_rights_reserved_must_be_0);
 }
 
 TEST_CASE("check_guest_ldtr_granularity")
@@ -4238,7 +4238,7 @@ TEST_CASE("check_guest_ldtr_granularity")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_granularity_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_granularity);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_granularity);
 }
 
 TEST_CASE("check_guest_ldtr_access_rights_remaining_reserved_bit_0")
@@ -4246,7 +4246,7 @@ TEST_CASE("check_guest_ldtr_access_rights_remaining_reserved_bit_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_ldtr_access_rights_remaining_reserved_bit_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_ldtr_access_rights_remaining_reserved_bit_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_ldtr_access_rights_remaining_reserved_bit_0);
 }
 
 TEST_CASE("check_guest_gdtr_base_must_be_canonical")
@@ -4254,7 +4254,7 @@ TEST_CASE("check_guest_gdtr_base_must_be_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gdtr_base_must_be_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gdtr_base_must_be_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gdtr_base_must_be_canonical);
 }
 
 TEST_CASE("check_guest_idtr_base_must_be_canonical")
@@ -4262,7 +4262,7 @@ TEST_CASE("check_guest_idtr_base_must_be_canonical")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_idtr_base_must_be_canonical_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_idtr_base_must_be_canonical);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_idtr_base_must_be_canonical);
 }
 
 TEST_CASE("check_guest_gdtr_limit_reserved_bits")
@@ -4270,7 +4270,7 @@ TEST_CASE("check_guest_gdtr_limit_reserved_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_gdtr_limit_reserved_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_gdtr_limit_reserved_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_gdtr_limit_reserved_bits);
 }
 
 TEST_CASE("check_guest_idtr_limit_reserved_bits")
@@ -4278,7 +4278,7 @@ TEST_CASE("check_guest_idtr_limit_reserved_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_idtr_limit_reserved_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_idtr_limit_reserved_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_idtr_limit_reserved_bits);
 }
 
 TEST_CASE("check_guest_rip_upper_bits")
@@ -4286,7 +4286,7 @@ TEST_CASE("check_guest_rip_upper_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rip_upper_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rip_upper_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rip_upper_bits);
 }
 
 TEST_CASE("check_guest_rip_valid_addr")
@@ -4294,7 +4294,7 @@ TEST_CASE("check_guest_rip_valid_addr")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rip_valid_addr_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rip_valid_addr);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rip_valid_addr);
 }
 
 TEST_CASE("check_guest_rflags_reserved_bits")
@@ -4302,7 +4302,7 @@ TEST_CASE("check_guest_rflags_reserved_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rflags_reserved_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rflags_reserved_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rflags_reserved_bits);
 }
 
 TEST_CASE("check_guest_rflags_vm_bit")
@@ -4310,7 +4310,7 @@ TEST_CASE("check_guest_rflags_vm_bit")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rflags_vm_bit_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rflags_vm_bit);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rflags_vm_bit);
 }
 
 TEST_CASE("check_guest_rflag_interrupt_enable")
@@ -4318,7 +4318,7 @@ TEST_CASE("check_guest_rflag_interrupt_enable")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_rflag_interrupt_enable_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_rflag_interrupt_enable);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_rflag_interrupt_enable);
 }
 
 TEST_CASE("check_guest_valid_activity_state")
@@ -4326,7 +4326,7 @@ TEST_CASE("check_guest_valid_activity_state")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_valid_activity_state_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_valid_activity_state);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_valid_activity_state);
 }
 
 TEST_CASE("check_guest_activity_state_not_hlt_when_dpl_not_0")
@@ -4334,7 +4334,7 @@ TEST_CASE("check_guest_activity_state_not_hlt_when_dpl_not_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_activity_state_not_hlt_when_dpl_not_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_activity_state_not_hlt_when_dpl_not_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_activity_state_not_hlt_when_dpl_not_0);
 }
 
 TEST_CASE("check_guest_must_be_active_if_injecting_blocking_state")
@@ -4342,7 +4342,7 @@ TEST_CASE("check_guest_must_be_active_if_injecting_blocking_state")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_must_be_active_if_injecting_blocking_state_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_must_be_active_if_injecting_blocking_state);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_must_be_active_if_injecting_blocking_state);
 }
 
 TEST_CASE("check_guest_hlt_valid_interrupts")
@@ -4350,7 +4350,7 @@ TEST_CASE("check_guest_hlt_valid_interrupts")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_hlt_valid_interrupts_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_hlt_valid_interrupts);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_hlt_valid_interrupts);
 }
 
 TEST_CASE("check_guest_shutdown_valid_interrupts")
@@ -4358,7 +4358,7 @@ TEST_CASE("check_guest_shutdown_valid_interrupts")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_shutdown_valid_interrupts_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_shutdown_valid_interrupts);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_shutdown_valid_interrupts);
 }
 
 TEST_CASE("check_guest_sipi_valid_interrupts")
@@ -4366,7 +4366,7 @@ TEST_CASE("check_guest_sipi_valid_interrupts")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_sipi_valid_interrupts_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_sipi_valid_interrupts);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_sipi_valid_interrupts);
 }
 
 TEST_CASE("check_guest_valid_activity_state_and_smm")
@@ -4374,7 +4374,7 @@ TEST_CASE("check_guest_valid_activity_state_and_smm")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_valid_activity_state_and_smm_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_valid_activity_state_and_smm);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_valid_activity_state_and_smm);
 }
 
 TEST_CASE("check_guest_interruptibility_state_reserved")
@@ -4382,7 +4382,7 @@ TEST_CASE("check_guest_interruptibility_state_reserved")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_reserved_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_reserved);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_reserved);
 }
 
 TEST_CASE("check_guest_interruptibility_state_sti_mov_ss")
@@ -4390,7 +4390,7 @@ TEST_CASE("check_guest_interruptibility_state_sti_mov_ss")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_sti_mov_ss_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_sti_mov_ss);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_sti_mov_ss);
 }
 
 TEST_CASE("check_guest_interruptibility_state_sti")
@@ -4398,7 +4398,7 @@ TEST_CASE("check_guest_interruptibility_state_sti")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_sti_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_sti);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_sti);
 }
 
 TEST_CASE("check_guest_interruptibility_state_external_interrupt")
@@ -4406,7 +4406,7 @@ TEST_CASE("check_guest_interruptibility_state_external_interrupt")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_external_interrupt_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_external_interrupt);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_external_interrupt);
 }
 
 TEST_CASE("check_guest_interruptibility_state_nmi")
@@ -4414,7 +4414,7 @@ TEST_CASE("check_guest_interruptibility_state_nmi")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_nmi_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_nmi);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_nmi);
 }
 
 TEST_CASE("check_guest_interruptibility_not_in_smm")
@@ -4422,7 +4422,7 @@ TEST_CASE("check_guest_interruptibility_not_in_smm")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_not_in_smm_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_not_in_smm);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_not_in_smm);
 }
 
 TEST_CASE("check_guest_interruptibility_entry_to_smm")
@@ -4430,7 +4430,7 @@ TEST_CASE("check_guest_interruptibility_entry_to_smm")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_entry_to_smm_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_entry_to_smm);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_entry_to_smm);
 }
 
 TEST_CASE("check_guest_interruptibility_state_sti_and_nmi")
@@ -4438,7 +4438,7 @@ TEST_CASE("check_guest_interruptibility_state_sti_and_nmi")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_sti_and_nmi_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_sti_and_nmi);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_sti_and_nmi);
 }
 
 TEST_CASE("check_guest_interruptibility_state_virtual_nmi")
@@ -4446,7 +4446,7 @@ TEST_CASE("check_guest_interruptibility_state_virtual_nmi")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_virtual_nmi_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_virtual_nmi);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_virtual_nmi);
 }
 
 TEST_CASE("check_guest_interruptibility_state_enclave_interrupt")
@@ -4454,7 +4454,7 @@ TEST_CASE("check_guest_interruptibility_state_enclave_interrupt")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_interruptibility_state_enclave_interrupt_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_interruptibility_state_enclave_interrupt);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_interruptibility_state_enclave_interrupt);
 }
 
 TEST_CASE("check_guest_pending_debug_exceptions_reserved")
@@ -4462,7 +4462,7 @@ TEST_CASE("check_guest_pending_debug_exceptions_reserved")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_pending_debug_exceptions_reserved_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_pending_debug_exceptions_reserved);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_pending_debug_exceptions_reserved);
 }
 
 TEST_CASE("check_guest_pending_debug_exceptions_dbg_ctl")
@@ -4470,7 +4470,7 @@ TEST_CASE("check_guest_pending_debug_exceptions_dbg_ctl")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_pending_debug_exceptions_dbg_ctl_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_pending_debug_exceptions_dbg_ctl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_pending_debug_exceptions_dbg_ctl);
 }
 
 TEST_CASE("check_guest_pending_debug_exceptions_rtm")
@@ -4478,7 +4478,7 @@ TEST_CASE("check_guest_pending_debug_exceptions_rtm")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_pending_debug_exceptions_rtm_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_pending_debug_exceptions_rtm);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_pending_debug_exceptions_rtm);
 }
 
 TEST_CASE("check_guest_vmcs_link_pointer_bits_11_0")
@@ -4486,7 +4486,7 @@ TEST_CASE("check_guest_vmcs_link_pointer_bits_11_0")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_vmcs_link_pointer_bits_11_0_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_vmcs_link_pointer_bits_11_0);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_vmcs_link_pointer_bits_11_0);
 }
 
 TEST_CASE("check_guest_vmcs_link_pointer_valid_addr")
@@ -4494,7 +4494,7 @@ TEST_CASE("check_guest_vmcs_link_pointer_valid_addr")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_vmcs_link_pointer_valid_addr_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_vmcs_link_pointer_valid_addr);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_vmcs_link_pointer_valid_addr);
 }
 
 TEST_CASE("check_guest_vmcs_link_pointer_first_word")
@@ -4502,7 +4502,7 @@ TEST_CASE("check_guest_vmcs_link_pointer_first_word")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_vmcs_link_pointer_first_word_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_vmcs_link_pointer_first_word);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_vmcs_link_pointer_first_word);
 }
 
 TEST_CASE("check_guest_valid_pdpte_with_ept_disabled")
@@ -4510,7 +4510,7 @@ TEST_CASE("check_guest_valid_pdpte_with_ept_disabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_valid_pdpte_with_ept_disabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_valid_pdpte_with_ept_disabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_valid_pdpte_with_ept_disabled);
 }
 
 TEST_CASE("check_guest_valid_pdpte_with_ept_enabled")
@@ -4518,7 +4518,7 @@ TEST_CASE("check_guest_valid_pdpte_with_ept_enabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_guest_valid_pdpte_with_ept_enabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::guest_valid_pdpte_with_ept_enabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::guest_valid_pdpte_with_ept_enabled);
 }
 
 #endif

--- a/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_host_fields.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/check/test_check_vmcs_host_fields.cpp
@@ -633,7 +633,7 @@ TEST_CASE("check_host_state_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_state_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_state_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_state_all);
 }
 
 TEST_CASE("check_host_control_registers_and_msrs_all")
@@ -641,7 +641,7 @@ TEST_CASE("check_host_control_registers_and_msrs_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_control_registers_and_msrs_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_control_registers_and_msrs_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_control_registers_and_msrs_all);
 }
 
 TEST_CASE("check_host_segment_and_descriptor_table_registers_all")
@@ -649,7 +649,7 @@ TEST_CASE("check_host_segment_and_descriptor_table_registers_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_segment_and_descriptor_table_registers_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_segment_and_descriptor_table_registers_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_segment_and_descriptor_table_registers_all);
 }
 
 TEST_CASE("check_host_address_space_size_all")
@@ -657,7 +657,7 @@ TEST_CASE("check_host_address_space_size_all")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_address_space_size_all_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_address_space_size_all);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_address_space_size_all);
 }
 
 TEST_CASE("check_host_cr0_for_unsupported_bits")
@@ -665,7 +665,7 @@ TEST_CASE("check_host_cr0_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_cr0_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_cr0_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_cr0_for_unsupported_bits);
 }
 
 TEST_CASE("check_host_cr4_for_unsupported_bits")
@@ -673,7 +673,7 @@ TEST_CASE("check_host_cr4_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_cr4_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_cr4_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_cr4_for_unsupported_bits);
 }
 
 TEST_CASE("check_host_cr3_for_unsupported_bits")
@@ -681,7 +681,7 @@ TEST_CASE("check_host_cr3_for_unsupported_bits")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_cr3_for_unsupported_bits_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_cr3_for_unsupported_bits);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_cr3_for_unsupported_bits);
 }
 
 TEST_CASE("check_host_ia32_sysenter_esp_canonical_address")
@@ -689,7 +689,7 @@ TEST_CASE("check_host_ia32_sysenter_esp_canonical_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_ia32_sysenter_esp_canonical_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_ia32_sysenter_esp_canonical_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_ia32_sysenter_esp_canonical_address);
 }
 
 TEST_CASE("check_host_ia32_sysenter_eip_canonical_address")
@@ -697,7 +697,7 @@ TEST_CASE("check_host_ia32_sysenter_eip_canonical_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_ia32_sysenter_eip_canonical_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_ia32_sysenter_eip_canonical_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_ia32_sysenter_eip_canonical_address);
 }
 
 TEST_CASE("check_host_verify_load_ia32_perf_global_ctrl")
@@ -705,7 +705,7 @@ TEST_CASE("check_host_verify_load_ia32_perf_global_ctrl")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_verify_load_ia32_perf_global_ctrl_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_verify_load_ia32_perf_global_ctrl);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_verify_load_ia32_perf_global_ctrl);
 }
 
 TEST_CASE("check_host_verify_load_ia32_pat")
@@ -713,7 +713,7 @@ TEST_CASE("check_host_verify_load_ia32_pat")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_verify_load_ia32_pat_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_verify_load_ia32_pat);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_verify_load_ia32_pat);
 }
 
 TEST_CASE("check_host_verify_load_ia32_efer")
@@ -721,7 +721,7 @@ TEST_CASE("check_host_verify_load_ia32_efer")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_verify_load_ia32_efer_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_verify_load_ia32_efer);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_verify_load_ia32_efer);
 }
 
 TEST_CASE("check_host_es_selector_rpl_ti_equal_zero")
@@ -729,7 +729,7 @@ TEST_CASE("check_host_es_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_es_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_es_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_es_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_cs_selector_rpl_ti_equal_zero")
@@ -737,7 +737,7 @@ TEST_CASE("check_host_cs_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_cs_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_cs_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_cs_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_ss_selector_rpl_ti_equal_zero")
@@ -745,7 +745,7 @@ TEST_CASE("check_host_ss_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_ss_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_ss_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_ss_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_ds_selector_rpl_ti_equal_zero")
@@ -753,7 +753,7 @@ TEST_CASE("check_host_ds_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_ds_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_ds_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_ds_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_fs_selector_rpl_ti_equal_zero")
@@ -761,7 +761,7 @@ TEST_CASE("check_host_fs_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_fs_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_fs_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_fs_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_gs_selector_rpl_ti_equal_zero")
@@ -769,7 +769,7 @@ TEST_CASE("check_host_gs_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_gs_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_gs_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_gs_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_tr_selector_rpl_ti_equal_zero")
@@ -777,7 +777,7 @@ TEST_CASE("check_host_tr_selector_rpl_ti_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_tr_selector_rpl_ti_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_tr_selector_rpl_ti_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_tr_selector_rpl_ti_equal_zero);
 }
 
 TEST_CASE("check_host_cs_not_equal_zero")
@@ -785,7 +785,7 @@ TEST_CASE("check_host_cs_not_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_cs_not_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_cs_not_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_cs_not_equal_zero);
 }
 
 TEST_CASE("check_host_tr_not_equal_zero")
@@ -793,7 +793,7 @@ TEST_CASE("check_host_tr_not_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_tr_not_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_tr_not_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_tr_not_equal_zero);
 }
 
 TEST_CASE("check_host_ss_not_equal_zero")
@@ -801,7 +801,7 @@ TEST_CASE("check_host_ss_not_equal_zero")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_ss_not_equal_zero_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_ss_not_equal_zero);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_ss_not_equal_zero);
 }
 
 TEST_CASE("check_host_fs_canonical_base_address")
@@ -809,7 +809,7 @@ TEST_CASE("check_host_fs_canonical_base_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_fs_canonical_base_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_fs_canonical_base_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_fs_canonical_base_address);
 }
 
 TEST_CASE("check_host_gs_canonical_base_address")
@@ -817,7 +817,7 @@ TEST_CASE("check_host_gs_canonical_base_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_gs_canonical_base_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_gs_canonical_base_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_gs_canonical_base_address);
 }
 
 TEST_CASE("check_host_gdtr_canonical_base_address")
@@ -825,7 +825,7 @@ TEST_CASE("check_host_gdtr_canonical_base_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_gdtr_canonical_base_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_gdtr_canonical_base_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_gdtr_canonical_base_address);
 }
 
 TEST_CASE("check_host_idtr_canonical_base_address")
@@ -833,7 +833,7 @@ TEST_CASE("check_host_idtr_canonical_base_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_idtr_canonical_base_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_idtr_canonical_base_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_idtr_canonical_base_address);
 }
 
 TEST_CASE("check_host_tr_canonical_base_address")
@@ -841,7 +841,7 @@ TEST_CASE("check_host_tr_canonical_base_address")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_tr_canonical_base_address_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_tr_canonical_base_address);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_tr_canonical_base_address);
 }
 
 TEST_CASE("check_host_if_outside_ia32e_mode")
@@ -849,7 +849,7 @@ TEST_CASE("check_host_if_outside_ia32e_mode")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_if_outside_ia32e_mode_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_if_outside_ia32e_mode);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_if_outside_ia32e_mode);
 }
 
 TEST_CASE("check_host_address_space_size_exit_ctl_is_set")
@@ -857,7 +857,7 @@ TEST_CASE("check_host_address_space_size_exit_ctl_is_set")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_address_space_size_exit_ctl_is_set_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_address_space_size_exit_ctl_is_set);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_address_space_size_exit_ctl_is_set);
 }
 
 TEST_CASE("check_host_address_space_disabled")
@@ -865,7 +865,7 @@ TEST_CASE("check_host_address_space_disabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_address_space_disabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_address_space_disabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_address_space_disabled);
 }
 
 TEST_CASE("check_host_address_space_enabled")
@@ -873,7 +873,7 @@ TEST_CASE("check_host_address_space_enabled")
     std::vector<struct control_flow_path> cfg;
     setup_check_host_address_space_enabled_paths(cfg);
 
-    test_vmcs_check(cfg, check::host_address_space_enabled);
+    test_vmcs_check(cfg, bfvmm::intel_x64::check::host_address_space_enabled);
 }
 
 #endif

--- a/bfvmm/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
@@ -1392,7 +1392,7 @@ TEST_CASE("exit_handler: vm_exit_failure_check")
     auto vmcs = setup_vmcs_unhandled(mocks, exit_reason::basic_exit_reason::xrstors | 0x80000000);
     auto ehlr = setup_ehlr(vmcs);
 
-    mocks.OnCallFunc(vmcs::check::all);
+    mocks.OnCallFunc(bfvmm::intel_x64::check::all);
 
     CHECK_NOTHROW(ehlr.dispatch());
 }

--- a/bfvmm/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/vmcs/test_vmcs.cpp
@@ -58,8 +58,8 @@ TEST_CASE("vmcs: launch_vmlaunch_demote_failure")
 
     setup_msrs();
 
-    mocks.OnCallFunc(check::all);
     mocks.OnCallFunc(debug::dump);
+    mocks.OnCallFunc(bfvmm::intel_x64::check::all);
     mocks.OnCall(guest_state, vmcs_intel_x64_state::is_guest).Return(false);
 
     g_vmlaunch_fails = true;

--- a/bfvmm/tests/support/arch/intel_x64/test_support.h
+++ b/bfvmm/tests/support/arch/intel_x64/test_support.h
@@ -26,13 +26,14 @@
 #include <hve/arch/intel_x64/exit_handler/exit_handler_support.h>
 
 #include <hve/arch/intel_x64/vmcs/vmcs.h>
-#include <hve/arch/intel_x64/vmcs/vmcs_check.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_launch.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_resume.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_promote.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_state.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_state_hvm.h>
 #include <hve/arch/intel_x64/vmcs/vmcs_state_vmm.h>
+
+#include <hve/arch/intel_x64/check/check.h>
 
 #include <hve/arch/x64/gdt.h>
 #include <hve/arch/x64/idt.h>


### PR DESCRIPTION
This patch adds the bfvmm namesapce to the check logic in the bfvmm.
This is the first of many PRs to add the bfvmm namespace and reduce the
need for hardcoding namespace logic into filenames / variable names

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/583

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>