### PR TITLE
Delegate and KVM bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bfdriver/src/.common.o.cmd
 bfdriver/src/platform/linux/.bareflank.ko.cmd
 bfdriver/src/platform/linux/.bareflank.mod.o.cmd
 bfdriver/src/platform/linux/.bareflank.o.cmd
+bfdriver/src/platform/linux/.cache.mk
 bfdriver/src/platform/linux/.entry.o.cmd
 bfdriver/src/platform/linux/.platform.o.cmd
 bfdriver/src/platform/linux/.tmp_versions/

--- a/bfsdk/include/bfdelegate.h
+++ b/bfsdk/include/bfdelegate.h
@@ -78,7 +78,7 @@ public:
     /// @return true if valid, false otherwise
     ///
     constexpr bool is_valid() const noexcept
-    { return m_stub != nullptr; }
+    { return m_stub != nullptr && m_obj != nullptr; }
 
     /// Is Valid
     ///

--- a/bfsdk/tests/test_delegate.cpp
+++ b/bfsdk/tests/test_delegate.cpp
@@ -70,6 +70,14 @@ TEST_CASE("segfault cases")
     // d1(1);
 }
 
+TEST_CASE("create from nullptr")
+{
+    delegate<int(int)> d0 = delegate<int(int)>::create<nullptr>();
+
+    CHECK(!d0);
+    CHECK(!d0.is_valid());
+}
+
 TEST_CASE("is valid")
 {
     delegate<int(int)> d0;


### PR DESCRIPTION
* `delegate::is_valid` now compares `m_obj != nullptr` in addition to `m_stub != nullptr`. This allows         users to use 

  ```cpp
  auto d = delegate<FOO>::create<nullptr>();
  ```
  to initialize invalid delegates. Without the `m_obj check`, the delegate is created and `is_valid()` but   still has a nullptr `m_obj`

* Created a `bfvmm::intel_x64::kvm_guest` namespace that contains alternative rdmsr and wrmsr handlers that is specific to running as an L1 KVM guest. The choice between the original and alternative is made in the exit handler constructor. I figured this was better than checking for the KVM case on every exit in the original handlers themselves.

If any has any ideas or feedback on how to handle these situations that would be great

