### PR TITLE
docs: Update Arch Linux setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,9 +140,18 @@ supported platforms and their dependencies:
 
 #### Arch Linux:
 ```
-sudo pacman -S git linux-headers nasm clang clang-tools-extra cmake base-devel yaourt
+sudo pacman -S git linux-headers nasm clang clang-tools-extra cmake base-devel
+git clone https://aur.archlinux.org/package-query.git
+git clone https://aur.archlinux.org/yaourt.git
+pushd package-query
+makepkg --install --sync-deps --needed
+popd
+pushd yaourt
+makepkg --install --sync-deps --needed
+popd
 sudo yaourt -S downgrade
-downgrade clang clang-tools-extra llvm-libs     # select clang 4.0
+sudo downgrade clang clang-tools-extra llvm-libs  # select 4.0.*
+sudo ln -s /usr/share/clang/run-clang-tidy.py /usr/bin/run-clang-tidy-4.0.py
 ```
 
 #### Ubuntu 17.04 (or Higher):


### PR DESCRIPTION
- Add commands for downloading and installing yaourt
  on a vanilla Arch system.
- Remove the 'yaourt' from the initial 'pacman -S' command
  since it is not an official Arch package.
- Add symlink for run-clang-tidy-4.0.py.