### PR TITLE
Add support for unordered_map

### DIFF
--- a/bfelf_loader/tests/test_load.cpp
+++ b/bfelf_loader/tests/test_load.cpp
@@ -151,10 +151,10 @@ TEST_CASE("bfelf_load: success")
     void *entry = nullptr;
     crt_info_t info = {};
     bfelf_loader_t loader = {};
-    bfelf_binary_t binaries[9] = {};
+    bfelf_binary_t binaries[10] = {};
 
     std::list<bfn::buffer> files;
-    for (auto i = 0ULL; i < 9; i++) {
+    for (auto i = 0ULL; i < 10; i++) {
         auto file = g_file.read_binary(g_filenames.at(i));
 
         gsl::at(binaries, i).file = file.data();
@@ -163,6 +163,6 @@ TEST_CASE("bfelf_load: success")
         files.emplace_back(std::move(file));
     }
 
-    auto ret = bfelf_load(reinterpret_cast<bfelf_binary_t *>(binaries), 9, &entry, &info, &loader);
+    auto ret = bfelf_load(reinterpret_cast<bfelf_binary_t *>(binaries), 10, &entry, &info, &loader);
     CHECK(ret == BF_SUCCESS);
 }

--- a/bfelf_loader/tests/test_real_elf.cpp
+++ b/bfelf_loader/tests/test_real_elf.cpp
@@ -31,9 +31,10 @@
 std::vector<std::string> g_filenames = {
     VMM_PREFIX_PATH + "/lib/libdummy_lib1_shared.so"_s,
     VMM_PREFIX_PATH + "/lib/libdummy_lib2_shared.so"_s,
-    VMM_PREFIX_PATH + "/lib/libc.so"_s,
     VMM_PREFIX_PATH + "/lib/libc++.so.1.0"_s,
     VMM_PREFIX_PATH + "/lib/libc++abi.so"_s,
+    VMM_PREFIX_PATH + "/lib/libc.so"_s,
+    VMM_PREFIX_PATH + "/lib/libm.so"_s,
     VMM_PREFIX_PATH + "/lib/libbfpthread_shared.so"_s,
     VMM_PREFIX_PATH + "/lib/libbfsyscall_shared.so"_s,
     VMM_PREFIX_PATH + "/lib/libbfunwind_shared.so"_s,

--- a/bfruntime/src/syscall/syscall.cpp
+++ b/bfruntime/src/syscall/syscall.cpp
@@ -397,6 +397,32 @@ __stack_chk_fail(void) noexcept
     abort();
 }
 
+extern "C" EXPORT_SYM float
+__mulsc3(float a, float b, float c, float d)
+{
+    bfignored(a);
+    bfignored(b);
+    bfignored(c);
+    bfignored(d);
+
+    UNHANDLED();
+
+    return 0;
+}
+
+extern "C" EXPORT_SYM double
+__muldc3(double a, double b, double c, double d)
+{
+    bfignored(a);
+    bfignored(b);
+    bfignored(c);
+    bfignored(d);
+
+    UNHANDLED();
+
+    return 0;
+}
+
 EXPORT_SYM int __g_eh_frame_list_num = 0;
 EXPORT_SYM eh_frame_t __g_eh_frame_list[MAX_NUM_MODULES] = {};
 EXPORT_SYM int __g_dwarf_sections_num = 0;

--- a/scripts/cmake/depends/newlib.cmake
+++ b/scripts/cmake/depends/newlib.cmake
@@ -97,6 +97,13 @@ if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
         COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${AR_FOR_TARGET} x libc.a"
         COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${LD_FOR_TARGET} -shared -o ${VMM_PREFIX_PATH}/lib/libc.so ${CMAKE_BINARY_DIR}/tmp/*.o ${LD_FLAGS}"
         COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tmp"
+
+        COMMAND eval "${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/tmp"
+        COMMAND eval "${CMAKE_COMMAND} -E copy_if_different ${VMM_PREFIX_PATH}/lib/libm.a ${CMAKE_BINARY_DIR}/tmp"
+        COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${AR_FOR_TARGET} x libm.a"
+        COMMAND eval "${CMAKE_COMMAND} -E chdir ${CMAKE_BINARY_DIR}/tmp ${LD_FOR_TARGET} -shared -o ${VMM_PREFIX_PATH}/lib/libm.so ${CMAKE_BINARY_DIR}/tmp/*.o ${LD_FLAGS}"
+        COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${CMAKE_BINARY_DIR}/tmp"
+
         COMMAND eval "${CMAKE_COMMAND} -E remove_directory ${PREFIXES_DIR}/share"
     )
 endif()

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -1171,6 +1171,7 @@ function(add_vmm_executable NAME)
             ${CMAKE_INSTALL_PREFIX}/lib/libbfpthread_shared.so
             ${CMAKE_INSTALL_PREFIX}/lib/libbfunwind_shared.so
             ${CMAKE_INSTALL_PREFIX}/lib/libc.so
+            ${CMAKE_INSTALL_PREFIX}/lib/libm.so
             --whole-archive ${CMAKE_INSTALL_PREFIX}/lib/libbfcrt_static.a --no-whole-archive
             ${CMAKE_INSTALL_PREFIX}/lib/libbfsyscall_shared.so
         )
@@ -1205,6 +1206,7 @@ function(add_vmm_executable NAME)
             ${CMAKE_INSTALL_PREFIX}/lib/libbfpthread_static.a
             ${CMAKE_INSTALL_PREFIX}/lib/libbfunwind_static.a
             ${CMAKE_INSTALL_PREFIX}/lib/libc.a
+            ${CMAKE_INSTALL_PREFIX}/lib/libm.a
             --whole-archive ${CMAKE_INSTALL_PREFIX}/lib/libbfcrt_static.a --no-whole-archive
             ${CMAKE_INSTALL_PREFIX}/lib/libbfsyscall_static.a
         )


### PR DESCRIPTION
This patch adds support for unordered_map. Specifically it adds support
for libm which is needed by unordered_map as it abuses the ceil
function for integer rounding in it's hash function.

Signed-off-by: “rianquinn” <“rianquinn@gmail.com”>