### PR TITLE
Move Intel-specific vcpu code to hve

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/vcpu/vcpu.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu/vcpu.h
@@ -19,11 +19,31 @@
 #ifndef VCPU_INTEL_X64_H
 #define VCPU_INTEL_X64_H
 
-#include "../../vcpu_factory.h"
+#include "../exit_handler/exit_handler.h"
+#include "../vmx/vmx.h"
+#include "../vmcs/vmcs.h"
+#include "../../../../vcpu/vcpu.h"
 
-#include "../../../hve/arch/intel_x64/vmx/vmx.h"
-#include "../../../hve/arch/intel_x64/vmcs/vmcs.h"
-#include "../../../hve/arch/intel_x64/exit_handler/exit_handler.h"
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+#include <bfexports.h>
+
+#ifndef STATIC_HVE
+#ifdef SHARED_HVE
+#define EXPORT_HVE EXPORT_SYM
+#else
+#define EXPORT_HVE IMPORT_SYM
+#endif
+#else
+#define EXPORT_HVE
+#endif
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4251)
+#endif
 
 namespace bfvmm
 {
@@ -35,8 +55,9 @@ namespace intel_x64
 /// This class provides the base implementation for an Intel based vCPU. For
 /// more information on how a vCPU works, please @see bfvmm::vcpu
 ///
-class vcpu : public bfvmm::vcpu
+class EXPORT_HVE vcpu : public bfvmm::vcpu
 {
+
 public:
 
     /// Default Constructor
@@ -115,7 +136,7 @@ public:
     ///
     /// @return Returns a pointer to the vCPU's VMCS
     ///
-    auto vmcs() const noexcept
+    bfvmm::intel_x64::vmcs *vmcs()
     { return m_vmcs.get(); }
 
     /// Get Exit Handler
@@ -125,7 +146,7 @@ public:
     ///
     /// @return Returns a pointer to the vCPU's exit handler
     ///
-    auto exit_handler() const noexcept
+    bfvmm::intel_x64::exit_handler *exit_handler()
     { return m_exit_handler.get(); }
 
 private:
@@ -137,5 +158,9 @@ private:
 
 }
 }
+
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #endif

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -21,17 +21,17 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/check/check_vmcs_control_fields.cpp
         arch/intel_x64/check/check_vmcs_guest_fields.cpp
         arch/intel_x64/check/check_vmcs_host_fields.cpp
-        arch/intel_x64/vmx/vmx.cpp
-        arch/intel_x64/vmcs/vmcs.cpp
         arch/intel_x64/exit_handler/exit_handler.cpp
+        arch/intel_x64/vmcs/vmcs.cpp
+        arch/intel_x64/vmx/vmx.cpp
     )
 
     if(NOT WIN32 AND NOT ENABLE_MOCKING)
         list(APPEND SOURCES
+            arch/intel_x64/exit_handler/exit_handler_entry.asm
             arch/intel_x64/vmcs/vmcs_launch.asm
             arch/intel_x64/vmcs/vmcs_promote.asm
             arch/intel_x64/vmcs/vmcs_resume.asm
-            arch/intel_x64/exit_handler/exit_handler_entry.asm
         )
     endif()
 elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")

--- a/bfvmm/src/main/arch/intel_x64/vcpu_factory.cpp
+++ b/bfvmm/src/main/arch/intel_x64/vcpu_factory.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <bfvmm/vcpu/vcpu_factory.h>
-#include <bfvmm/vcpu/arch/intel_x64/vcpu.h>
+#include <bfvmm/hve/arch/intel_x64/vcpu/vcpu.h>
 
 namespace bfvmm
 {


### PR DESCRIPTION
Downstream projects like the extended APIs need a stable interface. To
facilitate this, the existing interface will be changed to pass a single
vcpu pointer to client code. Any state or functionality needed by
extensions will be reachable from the vcpu pointer.

This design requires forward declarations of the vcpu class, resulting
in circular references. While this works on Linux, Windows does not
allow inter-dll circular references.  The workaround is to place the
API's vcpu code into hve.

Move the Intel-specific vcpu code to hve to remain consistent
with the extended APIs.