### PR TITLE
Fix Deadlock Issue

### DIFF
--- a/bfsdk/include/bfgsl.h
+++ b/bfsdk/include/bfgsl.h
@@ -36,7 +36,34 @@
 /// @endcond
 
 #ifndef NEED_GSL_LITE
+
 #include <gsl/gsl>
+
+namespace gsl
+{
+
+/// Memset
+///
+/// Same as std::memset, but for spans
+///
+/// @param dst The span to memset
+/// @param val The value to set the span to
+/// @return Returns dst
+///
+template<class DstElementType, std::ptrdiff_t DstExtent, class T>
+auto memset(span<DstElementType, DstExtent> dst, T val)
+{
+    expects(dst.size() > 0);
+
+    return std::memset(
+        dst.data(),
+        static_cast<int>(val),
+        static_cast<std::size_t>(dst.size())
+    );
+}
+
+}
+
 #else
 
 #ifdef NEED_STD_LITE

--- a/bfvmm/include/vcpu/arch/intel_x64/vcpu.h
+++ b/bfvmm/include/vcpu/arch/intel_x64/vcpu.h
@@ -59,6 +59,10 @@ public:
         this->add_run_delegate(
             run_delegate_t::create<intel_x64::vcpu, &intel_x64::vcpu::run_delegate>(this)
         );
+
+        this->add_hlt_delegate(
+            hlt_delegate_t::create<intel_x64::vcpu, &intel_x64::vcpu::hlt_delegate>(this)
+        );
     }
 
     /// Destructor
@@ -85,6 +89,23 @@ public:
 
         m_vmcs->load();
         m_vmcs->launch();
+
+        ::x64::cpuid::get(0xBF01, 0, 0, 0);
+    }
+
+    /// Halt Delegate
+    ///
+    /// Provides the base implementation for stopping the vCPU.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param obj ignored
+    ///
+    void hlt_delegate(bfobject *obj)
+    {
+        bfignored(obj);
+        ::x64::cpuid::get(0xBF00, 0, 0, 0);
     }
 
     /// Get VMCS

--- a/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -190,6 +190,16 @@ emulate_wrmsr(::x64::msrs::field_type msr, ::x64::msrs::value_type val)
 static bool
 handle_cpuid(gsl::not_null<bfvmm::intel_x64::vmcs *> vmcs)
 {
+    if (vmcs->save_state()->rax == 0xBF01) {
+        bfdebug_info(0, "host os is" bfcolor_green " now " bfcolor_end "in a vm");
+        return advance(vmcs);
+    }
+
+    if (vmcs->save_state()->rax == 0xBF00) {
+        bfdebug_info(0, "host os is" bfcolor_red " not " bfcolor_end "in a vm");
+        return advance(vmcs);
+    }
+
     auto ret =
         ::x64::cpuid::get(
             gsl::narrow_cast<::x64::cpuid::field_type>(vmcs->save_state()->rax),

--- a/bfvmm/src/vcpu/vcpu.cpp
+++ b/bfvmm/src/vcpu/vcpu.cpp
@@ -40,10 +40,6 @@ vcpu::run(bfobject *data)
     }
 
     m_is_running = true;
-
-    if (this->is_host_vm_vcpu()) {
-        bfdebug_info(0, "host os is" bfcolor_green " now " bfcolor_end "in a vm");
-    }
 }
 
 void
@@ -54,10 +50,6 @@ vcpu::hlt(bfobject *data)
     }
 
     m_is_running = false;
-
-    if (this->is_host_vm_vcpu()) {
-        bfdebug_info(0, "host os is" bfcolor_red " not " bfcolor_end "in a vm");
-    }
 }
 
 void

--- a/bfvmm/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/exit_handler/test_exit_handler.cpp
@@ -136,6 +136,32 @@ TEST_CASE("exit_handler: handle_cpuid")
     CHECK(g_save_state.rip != 0);
 }
 
+TEST_CASE("exit_handler: handle_cpuid start")
+{
+    MockRepository mocks;
+    auto &&vmcs = setup_vmcs(mocks, ::intel_x64::vmcs::exit_reason::basic_exit_reason::cpuid);
+    auto &&ehlr = bfvmm::intel_x64::exit_handler{vmcs};
+
+    g_save_state.rax = 0xBF01;
+    g_save_state.rip = 0;
+
+    CHECK_NOTHROW(ehlr.handle(&ehlr));
+    CHECK(g_save_state.rip != 0);
+}
+
+TEST_CASE("exit_handler: handle_cpuid stop")
+{
+    MockRepository mocks;
+    auto &&vmcs = setup_vmcs(mocks, ::intel_x64::vmcs::exit_reason::basic_exit_reason::cpuid);
+    auto &&ehlr = bfvmm::intel_x64::exit_handler{vmcs};
+
+    g_save_state.rax = 0xBF00;
+    g_save_state.rip = 0;
+
+    CHECK_NOTHROW(ehlr.handle(&ehlr));
+    CHECK(g_save_state.rip != 0);
+}
+
 TEST_CASE("exit_handler: handle_invd")
 {
     MockRepository mocks;


### PR DESCRIPTION
If the VM got a VMExit at the same time that it was trying to exit out
of the init process, deadlock would occur as printing to the console was
happening twice on the same CPU. This patch fixes this by moving the
console feedback to the CPUID instruction. v1.1 did something similar
using VMCall, but using CPUID prevents issues with VMCall casuing the
driver to explode when the hypervisor has not started properly, and
removes the need for the base hypervisor to implement VMcall.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/640

Signed-off-by: Rian Quinn <rianquinn@gmail.com>