### PR TITLE
Redownload on Error

### DIFF
--- a/scripts/cmake/depends/clang_tidy.cmake
+++ b/scripts/cmake/depends/clang_tidy.cmake
@@ -17,12 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 if(ENABLE_TIDY)
-    message(STATUS "Including dependency: clang-tidy")
-
     if(NOT CLANG_TIDY_BIN)
         find_program(CLANG_TIDY_BIN clang-tidy-4.0)
 
         if(NOT CLANG_TIDY_BIN)
+            message(STATUS "Including dependency: clang-tidy")
             message(STATUS "*** FATAL ERROR: Clang Tidy 4.0 was not found. To Fix:")
             message(STATUS "  - install clang-tidy-4.0 or")
             message(STATUS "  - ln -s /usr/bin/clang-tidy /usr/bin/clang-tidy-4.0")

--- a/scripts/cmake/depends/python.cmake
+++ b/scripts/cmake/depends/python.cmake
@@ -17,12 +17,11 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 if(ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST AND NOT WIN32)
-    message(STATUS "Including dependency: python")
-
     if(NOT PYTHON_BIN)
         find_program(PYTHON_BIN python)
 
         if(NOT PYTHON_BIN)
+            message(STATUS "Including dependency: python")
             message(FATAL_ERROR "Unable to find: python")
         endif()
     endif()


### PR DESCRIPTION
This patch adds a redownload on error feature to the dependency macro.
If an error occurs, the macro attempts to redownload the file 5 times
before erroring outRedownload on Error

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/611

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>