### PR TITLE
Add changes required for clean eapis build

### DIFF
--- a/bfvmm/include/hve/arch/x64/idt.h
+++ b/bfvmm/include/hve/arch/x64/idt.h
@@ -68,6 +68,7 @@ public:
     using interrupt_descriptor_type = uint64_t;     ///< IDT descriptor type
     using offset_type = uint64_t;                   ///< IDT offset type
     using selector_type = uint64_t;                 ///< IDT selector type
+    using isr_type = void(*)(void);                 ///< ISR type
 
     /// Constructor
     ///
@@ -166,6 +167,18 @@ public:
     /// @param off the RIP address of the ISR.
     ///
     void set_offset(index_type index, pointer off)
+    { set_offset(index, reinterpret_cast<offset_type>(off)); }
+
+    /// Set Descriptor Offset
+    ///
+    /// @expects index < m_idt.size() + 1
+    /// @expects off is canonical
+    /// @ensures none
+    ///
+    /// @param index the index of the IDT descriptor
+    /// @param off the RIP address of the ISR.
+    ///
+    void set_offset(index_type index, isr_type off)
     { set_offset(index, reinterpret_cast<offset_type>(off)); }
 
     /// Get Descriptor Offset
@@ -275,6 +288,23 @@ public:
     ///
     void set(
         index_type index, pointer off, selector_type selector)
+    {
+        this->set_offset(index, off);
+        this->set_selector(index, selector);
+        this->set_present(index, true);
+    }
+
+    /// Set All Fields
+    ///
+    /// @expects index < m_idt.size()
+    /// @ensures none
+    ///
+    /// @param index the index of the IDT descriptor
+    /// @param off the RIP address of the ISR.
+    /// @param selector the descriptor
+    ///
+    void set(
+        index_type index, isr_type off, selector_type selector)
     {
         this->set_offset(index, off);
         this->set_selector(index, selector);

--- a/bfvmm/include/memory_manager/object_allocator.h
+++ b/bfvmm/include/memory_manager/object_allocator.h
@@ -42,7 +42,7 @@ constexpr const auto objtpool_size = 255U;
 /// Once the buddy allocator is complete, this code should alloc from the
 /// buddy allocator.
 ///
-#include <memory_manager/memory_manager_x64.h>
+#include "../memory_manager/memory_manager_x64.h"
 
 /// @struct __oa_page
 ///

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include <bfvcpuid.h>
-#include <user_data.h>
+#include "../user_data.h"
 
 // -----------------------------------------------------------------------------
 // Exports

--- a/bfvmm/src/CMakeLists.txt
+++ b/bfvmm/src/CMakeLists.txt
@@ -34,4 +34,4 @@ add_subdirectory(entry)
 # Install
 # ------------------------------------------------------------------------------
 
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include DESTINATION include/bfvmm)
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/ DESTINATION include/bfvmm)


### PR DESCRIPTION
- Add an isr_type in the idt class to avoid compiler cast errors
- Use relative paths with memory_manager/object_allocator.h and user_data.h
- Add trailing slash on the source install path in bfvmm/src/CMakeLists.txt.
  Without the slash, the headers were being installed as
  <prefix>/include/bfvmm/include/...