### PR TITLE
Add support for unordered_map

### DIFF
--- a/scripts/cmake/depends/newlib.cmake
+++ b/scripts/cmake/depends/newlib.cmake
@@ -97,6 +97,13 @@ if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
         COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${AR_FOR_TARGET} x libc.a"
         COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${LD_FOR_TARGET} -shared -o ${VMM_PREFIX_PATH}/lib/libc.so ${CMAKE_BINARY_DIR}/tmp/*.o ${LD_FLAGS}"
         COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tmp"
+
+        COMMAND eval "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/tmp"
+        COMMAND eval "${CMAKE_COMMAND} -E copy_if_different ${VMM_PREFIX_PATH}/lib/libm.a ${CMAKE_BINARY_DIR}/tmp"
+        COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${AR_FOR_TARGET} x libm.a"
+        COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${LD_FOR_TARGET} -shared -o ${VMM_PREFIX_PATH}/lib/libm.so ${CMAKE_BINARY_DIR}/tmp/*.o ${LD_FLAGS}"
+        COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tmp"
+
         COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${PREFIXES_DIR}/share"
     )
 endif()

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -1171,6 +1171,7 @@ function(add_vmm_executable NAME)
             ${CMAKE_INSTALL_PREFIX}/lib/libbfpthread_shared.so
             ${CMAKE_INSTALL_PREFIX}/lib/libbfunwind_shared.so
             ${CMAKE_INSTALL_PREFIX}/lib/libc.so
+            ${CMAKE_INSTALL_PREFIX}/lib/libm.so
             --whole-archive ${CMAKE_INSTALL_PREFIX}/lib/libbfcrt_static.a --no-whole-archive
             ${CMAKE_INSTALL_PREFIX}/lib/libbfsyscall_shared.so
         )
@@ -1205,6 +1206,7 @@ function(add_vmm_executable NAME)
             ${CMAKE_INSTALL_PREFIX}/lib/libbfpthread_static.a
             ${CMAKE_INSTALL_PREFIX}/lib/libbfunwind_static.a
             ${CMAKE_INSTALL_PREFIX}/lib/libc.a
+            ${CMAKE_INSTALL_PREFIX}/lib/libm.a
             --whole-archive ${CMAKE_INSTALL_PREFIX}/lib/libbfcrt_static.a --no-whole-archive
             ${CMAKE_INSTALL_PREFIX}/lib/libbfsyscall_static.a
         )


### PR DESCRIPTION
This patch adds support for unordered_map. Specifically it adds support
for libm which is needed by unordered_map as it abuses the ceil
function for integer rounding in it's hash function.

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>