### PR TITLE
use https instead of http to download binutils.

### DIFF
--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -692,7 +692,7 @@ add_config(
 add_config(
     CONFIG_NAME BINUTILS_URL
     CONFIG_TYPE STRING
-    DEFAULT_VAL "http://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.gz"
+    DEFAULT_VAL "https://ftp.gnu.org/gnu/binutils/binutils-2.28.tar.gz"
     DESCRIPTION "Binutils URL"
 )
 


### PR DESCRIPTION
Some proxies(like the one we have at my university) could block user agent like `wget` and `curl` for
security reasons. So When you use https, the entire connection is
encrypted and authenticated, so such in-between boxes can't see what
is inside.

Signed-off-by: "Manohar Reddy" <"201451024@iiitvadodara.ac.in">