### PR TITLE
Add save_state and bitmanip changes for the VIC

### DIFF
--- a/bfsdk/include/bfbitmanip.h
+++ b/bfsdk/include/bfbitmanip.h
@@ -45,7 +45,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 set_bit(T t, B b) noexcept
 {
     return t | (0x1ULL << b);
@@ -68,7 +68,7 @@ template <
     typename = std::enable_if<std::is_pointer<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 set_bit(gsl::span<T> &view, B b)
 {
     auto byte_view = gsl::as_writeable_bytes(view);
@@ -92,7 +92,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 clear_bit(T t, B b) noexcept
 {
     return t & ~(0x1ULL << b);
@@ -115,7 +115,7 @@ template <
     typename = std::enable_if<std::is_pointer<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 clear_bit(gsl::span<T> &view, B b)
 {
     auto byte_view = gsl::as_writeable_bytes(view);
@@ -137,7 +137,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 get_bit(T t, B b) noexcept
 {
     return (t & (0x1ULL << b)) >> b;
@@ -158,7 +158,7 @@ template <
     typename = std::enable_if<std::is_pointer<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 get_bit(const gsl::span<T> &view, B b)
 {
     auto byte_view = gsl::as_writeable_bytes(view);
@@ -180,7 +180,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 is_bit_set(T t, B b) noexcept
 {
     return static_cast<uint64_t>(get_bit(t, b)) != static_cast<uint64_t>(0);
@@ -201,7 +201,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<B>::value>
     >
-auto
+constexpr auto
 is_bit_cleared(T t, B b) noexcept
 {
     return static_cast<uint64_t>(get_bit(t, b)) == static_cast<uint64_t>(0);
@@ -241,7 +241,7 @@ template <
     typename = std::enable_if<std::is_integral<T>::value>,
     typename = std::enable_if<std::is_integral<M>::value>
     >
-auto
+constexpr auto
 get_bits(T t, M m) noexcept
 {
     return t & m;
@@ -265,7 +265,7 @@ template <
     typename = std::enable_if<std::is_integral<M>::value>,
     typename = std::enable_if<std::is_integral<V>::value>
     >
-auto
+constexpr auto
 set_bits(T t, M m, V v) noexcept
 {
     return (t & ~m) | (v & m);

--- a/bfvmm/include/hve/arch/intel_x64/save_state.h
+++ b/bfvmm/include/hve/arch/intel_x64/save_state.h
@@ -48,7 +48,7 @@ struct save_state_t {
     uint64_t rip;                   // 0x078
     uint64_t rsp;                   // 0x080
 
-    uint64_t reserved1;             // 0x088
+    uint64_t vic_ptr;               // 0x088
     uint64_t reserved2;             // 0x090
     uint64_t vcpuid;                // 0x098
     uint64_t exit_handler_ptr;      // 0x0A0


### PR DESCRIPTION
- Replaces a reserved field in the save_state with an entry
  for the VIC from the extended APIs
- Mark bitmanip functions as constexpr

Signed-off-by: Connor Davis <davisc@ainfosec.com>