### PR TITLE
Fix non-install of VMM headers for Test

### DIFF
--- a/bfvmm/src/CMakeLists.txt
+++ b/bfvmm/src/CMakeLists.txt
@@ -29,9 +29,3 @@ add_subdirectory(memory_manager)
 add_subdirectory(hve)
 add_subdirectory(vcpu)
 add_subdirectory(entry)
-
-# ------------------------------------------------------------------------------
-# Install
-# ------------------------------------------------------------------------------
-
-install(DIRECTORY ${CMAKE_SOURCE_DIR}/../include/ DESTINATION include/bfvmm)

--- a/bfvmm/src/debug/CMakeLists.txt
+++ b/bfvmm/src/debug/CMakeLists.txt
@@ -44,3 +44,9 @@ add_static_library(
     DEFINES STATIC_DEBUG
     DEFINES STATIC_INTRINSICS
 )
+
+# ------------------------------------------------------------------------------
+# Install
+# ------------------------------------------------------------------------------
+
+install(DIRECTORY ../../include/debug/ DESTINATION include/bfvmm/debug)

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -55,3 +55,9 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
+
+# ------------------------------------------------------------------------------
+# Install
+# ------------------------------------------------------------------------------
+
+install(DIRECTORY ../../include/hve/ DESTINATION include/bfvmm/hve)

--- a/bfvmm/src/memory_manager/CMakeLists.txt
+++ b/bfvmm/src/memory_manager/CMakeLists.txt
@@ -46,3 +46,9 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
+
+# ------------------------------------------------------------------------------
+# Install
+# ------------------------------------------------------------------------------
+
+install(DIRECTORY ../../include/memory_manager/ DESTINATION include/bfvmm/memory_manager)

--- a/bfvmm/src/vcpu/CMakeLists.txt
+++ b/bfvmm/src/vcpu/CMakeLists.txt
@@ -38,3 +38,9 @@ add_static_library(
     DEFINES STATIC_MEMORY_MANAGER
     DEFINES STATIC_INTRINSICS
 )
+
+# ------------------------------------------------------------------------------
+# Install
+# ------------------------------------------------------------------------------
+
+install(DIRECTORY ../../include/vcpu/ DESTINATION include/bfvmm/vcpu)


### PR DESCRIPTION
The VMM headers were not being installed into the test prefix becuase
the install command was not being shared between the test and vmm
prefixes. This patch fixes that.

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/651

Signed-off-by: Rian Quinn <rianquinn@gmail.com>