### PR TITLE
x64/hve: Fix KVM and promote bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ bfdriver/src/.common.o.cmd
 bfdriver/src/platform/linux/.bareflank.ko.cmd
 bfdriver/src/platform/linux/.bareflank.mod.o.cmd
 bfdriver/src/platform/linux/.bareflank.o.cmd
+bfdriver/src/platform/linux/.cache.mk
 bfdriver/src/platform/linux/.entry.o.cmd
 bfdriver/src/platform/linux/.platform.o.cmd
 bfdriver/src/platform/linux/.tmp_versions/

--- a/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler.h
+++ b/bfvmm/include/hve/arch/intel_x64/exit_handler/exit_handler.h
@@ -153,6 +153,36 @@ public:
     static void handle(
         bfvmm::intel_x64::exit_handler *exit_handler) noexcept;
 
+    /// Get Host TSS
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return Returns a pointer to the host_tss
+    ///
+    auto host_tss() noexcept
+    { return &m_host_tss; }
+
+    /// Get Host IDT
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return Returns a pointer to the host_idt
+    ///
+    auto host_idt() noexcept
+    { return &m_host_idt; }
+
+    /// Get Host GDT
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @return Returns a pointer to the host_gdt
+    ///
+    auto host_gdt() noexcept
+    { return &m_host_gdt; }
+
 private:
 
     void write_host_state();

--- a/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -98,7 +98,7 @@ emulate_rdmsr(::x64::msrs::field_type msr)
             return ::intel_x64::vmcs::guest_ia32_efer::get();
 
         case ::intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            return ::intel_x64::vmcs::guest_ia32_perf_global_ctrl::get();
+            return ::intel_x64::vmcs::guest_ia32_perf_global_ctrl::get_if_exists();
 
         case ::intel_x64::msrs::ia32_sysenter_cs::addr:
             return ::intel_x64::vmcs::guest_ia32_sysenter_cs::get();
@@ -154,7 +154,7 @@ emulate_wrmsr(::x64::msrs::field_type msr, ::x64::msrs::value_type val)
             return;
 
         case ::intel_x64::msrs::ia32_perf_global_ctrl::addr:
-            ::intel_x64::vmcs::guest_ia32_perf_global_ctrl::set(val);
+            ::intel_x64::vmcs::guest_ia32_perf_global_ctrl::set_if_exists(val);
             return;
 
         case ::intel_x64::msrs::ia32_sysenter_cs::addr:
@@ -434,7 +434,7 @@ exit_handler::write_guest_state()
     guest_ia32_efer::set(::intel_x64::msrs::ia32_efer::get());
 
     if (::intel_x64::cpuid::arch_perf_monitoring::eax::version_id::get() >= 2) {
-        guest_ia32_perf_global_ctrl::set(::intel_x64::msrs::ia32_perf_global_ctrl::get());
+        guest_ia32_perf_global_ctrl::set_if_exists(::intel_x64::msrs::ia32_perf_global_ctrl::get());
     }
 
     guest_gdtr_limit::set(guest_gdt.limit());
@@ -531,7 +531,7 @@ exit_handler::write_control_state()
 
     vm_exit_controls::save_debug_controls::enable();
     vm_exit_controls::host_address_space_size::enable();
-    vm_exit_controls::load_ia32_perf_global_ctrl::enable();
+    vm_exit_controls::load_ia32_perf_global_ctrl::enable_if_allowed();
     vm_exit_controls::save_ia32_pat::enable();
     vm_exit_controls::load_ia32_pat::enable();
     vm_exit_controls::save_ia32_efer::enable();
@@ -539,7 +539,7 @@ exit_handler::write_control_state()
 
     vm_entry_controls::load_debug_controls::enable();
     vm_entry_controls::ia_32e_mode_guest::enable();
-    vm_entry_controls::load_ia32_perf_global_ctrl::enable();
+    vm_entry_controls::load_ia32_perf_global_ctrl::enable_if_allowed();
     vm_entry_controls::load_ia32_pat::enable();
     vm_entry_controls::load_ia32_efer::enable();
 }

--- a/bfvmm/src/hve/arch/intel_x64/vmcs/vmcs_promote.asm
+++ b/bfvmm/src/hve/arch/intel_x64/vmcs/vmcs_promote.asm
@@ -78,6 +78,7 @@ extern _write_idt
 extern _write_cr0
 extern _write_cr3
 extern _write_cr4
+extern _write_cr8
 extern _write_dr7
 
 extern _cpuid_eax
@@ -96,6 +97,7 @@ section .text
 ;
 vmcs_promote:
 
+    cli
     mov r15, rdi
     mov r14, rsi
 
@@ -103,7 +105,7 @@ vmcs_promote:
     ; Clear TSS Busy
     ;
     ; rsi contains the virtual address of the guest's GDT mapped r/w
-    ; in the VMM's address space (see exit_handler_intel_x64::handle_vmxoff)
+    ; in the VMM's address space (see handle_vmxoff)
     ;
 
     mov rdi, rsi
@@ -201,6 +203,9 @@ vmcs_promote:
 
     pop rdi
     call _write_cr3 wrt ..plt
+
+    mov rdi, 0x0
+    call _write_cr8 wrt ..plt
 
     mov rsi, VMCS_GUEST_DR7
     vmread rdi, rsi


### PR DESCRIPTION
exit_handler.cpp:
KVM does not allow the "load IA32_PERF_GLOBAL_CTRL" to be set to 1 in
both the vm-exit and vm-entry controls. This prevents the vmcs field
guest_ia32_perf_global_ctrl from existing, so reads and writes
to it (e.g. handle_rdmsr and handlr_wrmsr in exit_handler.cpp) cause an
exception to be raised by Bareflank.

- Modify the bfvmm's exit_handler private functions to only enable the
  entry/exit control if it is allowed to be set to 1.

- Read/write from the guest_ia32_perf_global_ctrl vmcs field only if it
  exists.

vmcs_promote.asm:
Restore host cr8 on promote