### PR TITLE
Add platform_info_t, support runtime serial port address

### DIFF
--- a/bfdriver/src/common.c
+++ b/bfdriver/src/common.c
@@ -84,6 +84,12 @@ private_setup_tls(void)
 }
 
 int64_t
+private_setup_info(void)
+{
+    return platform_populate_info(&g_info.platform_info);
+}
+
+int64_t
 private_call_vmm(uintptr_t request, uintptr_t arg1, uintptr_t arg2, uintptr_t arg3)
 {
     int64_t ret = 0;
@@ -209,6 +215,8 @@ common_reset(void)
 {
     int64_t i;
 
+    platform_unload_info(&g_info.platform_info);
+
     for (i = 0; i < g_num_modules; i++) {
         if (g_modules[i].exec != 0) {
             platform_free_rwe(g_modules[i].exec, g_modules[i].exec_size);
@@ -327,6 +335,11 @@ common_load_vmm(void)
     }
 
     ret = private_setup_tls();
+    if (ret != BF_SUCCESS) {
+        goto failure;
+    }
+
+    ret = private_setup_info();
     if (ret != BF_SUCCESS) {
         goto failure;
     }

--- a/bfdriver/src/platform/linux/platform.c
+++ b/bfdriver/src/platform/linux/platform.c
@@ -17,6 +17,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  */
 
+#include <bfarch.h>
 #include <bftypes.h>
 #include <bfdebug.h>
 #include <bfplatform.h>
@@ -31,6 +32,10 @@
 #include <linux/cpumask.h>
 #include <linux/sched.h>
 #include <linux/kallsyms.h>
+
+#if defined(BF_AARCH64)
+#   include <asm/io.h>
+#endif
 
 #include <asm/tlbflush.h>
 
@@ -195,3 +200,42 @@ platform_restore_preemption(void)
 {
     put_cpu();
 }
+
+#if defined(BF_AARCH64)
+
+int64_t
+platform_populate_info(struct platform_info_t *info)
+{
+    info->serial_address = (uintptr_t) ioremap(DEFAULT_COM_PORT, DEFAULT_COM_LENGTH);
+
+    return BF_SUCCESS;
+}
+
+void
+platform_unload_info(struct platform_info_t *info)
+{
+    if (info->serial_address) {
+        iounmap((void*) info->serial_address);
+        info->serial_address = 0;
+    }
+}
+
+#else
+
+int64_t
+platform_populate_info(struct platform_info_t *info)
+{
+    if (info) {
+        platform_memset(info, 0, sizeof(struct platform_info_t));
+    }
+
+    return BF_SUCCESS;
+}
+
+void
+platform_unload_info(struct platform_info_t *info)
+{
+    (void) info;
+}
+
+#endif

--- a/bfdriver/src/platform/test/platform.c
+++ b/bfdriver/src/platform/test/platform.c
@@ -121,3 +121,19 @@ platform_restore_preemption(void)
 void
 _vmcall(struct vmcall_registers_t *regs)
 { regs->r01 = 0; }
+
+int64_t
+platform_populate_info(struct platform_info_t *info)
+{
+    if (info) {
+        platform_memset(info, 0, sizeof(struct platform_info_t));
+    }
+
+    return BF_SUCCESS;
+}
+
+void
+platform_unload_info(struct platform_info_t *info)
+{
+    (void) info;
+}

--- a/bfdriver/src/platform/windows/platform.c
+++ b/bfdriver/src/platform/windows/platform.c
@@ -160,3 +160,19 @@ void
 platform_restore_preemption(void)
 {
 }
+
+int64_t
+platform_populate_info(struct platform_info_t *info)
+{
+    if (info) {
+        platform_memset(info, 0, sizeof(struct platform_info_t));
+    }
+
+    return BF_SUCCESS;
+}
+
+void
+platform_unload_info(struct platform_info_t *info)
+{
+    (void) info;
+}

--- a/bfsdk/include/bfconstants.h
+++ b/bfsdk/include/bfconstants.h
@@ -20,6 +20,7 @@
 #ifndef BFCONSTANTS_H
 #define BFCONSTANTS_H
 
+#include <bfarch.h>
 #include <bftypes.h>
 
 /*
@@ -262,7 +263,7 @@
 /*
  * Default Serial COM Port
  *
- * Possible values include (but not limited to):
+ * On x64, possible values include (but not limited to):
  *    - 0x03F8U  // COM1
  *    - 0x02F8U  // COM2
  *    - 0x03E8U  // COM3
@@ -270,10 +271,44 @@
  *    - 0xE000U
  *    - 0xE010U
  *
+ * On aarch64, the value is the serial peripheral's physical base address.
+ *
  * Note: See bfvmm/serial/serial_port_ns16550a.h
  */
 #ifndef DEFAULT_COM_PORT
-#define DEFAULT_COM_PORT 0x3F8U
+#if defined(BF_AARCH64)
+#   define DEFAULT_COM_PORT 0x09000000
+#else
+#   define DEFAULT_COM_PORT 0x3F8U
+#   define DEFAULT_COM_DRIVER serial_port_ns16550a
+#endif
+#endif
+
+/*
+ * Serial Port Driver
+ *
+ * Possible values include:
+ *     - serial_port_ns16550a
+ *     - serial_port_pl011
+ *
+ * On x64, this should always be serial_port_ns16550a.
+ */
+#ifndef DEFAULT_COM_DRIVER
+#if defined(BF_AARCH64)
+#   define DEFAULT_COM_DRIVER serial_port_pl011
+#else
+#   define DEFAULT_COM_DRIVER serial_port_ns16550a
+#endif
+#endif
+
+/*
+ * Serial port memory length (aarch64 only)
+ *
+ * This is the length of the memory region occupied by the memory-mapped
+ * serial port.
+ */
+#if !defined(DEFAULT_COM_LENGTH) && defined(BF_AARCH64)
+#define DEFAULT_COM_LENGTH 0x1000
 #endif
 
 /*

--- a/bfsdk/include/bfplatform.h
+++ b/bfsdk/include/bfplatform.h
@@ -25,6 +25,7 @@
 #define BFPLATFORM_H
 
 #include <bftypes.h>
+#include <bfsupport.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -187,6 +188,30 @@ int64_t platform_get_current_cpu_num(void);
  * @ensures none
  */
 void platform_restore_preemption(void);
+
+/**
+ * Get platform-specific information for the VMM
+ *
+ * Populate a struct with platform-specific information that is to be passed
+ * from bfdriver to bfvmm at initialization.
+ *
+ * @expects none
+ * @ensures none
+ *
+ * @return BF_SUCCESS or an error code on failure
+ */
+int64_t platform_populate_info(struct platform_info_t *info);
+
+/**
+ * Unload platform-specific information after the VMM is unloaded.
+ *
+ * @expects none
+ * @ensures none
+ *
+ * @param info platform-specific info struct previously populated by
+ *             platform_populate_info()
+ */
+void platform_unload_info(struct platform_info_t *info);
 
 #ifdef __cplusplus
 }

--- a/bfsdk/include/bfsupport.h
+++ b/bfsdk/include/bfsupport.h
@@ -24,9 +24,14 @@
 #ifndef BFSUPPORT_H
 #define BFSUPPORT_H
 
+#include <bfarch.h>
 #include <bftypes.h>
 #include <bfconstants.h>
 #include <bferrorcodes.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @struct section_info_t
@@ -101,6 +106,21 @@ struct section_info_t {
 };
 
 /**
+ * @struct platform_info_t
+ *
+ * Provides platform-specific information to be passed into the VMM from
+ * bfdriver. Definition of this struct varies based on build target.
+ */
+struct platform_info_t {
+    bool initialized;
+
+#if defined(BF_AARCH64)
+    /// Address of serial peripheral within kernel space
+    uintptr_t serial_address;
+#endif
+};
+
+/**
  * @struct crt_info_t
  *
  * Provides information for executing an application including section
@@ -130,6 +150,8 @@ struct section_info_t {
  *     (optional) vcpuid the executable is running on
  * @var crt_info_t::program_break
  *     (optional) the executable's program break
+ * @var crt_info_t::platform_info
+ *     platform-specific information from bfdriver
  */
 struct crt_info_t {
 
@@ -149,6 +171,8 @@ struct crt_info_t {
     uintptr_t func;
     uintptr_t vcpuid;
     uintptr_t program_break;
+
+    struct platform_info_t platform_info;
 };
 
 /**
@@ -180,6 +204,20 @@ struct crt_info_t {
 using _start_t = int64_t (*)(char *stack, const struct crt_info_t *);
 #else
 typedef int64_t (*_start_t)(char *stack, const struct crt_info_t *);
+#endif
+
+/**
+ * get_platform_info
+ *
+ * Returns a pointer to a populated platform_info_t. Returns nullptr if the
+ * platform info was never received from the driver - this will not happen
+ * except in the case of a driver bug.
+ */
+struct platform_info_t *
+get_platform_info(void);
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif

--- a/bfvmm/include/debug/serial/serial_port_ns16550a.h
+++ b/bfvmm/include/debug/serial/serial_port_ns16550a.h
@@ -159,14 +159,21 @@ public:
 
 public:
 
-    /// Default Constructor
+    /// Default constructor - uses the default port
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    serial_port_ns16550a() noexcept;
+
+    /// Specific constructor - accepts a target port address
     ///
     /// @expects none
     /// @ensures none
     ///
     /// @param port the serial port to connect to
     ///
-    serial_port_ns16550a(port_type port = DEFAULT_COM_PORT) noexcept;
+    serial_port_ns16550a(port_type port) noexcept;
 
     /// Destructor
     ///
@@ -320,7 +327,7 @@ private:
 
     bool get_line_status_empty_transmitter() const noexcept;
 
-private:
+    void init(port_type port) noexcept;
 
     port_type m_port;
 

--- a/bfvmm/include/debug/serial/serial_port_pl011.h
+++ b/bfvmm/include/debug/serial/serial_port_pl011.h
@@ -229,14 +229,20 @@ public:
 
 public:
 
-    /// Default Constructor
+    /// Default constructor - uses the default port
     ///
+    /// @expects none
+    /// @ensures none
+    ///
+    serial_port_pl011() noexcept;
+
+    /// Specific constructor - accepts a target port address
     /// @expects none
     /// @ensures none
     ///
     /// @param port the serial port to connect to
     ///
-    serial_port_pl011(port_type port = DEFAULT_COM_PORT) noexcept;
+    serial_port_pl011(port_type port) noexcept;
 
     /// Destructor
     ///
@@ -382,7 +388,7 @@ private:
 
     bool get_status_full_transmitter() const noexcept;
 
-private:
+    void init(port_type port) noexcept;
 
     port_type m_port;
 

--- a/bfvmm/src/debug/serial/serial_port_ns16550a.cpp
+++ b/bfvmm/src/debug/serial/serial_port_ns16550a.cpp
@@ -17,6 +17,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfgsl.h>
+#include <bfarch.h>
+#include <bfsupport.h>
 #include <debug/serial/serial_port_ns16550a.h>
 
 namespace bfvmm
@@ -24,9 +26,28 @@ namespace bfvmm
 
 using namespace serial_ns16550a;
 
-serial_port_ns16550a::serial_port_ns16550a(serial_port_ns16550a::port_type port) noexcept :
-    m_port(port)
+serial_port_ns16550a::serial_port_ns16550a() noexcept
 {
+#ifdef BF_AARCH64
+    auto platform_info = get_platform_info();
+    auto port = platform_info
+        ? reinterpret_cast<port_type>(platform_info->serial_address)
+        : DEFAULT_COM_PORT;
+    init(port);
+#else
+    init(DEFAULT_COM_PORT);
+#endif
+}
+
+serial_port_ns16550a::serial_port_ns16550a(serial_port_ns16550a::port_type port) noexcept
+{
+    init(port);
+}
+
+void serial_port_ns16550a::init(serial_port_ns16550a::port_type port) noexcept
+{
+    m_port = port;
+
     value_type_8 bits = 0;
 
     this->disable_dlab();

--- a/bfvmm/src/debug/serial/serial_port_pl011.cpp
+++ b/bfvmm/src/debug/serial/serial_port_pl011.cpp
@@ -17,6 +17,8 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfgsl.h>
+#include <bfarch.h>
+#include <bfsupport.h>
 #include <debug/serial/serial_port_pl011.h>
 
 namespace bfvmm
@@ -24,9 +26,29 @@ namespace bfvmm
 
 using namespace serial_pl011;
 
+serial_port_pl011::serial_port_pl011() noexcept
+{
+#ifdef BF_AARCH64
+    auto platform_info = get_platform_info();
+    auto port = platform_info
+        ? reinterpret_cast<port_type>(platform_info->serial_address)
+        : DEFAULT_COM_PORT;
+    init(port);
+#else
+    init(DEFAULT_COM_PORT);
+#endif
+}
+
 serial_port_pl011::serial_port_pl011(serial_port_pl011::port_type port) noexcept :
     m_port(port)
 {
+    init(port);
+}
+
+void serial_port_pl011::init(serial_port_pl011::port_type port) noexcept
+{
+    m_port = port;
+
     auto bits = offset_ind(uartlcr_h_reg);
 
     bits |= uartlcr_h_fifo_enable;

--- a/bfvmm/src/debug/unistd.cpp
+++ b/bfvmm/src/debug/unistd.cpp
@@ -21,6 +21,7 @@
 
 #include <debug/debug_ring/debug_ring.h>
 #include <debug/serial/serial_port_ns16550a.h>
+#include <debug/serial/serial_port_pl011.h>
 
 #include <mutex>
 std::mutex g_write_mutex;
@@ -43,7 +44,7 @@ write_str(const std::string &str)
         std::lock_guard<std::mutex> guard(g_write_mutex);
 
         g_debug_ring()->write(str);
-        bfvmm::serial_port_ns16550a::instance()->write(str);
+        bfvmm::DEFAULT_COM_DRIVER::instance()->write(str);
 
         return str.length();
     }


### PR DESCRIPTION
`platform_info_t` is used to pass platform-specific information from the kernel into the vmm. On aarch64, this is used to map the serial peripheral and pass the resulting virtual address.

Closes #527.

It is possible we may want to restructure the small section of code in `platform.c`, which is currently implemented using `ifdef`; we could of course pull this out into `arch/intel_x64/platform.c` and `arch/aarch64/platform.c` or something - let me know if you want me to make changes.