### PR TITLE
Buddy Allocator Part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ matrix:
     script:
       - cmake -DCONFIG=travis_format ..
       - make astyle_x86_64-userspace-elf
-      - make format
+      - make format-all
       - |
         if [[ -n $(git diff) ]]; then
           echo "You must run make format before submitting a pull request"

--- a/bfdummy/src/main/dummy_main.cpp
+++ b/bfdummy/src/main/dummy_main.cpp
@@ -77,8 +77,7 @@ main(int argc, char *argv[])
     try {
         throw std::runtime_error("test exceptions");
     }
-    catch (std::exception &)
-    {
+    catch (std::exception &) {
         auto view = gsl::make_span(argv, argc);
 
         return g_derived1.foo(gsl::narrow_cast<int>(atoi(view[0]))) +

--- a/bfelf_loader/tests/test_loader_add.cpp
+++ b/bfelf_loader/tests/test_loader_add.cpp
@@ -79,11 +79,11 @@ TEST_CASE("bfelf_loader_add: too many files")
         REQUIRE(ret == BFELF_SUCCESS);
 
         ret = bfelf_loader_add(
-            &loader,
-            &gsl::at(efs, static_cast<std::ptrdiff_t>(i)),
-            static_cast<char *>(dummy),
-            static_cast<char *>(dummy)
-        );
+                  &loader,
+                  &gsl::at(efs, static_cast<std::ptrdiff_t>(i)),
+                  static_cast<char *>(dummy),
+                  static_cast<char *>(dummy)
+              );
 
         if (i < MAX_NUM_MODULES) {
             CHECK(ret == BF_SUCCESS);

--- a/bfintrinsics/include/arch/intel_x64/apic/lapic.h
+++ b/bfintrinsics/include/arch/intel_x64/apic/lapic.h
@@ -53,211 +53,211 @@ namespace msrs
 
 namespace ia32_apic_base
 {
-    constexpr const auto addr = 0x0000001BU;
-    constexpr const auto name = "ia32_apic_base";
+constexpr const auto addr = 0x0000001BU;
+constexpr const auto name = "ia32_apic_base";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace bsp
-    {
-        constexpr const auto mask = 0x0000000000000100ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "bsp";
+namespace bsp
+{
+constexpr const auto mask = 0x0000000000000100ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "bsp";
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
+
+namespace extd
+{
+constexpr const auto mask = 0x0000000000000400ULL;
+constexpr const auto from = 10ULL;
+constexpr const auto name = "extd";
+
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
+
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
+
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
+
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
+
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
+
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
+
+namespace en
+{
+constexpr const auto mask = 0x0000000000000800ULL;
+constexpr const auto from = 11ULL;
+constexpr const auto name = "en";
+
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
+
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
+
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
+
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
+
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
+
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
+
+///
+/// NOTE: `state` is a combination field of `extd` and `en` to facilitate
+/// atomic apic state changes and to provide a simplified interface
+///
+namespace state
+{
+constexpr const auto mask = 0xC00ULL;
+constexpr const auto from = 10ULL;
+constexpr const auto name = "state";
+
+constexpr const auto disabled = 0x0ULL;
+constexpr const auto invalid = 0x1ULL;
+constexpr const auto xapic = 0x2ULL;
+constexpr const auto x2apic = 0x3ULL;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void enable_x2apic() noexcept
+{ set(x2apic); }
+
+inline auto enable_x2apic(value_type msr) noexcept
+{ return set_bits(msr, mask, x2apic << from); }
+
+inline void enable_xapic() noexcept
+{ set(xapic); }
+
+inline auto enable_xapic(value_type msr) noexcept
+{ return set_bits(msr, mask, xapic << from); }
+
+inline void disable() noexcept
+{ set(disabled); }
+
+inline auto disable(value_type msr) noexcept
+{ return set_bits(msr, mask, disabled << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case x2apic:
+            bfdebug_subtext(level, name, "x2apic", msg);
+            return;
+        case xapic:
+            bfdebug_subtext(level, name, "xapic", msg);
+            return;
+        case disabled:
+            bfdebug_subtext(level, name, "disabled", msg);
+            return;
+        case invalid:
+            bfdebug_subtext(level, name, "invalid", msg);
+            return;
     }
+}
+}
 
-    namespace extd
-    {
-        constexpr const auto mask = 0x0000000000000400ULL;
-        constexpr const auto from = 10ULL;
-        constexpr const auto name = "extd";
+namespace apic_base
+{
+constexpr const auto mask = 0x0000000FFFFFF000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "apic_base";
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask); }
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val)); }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val); }
 
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    namespace en
-    {
-        constexpr const auto mask = 0x0000000000000800ULL;
-        constexpr const auto from = 11ULL;
-        constexpr const auto name = "en";
-
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
-
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
-
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    ///
-    /// NOTE: `state` is a combination field of `extd` and `en` to facilitate
-    /// atomic apic state changes and to provide a simplified interface
-    ///
-    namespace state
-    {
-        constexpr const auto mask = 0xC00ULL;
-        constexpr const auto from = 10ULL;
-        constexpr const auto name = "state";
-
-        constexpr const auto disabled = 0x0ULL;
-        constexpr const auto invalid = 0x1ULL;
-        constexpr const auto xapic = 0x2ULL;
-        constexpr const auto x2apic = 0x3ULL;
-
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
-
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
-
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
-
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
-
-        inline void enable_x2apic() noexcept
-        { set(x2apic); }
-
-        inline auto enable_x2apic(value_type msr) noexcept
-        { return set_bits(msr, mask, x2apic << from); }
-
-        inline void enable_xapic() noexcept
-        { set(xapic); }
-
-        inline auto enable_xapic(value_type msr) noexcept
-        { return set_bits(msr, mask, xapic << from); }
-
-        inline void disable() noexcept
-        { set(disabled); }
-
-        inline auto disable(value_type msr) noexcept
-        { return set_bits(msr, mask, disabled << from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case x2apic:
-                    bfdebug_subtext(level, name, "x2apic", msg);
-                    return;
-                case xapic:
-                    bfdebug_subtext(level, name, "xapic", msg);
-                    return;
-                case disabled:
-                    bfdebug_subtext(level, name, "disabled", msg);
-                    return;
-                case invalid:
-                    bfdebug_subtext(level, name, "invalid", msg);
-                    return;
-            }
-        }
-    }
-
-    namespace apic_base
-    {
-        constexpr const auto mask = 0x0000000FFFFFF000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "apic_base";
-
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask); }
-
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask); }
-
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val)); }
-
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        bsp::dump(level, msg);
-        extd::dump(level, msg);
-        en::dump(level, msg);
-        apic_base::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    bsp::dump(level, msg);
+    extd::dump(level, msg);
+    en::dump(level, msg);
+    apic_base::dump(level, msg);
+}
 }
 }
 
@@ -296,1193 +296,1193 @@ constexpr const auto default_size = 0x7ULL;
 
 namespace cmci
 {
-    constexpr const auto name = "cmci";
+constexpr const auto name = "cmci";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_mode::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_mode::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 namespace timer
 {
-    constexpr const auto name = "timer";
+constexpr const auto name = "timer";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
+
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
+
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
+
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
+
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
+
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
+
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
+
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
+
+namespace timer_mode
+{
+constexpr const auto mask = 0x0000000000060000ULL;
+constexpr const auto from = 17ULL;
+constexpr const auto name = "timer_mode";
+
+constexpr const auto one_shot = 0U;
+constexpr const auto periodic = 1U;
+constexpr const auto tsc_deadline = 2U;
+
+inline auto get(value_type val)
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val)
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    switch (get(val)) {
+        case one_shot: bfdebug_subtext(lev, name, "one-shot", msg);
+            break;
+        case periodic: bfdebug_subtext(lev, name, "periodic", msg);
+            break;
+        case tsc_deadline: bfdebug_subtext(lev, name, "TSC-deadline", msg);
+            break;
+        default:
+            bferror_subtext(lev, name, "reserved", msg);
+            bferror_subnhex(lev, "value", val, msg);
+            throw std::invalid_argument("reserved timer_mode: " + std::to_string(val));
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
-
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
-
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
-
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
-
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
-
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
-
-    namespace timer_mode
-    {
-        constexpr const auto mask = 0x0000000000060000ULL;
-        constexpr const auto from = 17ULL;
-        constexpr const auto name = "timer_mode";
-
-        constexpr const auto one_shot = 0U;
-        constexpr const auto periodic = 1U;
-        constexpr const auto tsc_deadline = 2U;
-
-        inline auto get(value_type val)
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val)
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            switch (get(val)) {
-                case one_shot: bfdebug_subtext(lev, name, "one-shot", msg);
-                    break;
-                case periodic: bfdebug_subtext(lev, name, "periodic", msg);
-                    break;
-                case tsc_deadline: bfdebug_subtext(lev, name, "TSC-deadline", msg);
-                    break;
-                default:
-                    bferror_subtext(lev, name, "reserved", msg);
-                    bferror_subnhex(lev, "value", val, msg);
-                    throw std::invalid_argument("reserved timer_mode: " + std::to_string(val));
-            }
-        }
-    }
-
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val, msg);
-        vector::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-        timer_mode::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val, msg);
+    vector::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+    timer_mode::dump(lev, val, msg);
+}
 }
 
 namespace thermal
 {
-    constexpr const auto name = "thermal";
+constexpr const auto name = "thermal";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_mode::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_mode::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 namespace pmi
 {
-    constexpr const auto name = "pmi";
+constexpr const auto name = "pmi";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_mode::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_mode::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 namespace lint0
 {
-    constexpr const auto name = "lint0";
+constexpr const auto name = "lint0";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
+
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
+
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
+
+namespace polarity
+{
+constexpr const auto mask = 0x0000000000002000ULL;
+constexpr const auto from = 13ULL;
+constexpr const auto name = "polarity";
+
+constexpr const auto active_high = 0U;
+constexpr const auto active_low = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == active_high) {
+        bfdebug_subtext(lev, name, "active_high", msg);
+        return;
     }
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+    bfdebug_subtext(lev, name, "active_low", msg);
+}
+}
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+namespace remote_irr
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "remote_irr";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
+
+constexpr const auto edge = 0U;
+constexpr const auto level = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == edge) {
+        bfdebug_subtext(lev, name, "edge", msg);
+        return;
     }
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+    bfdebug_subtext(lev, name, "level", msg);
+}
+}
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-    namespace polarity
-    {
-        constexpr const auto mask = 0x0000000000002000ULL;
-        constexpr const auto from = 13ULL;
-        constexpr const auto name = "polarity";
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        constexpr const auto active_high = 0U;
-        constexpr const auto active_low = 1U;
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == active_high) {
-                bfdebug_subtext(lev, name, "active_high", msg);
-                return;
-            }
-
-            bfdebug_subtext(lev, name, "active_low", msg);
-        }
-    }
-
-    namespace remote_irr
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "remote_irr";
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
-
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
-
-        constexpr const auto edge = 0U;
-        constexpr const auto level = 1U;
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == edge) {
-                bfdebug_subtext(lev, name, "edge", msg);
-                return;
-            }
-
-            bfdebug_subtext(lev, name, "level", msg);
-        }
-    }
-
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
-
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
-
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
-
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
-
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        polarity::dump(lev, val, msg);
-        remote_irr::dump(lev, val, msg);
-        trigger_mode::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    polarity::dump(lev, val, msg);
+    remote_irr::dump(lev, val, msg);
+    trigger_mode::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 namespace lint1
 {
-    constexpr const auto name = "lint1";
+constexpr const auto name = "lint1";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
+
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
+
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
+
+namespace polarity
+{
+constexpr const auto mask = 0x0000000000002000ULL;
+constexpr const auto from = 13ULL;
+constexpr const auto name = "polarity";
+
+constexpr const auto active_high = 0U;
+constexpr const auto active_low = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == active_high) {
+        bfdebug_subtext(lev, name, "active_high", msg);
+        return;
     }
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+    bfdebug_subtext(lev, name, "active_low", msg);
+}
+}
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+namespace remote_irr
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "remote_irr";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
+
+constexpr const auto edge = 0U;
+constexpr const auto level = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == edge) {
+        bfdebug_subtext(lev, name, "edge", msg);
+        return;
     }
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+    bfdebug_subtext(lev, name, "level", msg);
+}
+}
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-    namespace polarity
-    {
-        constexpr const auto mask = 0x0000000000002000ULL;
-        constexpr const auto from = 13ULL;
-        constexpr const auto name = "polarity";
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        constexpr const auto active_high = 0U;
-        constexpr const auto active_low = 1U;
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == active_high) {
-                bfdebug_subtext(lev, name, "active_high", msg);
-                return;
-            }
-
-            bfdebug_subtext(lev, name, "active_low", msg);
-        }
-    }
-
-    namespace remote_irr
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "remote_irr";
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
-
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
-
-        constexpr const auto edge = 0U;
-        constexpr const auto level = 1U;
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == edge) {
-                bfdebug_subtext(lev, name, "edge", msg);
-                return;
-            }
-
-            bfdebug_subtext(lev, name, "level", msg);
-        }
-    }
-
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
-
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
-
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
-
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
-
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        polarity::dump(lev, val, msg);
-        remote_irr::dump(lev, val, msg);
-        trigger_mode::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    polarity::dump(lev, val, msg);
+    remote_irr::dump(lev, val, msg);
+    trigger_mode::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 namespace error
 {
-    constexpr const auto name = "error";
+constexpr const auto name = "error";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val,  msg);
-        vector::dump(lev, val, msg);
-        delivery_status::dump(lev, val, msg);
-        mask_bit::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val,  msg);
+    vector::dump(lev, val, msg);
+    delivery_status::dump(lev, val, msg);
+    mask_bit::dump(lev, val, msg);
+}
 }
 
 }
 
 namespace icr
 {
-    constexpr const auto name = "icr";
+constexpr const auto name = "icr";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_mode(lev, get(val), msg); }
+}
+
+namespace destination_mode
+{
+constexpr const auto mask = 0x0000000000000800ULL;
+constexpr const auto from = 11ULL;
+constexpr const auto name = "destination_mode";
+
+constexpr const auto physical = 0U;
+constexpr const auto logical = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == physical) {
+        bfdebug_subtext(lev, name, "physical", msg);
+        return;
     }
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+    bfdebug_subtext(lev, name, "logical", msg);
+}
+}
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_mode(lev, get(val), msg); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ dump_delivery_status(lev, get(val), msg); }
+}
+
+namespace level
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "level";
+
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
+
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
+
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
+
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, val, msg); }
+}
+
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
+
+constexpr const auto edge = 0U;
+constexpr const auto level = 1U;
+
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
+
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
+
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == edge) {
+        bfdebug_subtext(lev, name, "edge", msg);
+        return;
     }
 
-    namespace destination_mode
-    {
-        constexpr const auto mask = 0x0000000000000800ULL;
-        constexpr const auto from = 11ULL;
-        constexpr const auto name = "destination_mode";
+    bfdebug_subtext(lev, name, "level", msg);
+}
+}
 
-        constexpr const auto physical = 0U;
-        constexpr const auto logical = 1U;
+namespace destination_shorthand
+{
+constexpr const auto mask = 0x00000000000C0000ULL;
+constexpr const auto from = 18ULL;
+constexpr const auto name = "destination_shorthand";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+constexpr const auto none = 0U;
+constexpr const auto self = 1U;
+constexpr const auto all_incl_self = 2U;
+constexpr const auto all_excl_self = 3U;
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == physical) {
-                bfdebug_subtext(lev, name, "physical", msg);
-                return;
-            }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-            bfdebug_subtext(lev, name, "logical", msg);
-        }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    if (get(val) == none) {
+        bfdebug_subtext(lev, name, "none", msg);
+        return;
     }
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
-
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { dump_delivery_status(lev, get(val), msg); }
+    if (get(val) == self) {
+        bfdebug_subtext(lev, name, "self", msg);
+        return;
     }
 
-    namespace level
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "level";
-
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
-
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
-
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
-
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, val, msg); }
+    if (get(val) == all_incl_self) {
+        bfdebug_subtext(lev, name, "all_incl_self", msg);
+        return;
     }
 
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
-
-        constexpr const auto edge = 0U;
-        constexpr const auto level = 1U;
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == edge) {
-                bfdebug_subtext(lev, name, "edge", msg);
-                return;
-            }
-
-            bfdebug_subtext(lev, name, "level", msg);
-        }
+    if (get(val) == all_excl_self) {
+        bfdebug_subtext(lev, name, "all_excl_self", msg);
+        return;
     }
+}
+}
 
-    namespace destination_shorthand
-    {
-        constexpr const auto mask = 0x00000000000C0000ULL;
-        constexpr const auto from = 18ULL;
-        constexpr const auto name = "destination_shorthand";
+namespace x2apic_destination
+{
+constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+constexpr const auto from = 32ULL;
+constexpr const auto name = "x2apic_destination";
 
-        constexpr const auto none = 0U;
-        constexpr const auto self = 1U;
-        constexpr const auto all_incl_self = 2U;
-        constexpr const auto all_excl_self = 3U;
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        {
-            if (get(val) == none) {
-                bfdebug_subtext(lev, name, "none", msg);
-                return;
-            }
+namespace xapic_destination
+{
+constexpr const auto mask = 0xFF00000000000000ULL;
+constexpr const auto from = 56ULL;
+constexpr const auto name = "xapic_destination";
 
-            if (get(val) == self) {
-                bfdebug_subtext(lev, name, "self", msg);
-                return;
-            }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-            if (get(val) == all_incl_self) {
-                bfdebug_subtext(lev, name, "all_incl_self", msg);
-                return;
-            }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-            if (get(val) == all_excl_self) {
-                bfdebug_subtext(lev, name, "all_excl_self", msg);
-                return;
-            }
-        }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace x2apic_destination
-    {
-        constexpr const auto mask = 0xFFFFFFFF00000000ULL;
-        constexpr const auto from = 32ULL;
-        constexpr const auto name = "x2apic_destination";
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
-
-    namespace xapic_destination
-    {
-        constexpr const auto mask = 0xFF00000000000000ULL;
-        constexpr const auto from = 56ULL;
-        constexpr const auto name = "xapic_destination";
-
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
-
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
-
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
-
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val, msg);
-        vector::dump(lev, val, msg);
-        delivery_mode::dump(lev, val, msg);
-        destination_mode::dump(lev, val, msg);
-        level::dump(lev, val, msg);
-        trigger_mode::dump(lev, val, msg);
-        destination_shorthand::dump(lev, val, msg);
-        x2apic_destination::dump(lev, val, msg);
-        xapic_destination::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val, msg);
+    vector::dump(lev, val, msg);
+    delivery_mode::dump(lev, val, msg);
+    destination_mode::dump(lev, val, msg);
+    level::dump(lev, val, msg);
+    trigger_mode::dump(lev, val, msg);
+    destination_shorthand::dump(lev, val, msg);
+    x2apic_destination::dump(lev, val, msg);
+    xapic_destination::dump(lev, val, msg);
+}
 }
 
 namespace self_ipi
 {
-    constexpr const auto name = "self_ipi";
+constexpr const auto name = "self_ipi";
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val, msg);
-        vector::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val, msg);
+    vector::dump(lev, val, msg);
+}
 }
 
 namespace version
 {
-    constexpr const auto name = "version";
+constexpr const auto name = "version";
 
-    namespace version
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "version";
+namespace version
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "version";
 
-        constexpr const auto reset_value = 0x10U;
+constexpr const auto reset_value = 0x10U;
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace max_lvt_entry_minus_one
-    {
-        constexpr const auto mask = 0x0000000000FF0000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "max_lvt_entry_minus_one";
+namespace max_lvt_entry_minus_one
+{
+constexpr const auto mask = 0x0000000000FF0000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "max_lvt_entry_minus_one";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace suppress_eoi_broadcast_supported
-    {
-        constexpr const auto mask = 0x0000000001000000ULL;
-        constexpr const auto from = 24ULL;
-        constexpr const auto name = "suppress_eoi_broadcast_supported";
+namespace suppress_eoi_broadcast_supported
+{
+constexpr const auto mask = 0x0000000001000000ULL;
+constexpr const auto from = 24ULL;
+constexpr const auto name = "suppress_eoi_broadcast_supported";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val, msg);
-        version::dump(lev, val, msg);
-        max_lvt_entry_minus_one::dump(lev, val, msg);
-        suppress_eoi_broadcast_supported::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val, msg);
+    version::dump(lev, val, msg);
+    max_lvt_entry_minus_one::dump(lev, val, msg);
+    suppress_eoi_broadcast_supported::dump(lev, val, msg);
+}
 }
 
 namespace svr
 {
-    constexpr const auto name = "svr";
-    constexpr const auto reset_value = 0x000000FFULL;
+constexpr const auto name = "svr";
+constexpr const auto reset_value = 0x000000FFULL;
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get(value_type val) noexcept
-        { return get_bits(val, mask) >> from; }
+inline auto get(value_type val) noexcept
+{ return get_bits(val, mask) >> from; }
 
-        inline auto set(value_type reg, value_type val) noexcept
-        { return set_bits(reg, mask, val << from); }
+inline auto set(value_type reg, value_type val) noexcept
+{ return set_bits(reg, mask, val << from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subnhex(lev, name, get(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subnhex(lev, name, get(val), msg); }
+}
 
-    namespace apic_enable_bit
-    {
-        constexpr const auto mask = 0x0000000000000100ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "apic_enable_bit";
+namespace apic_enable_bit
+{
+constexpr const auto mask = 0x0000000000000100ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "apic_enable_bit";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    namespace focus_checking
-    {
-        constexpr const auto mask = 0x0000000000000200ULL;
-        constexpr const auto from = 9ULL;
-        constexpr const auto name = "focus_checking";
+namespace focus_checking
+{
+constexpr const auto mask = 0x0000000000000200ULL;
+constexpr const auto from = 9ULL;
+constexpr const auto name = "focus_checking";
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto disable(value_type val)
-        { return set_bit(val, from); }
+inline auto disable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto enable(value_type val)
-        { return clear_bit(val, from); }
+inline auto enable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    namespace suppress_eoi_broadcast
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "suppress_eoi_broadcast";
+namespace suppress_eoi_broadcast
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "suppress_eoi_broadcast";
 
-        inline auto is_enabled(value_type val)
-        { return is_bit_set(val, from); }
+inline auto is_enabled(value_type val)
+{ return is_bit_set(val, from); }
 
-        inline auto is_disabled(value_type val)
-        { return is_bit_cleared(val, from); }
+inline auto is_disabled(value_type val)
+{ return is_bit_cleared(val, from); }
 
-        inline auto enable(value_type val)
-        { return set_bit(val, from); }
+inline auto enable(value_type val)
+{ return set_bit(val, from); }
 
-        inline auto disable(value_type val)
-        { return clear_bit(val, from); }
+inline auto disable(value_type val)
+{ return clear_bit(val, from); }
 
-        inline void dump(int lev, value_type val, std::string *msg = nullptr)
-        { bfdebug_subbool(lev, name, is_enabled(val), msg); }
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{ bfdebug_subbool(lev, name, is_enabled(val), msg); }
+}
 
-    inline void dump(int lev, value_type val, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(lev, name, val, msg);
-        vector::dump(lev, val, msg);
-        apic_enable_bit::dump(lev, val, msg);
-        focus_checking::dump(lev, val, msg);
-        suppress_eoi_broadcast::dump(lev, val, msg);
-    }
+inline void dump(int lev, value_type val, std::string *msg = nullptr)
+{
+    bfdebug_nhex(lev, name, val, msg);
+    vector::dump(lev, val, msg);
+    apic_enable_bit::dump(lev, val, msg);
+    focus_checking::dump(lev, val, msg);
+    suppress_eoi_broadcast::dump(lev, val, msg);
+}
 }
 
 inline void dump_delivery_status(int lev, value_type val, std::string *msg)

--- a/bfintrinsics/include/arch/intel_x64/apic/x2apic.h
+++ b/bfintrinsics/include/arch/intel_x64/apic/x2apic.h
@@ -52,2026 +52,2026 @@ namespace msrs
 {
 namespace ia32_x2apic_apicid
 {
-    constexpr const auto addr = 0x00000802U;
-    constexpr const auto name = "ia32_x2apic_apicid";
+constexpr const auto addr = 0x00000802U;
+constexpr const auto name = "ia32_x2apic_apicid";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_version
 {
-    constexpr const auto addr = 0x00000803U;
-    constexpr const auto name = "ia32_x2apic_version";
+constexpr const auto addr = 0x00000803U;
+constexpr const auto name = "ia32_x2apic_version";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tpr
 {
-    constexpr const auto addr = 0x00000808U;
-    constexpr const auto name = "ia32_x2apic_tpr";
+constexpr const auto addr = 0x00000808U;
+constexpr const auto name = "ia32_x2apic_tpr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_ppr
 {
-    constexpr const auto addr = 0x0000080AU;
-    constexpr const auto name = "ia32_x2apic_ppr";
+constexpr const auto addr = 0x0000080AU;
+constexpr const auto name = "ia32_x2apic_ppr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_eoi
 {
-    constexpr const auto addr = 0x0000080BU;
-    constexpr const auto name = "ia32_x2apic_eoi";
+constexpr const auto addr = 0x0000080BU;
+constexpr const auto name = "ia32_x2apic_eoi";
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 }
 
 namespace ia32_x2apic_ldr
 {
-    constexpr const auto addr = 0x0000080DU;
-    constexpr const auto name = "ia32_x2apic_ldr";
+constexpr const auto addr = 0x0000080DU;
+constexpr const auto name = "ia32_x2apic_ldr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    namespace logical_id
-    {
-        constexpr const auto mask = 0x000000000000FFFFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "logical_id";
+namespace logical_id
+{
+constexpr const auto mask = 0x000000000000FFFFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "logical_id";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-    namespace cluster_id
-    {
-        constexpr const auto mask = 0x00000000FFFF0000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "cluster_id";
+namespace cluster_id
+{
+constexpr const auto mask = 0x00000000FFFF0000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "cluster_id";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        logical_id::dump(level, msg);
-        cluster_id::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    logical_id::dump(level, msg);
+    cluster_id::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_sivr
 {
-    constexpr const auto addr = 0x0000080FU;
-    constexpr const auto name = "ia32_x2apic_sivr";
+constexpr const auto addr = 0x0000080FU;
+constexpr const auto name = "ia32_x2apic_sivr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-    namespace apic_enable_bit
-    {
-        constexpr const auto mask = 0x0000000000000100ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "apic_enable_bit";
+namespace apic_enable_bit
+{
+constexpr const auto mask = 0x0000000000000100ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "apic_enable_bit";
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-    namespace focus_checking
-    {
-        constexpr const auto mask = 0x0000000000000200ULL;
-        constexpr const auto from = 9ULL;
-        constexpr const auto name = "focus_checking";
+namespace focus_checking
+{
+constexpr const auto mask = 0x0000000000000200ULL;
+constexpr const auto from = 9ULL;
+constexpr const auto name = "focus_checking";
 
-        inline auto is_disabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto is_disabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto is_enabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline auto is_enabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline auto is_enabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline void disable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline void disable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto disable(value_type msr)
-        { return set_bit(msr, from); }
+inline auto disable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline void enable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+inline void enable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto enable(value_type msr)
-        { return clear_bit(msr, from); }
+inline auto enable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-    namespace suppress_eoi_broadcast
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "suppress_eoi_broadcast";
+namespace suppress_eoi_broadcast
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "suppress_eoi_broadcast";
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        vector::dump(level, msg);
-        apic_enable_bit::dump(level, msg);
-        focus_checking::dump(level, msg);
-        suppress_eoi_broadcast::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    vector::dump(level, msg);
+    apic_enable_bit::dump(level, msg);
+    focus_checking::dump(level, msg);
+    suppress_eoi_broadcast::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_isr0
 {
-    constexpr const auto addr = 0x00000810U;
-    constexpr const auto name = "ia32_x2apic_isr0";
+constexpr const auto addr = 0x00000810U;
+constexpr const auto name = "ia32_x2apic_isr0";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr1
 {
-    constexpr const auto addr = 0x00000811U;
-    constexpr const auto name = "ia32_x2apic_isr1";
+constexpr const auto addr = 0x00000811U;
+constexpr const auto name = "ia32_x2apic_isr1";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr2
 {
-    constexpr const auto addr = 0x00000812U;
-    constexpr const auto name = "ia32_x2apic_isr2";
+constexpr const auto addr = 0x00000812U;
+constexpr const auto name = "ia32_x2apic_isr2";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr3
 {
-    constexpr const auto addr = 0x00000813U;
-    constexpr const auto name = "ia32_x2apic_isr3";
+constexpr const auto addr = 0x00000813U;
+constexpr const auto name = "ia32_x2apic_isr3";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr4
 {
-    constexpr const auto addr = 0x00000814U;
-    constexpr const auto name = "ia32_x2apic_isr4";
+constexpr const auto addr = 0x00000814U;
+constexpr const auto name = "ia32_x2apic_isr4";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr5
 {
-    constexpr const auto addr = 0x00000815U;
-    constexpr const auto name = "ia32_x2apic_isr5";
+constexpr const auto addr = 0x00000815U;
+constexpr const auto name = "ia32_x2apic_isr5";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr6
 {
-    constexpr const auto addr = 0x00000816U;
-    constexpr const auto name = "ia32_x2apic_isr6";
+constexpr const auto addr = 0x00000816U;
+constexpr const auto name = "ia32_x2apic_isr6";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_isr7
 {
-    constexpr const auto addr = 0x00000817U;
-    constexpr const auto name = "ia32_x2apic_isr7";
+constexpr const auto addr = 0x00000817U;
+constexpr const auto name = "ia32_x2apic_isr7";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr0
 {
-    constexpr const auto addr = 0x00000818U;
-    constexpr const auto name = "ia32_x2apic_tmr0";
+constexpr const auto addr = 0x00000818U;
+constexpr const auto name = "ia32_x2apic_tmr0";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr1
 {
-    constexpr const auto addr = 0x00000819U;
-    constexpr const auto name = "ia32_x2apic_tmr1";
+constexpr const auto addr = 0x00000819U;
+constexpr const auto name = "ia32_x2apic_tmr1";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr2
 {
-    constexpr const auto addr = 0x0000081AU;
-    constexpr const auto name = "ia32_x2apic_tmr2";
+constexpr const auto addr = 0x0000081AU;
+constexpr const auto name = "ia32_x2apic_tmr2";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr3
 {
-    constexpr const auto addr = 0x0000081BU;
-    constexpr const auto name = "ia32_x2apic_tmr3";
+constexpr const auto addr = 0x0000081BU;
+constexpr const auto name = "ia32_x2apic_tmr3";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr4
 {
-    constexpr const auto addr = 0x0000081CU;
-    constexpr const auto name = "ia32_x2apic_tmr4";
+constexpr const auto addr = 0x0000081CU;
+constexpr const auto name = "ia32_x2apic_tmr4";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr5
 {
-    constexpr const auto addr = 0x0000081DU;
-    constexpr const auto name = "ia32_x2apic_tmr5";
+constexpr const auto addr = 0x0000081DU;
+constexpr const auto name = "ia32_x2apic_tmr5";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr6
 {
-    constexpr const auto addr = 0x0000081EU;
-    constexpr const auto name = "ia32_x2apic_tmr6";
+constexpr const auto addr = 0x0000081EU;
+constexpr const auto name = "ia32_x2apic_tmr6";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_tmr7
 {
-    constexpr const auto addr = 0x0000081FU;
-    constexpr const auto name = "ia32_x2apic_tmr7";
+constexpr const auto addr = 0x0000081FU;
+constexpr const auto name = "ia32_x2apic_tmr7";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr0
 {
-    constexpr const auto addr = 0x00000820U;
-    constexpr const auto name = "ia32_x2apic_irr0";
+constexpr const auto addr = 0x00000820U;
+constexpr const auto name = "ia32_x2apic_irr0";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr1
 {
-    constexpr const auto addr = 0x00000821U;
-    constexpr const auto name = "ia32_x2apic_irr1";
+constexpr const auto addr = 0x00000821U;
+constexpr const auto name = "ia32_x2apic_irr1";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr2
 {
-    constexpr const auto addr = 0x00000822U;
-    constexpr const auto name = "ia32_x2apic_irr2";
+constexpr const auto addr = 0x00000822U;
+constexpr const auto name = "ia32_x2apic_irr2";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr3
 {
-    constexpr const auto addr = 0x00000823U;
-    constexpr const auto name = "ia32_x2apic_irr3";
+constexpr const auto addr = 0x00000823U;
+constexpr const auto name = "ia32_x2apic_irr3";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr4
 {
-    constexpr const auto addr = 0x00000824U;
-    constexpr const auto name = "ia32_x2apic_irr4";
+constexpr const auto addr = 0x00000824U;
+constexpr const auto name = "ia32_x2apic_irr4";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr5
 {
-    constexpr const auto addr = 0x00000825U;
-    constexpr const auto name = "ia32_x2apic_irr5";
+constexpr const auto addr = 0x00000825U;
+constexpr const auto name = "ia32_x2apic_irr5";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr6
 {
-    constexpr const auto addr = 0x00000826U;
-    constexpr const auto name = "ia32_x2apic_irr6";
+constexpr const auto addr = 0x00000826U;
+constexpr const auto name = "ia32_x2apic_irr6";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_irr7
 {
-    constexpr const auto addr = 0x00000827U;
-    constexpr const auto name = "ia32_x2apic_irr7";
+constexpr const auto addr = 0x00000827U;
+constexpr const auto name = "ia32_x2apic_irr7";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_esr
 {
-    constexpr const auto addr = 0x00000828U;
-    constexpr const auto name = "ia32_x2apic_esr";
+constexpr const auto addr = 0x00000828U;
+constexpr const auto name = "ia32_x2apic_esr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_lvt_cmci
 {
-    constexpr const auto addr = 0x0000082FU;
-    constexpr const auto name = "ia32_x2apic_lvt_cmci";
+constexpr const auto addr = 0x0000082FU;
+constexpr const auto name = "ia32_x2apic_lvt_cmci";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
-    }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_mode::dump(level, msg);
-        delivery_status::dump(level, msg);
-        mask_bit::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_mode::dump(level, msg);
+    delivery_status::dump(level, msg);
+    mask_bit::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_icr
 {
-    constexpr const auto addr = 0x00000830U;
-    constexpr const auto name = "ia32_x2apic_icr";
+constexpr const auto addr = 0x00000830U;
+constexpr const auto name = "ia32_x2apic_icr";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace destination_mode
+{
+constexpr const auto mask = 0x0000000000000800ULL;
+constexpr const auto from = 11ULL;
+constexpr const auto name = "destination_mode";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto physical = 0U;
+constexpr const auto logical = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case physical: bfdebug_subtext(level, name, "physical", msg); break;
+        case logical: bfdebug_subtext(level, name, "logical", msg); break;
     }
+}
+}
 
-    namespace destination_mode
-    {
-        constexpr const auto mask = 0x0000000000000800ULL;
-        constexpr const auto from = 11ULL;
-        constexpr const auto name = "destination_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto physical = 0U;
-        constexpr const auto logical = 1U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case physical: bfdebug_subtext(level, name, "physical", msg); break;
-                case logical: bfdebug_subtext(level, name, "logical", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace level
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "level";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
+
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
+
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
+
+constexpr const auto edge_mode = 0U;
+constexpr const auto level_mode = 1U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
+        case level_mode: bfdebug_subtext(level, name, "level", msg); break;
     }
+}
+}
 
-    namespace level
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "level";
+namespace destination_shorthand
+{
+constexpr const auto mask = 0x00000000000C0000ULL;
+constexpr const auto from = 18ULL;
+constexpr const auto name = "destination_shorthand";
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+constexpr const auto no_shorthand = 0U;
+constexpr const auto self = 1U;
+constexpr const auto all_including_self = 2U;
+constexpr const auto all_excluding_self = 3U;
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
+inline void dump(int lev, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case no_shorthand: bfdebug_subtext(lev, name, "no_shorthand", msg); break;
+        case self: bfdebug_subtext(lev, name, "self", msg); break;
+        case all_including_self: bfdebug_subtext(lev, name, "all_including_self", msg); break;
+        case all_excluding_self: bfdebug_subtext(lev, name, "all_excluding_self", msg); break;
     }
+}
+}
 
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
+namespace destination_field
+{
+constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+constexpr const auto from = 32ULL;
+constexpr const auto name = "destination_field";
 
-        constexpr const auto edge_mode = 0U;
-        constexpr const auto level_mode = 1U;
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
-                case level_mode: bfdebug_subtext(level, name, "level", msg); break;
-            }
-        }
-    }
-
-    namespace destination_shorthand
-    {
-        constexpr const auto mask = 0x00000000000C0000ULL;
-        constexpr const auto from = 18ULL;
-        constexpr const auto name = "destination_shorthand";
-
-        constexpr const auto no_shorthand = 0U;
-        constexpr const auto self = 1U;
-        constexpr const auto all_including_self = 2U;
-        constexpr const auto all_excluding_self = 3U;
-
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
-
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
-
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
-
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
-
-        inline void dump(int lev, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case no_shorthand: bfdebug_subtext(lev, name, "no_shorthand", msg); break;
-                case self: bfdebug_subtext(lev, name, "self", msg); break;
-                case all_including_self: bfdebug_subtext(lev, name, "all_including_self", msg); break;
-                case all_excluding_self: bfdebug_subtext(lev, name, "all_excluding_self", msg); break;
-            }
-        }
-    }
-
-    namespace destination_field
-    {
-        constexpr const auto mask = 0xFFFFFFFF00000000ULL;
-        constexpr const auto from = 32ULL;
-        constexpr const auto name = "destination_field";
-
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
-
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
-
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
-
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        vector::dump(level, msg);
-        delivery_mode::dump(level, msg);
-        destination_mode::dump(level, msg);
-        level::dump(level, msg);
-        trigger_mode::dump(level, msg);
-        destination_shorthand::dump(level, msg);
-        destination_field::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    vector::dump(level, msg);
+    delivery_mode::dump(level, msg);
+    destination_mode::dump(level, msg);
+    level::dump(level, msg);
+    trigger_mode::dump(level, msg);
+    destination_shorthand::dump(level, msg);
+    destination_field::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_timer
 {
-    constexpr const auto addr = 0x00000832U;
-    constexpr const auto name = "ia32_x2apic_lvt_timer";
+constexpr const auto addr = 0x00000832U;
+constexpr const auto name = "ia32_x2apic_lvt_timer";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
+
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
+
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
+
+namespace timer_mode
+{
+constexpr const auto mask = 0x0000000000060000ULL;
+constexpr const auto from = 17ULL;
+constexpr const auto name = "timer_mode";
+
+constexpr const auto one_shot = 0U;
+constexpr const auto periodic = 1U;
+constexpr const auto tsc_deadline = 2U;
+
+inline auto get()
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr)
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val)
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val)
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case one_shot: bfdebug_subtext(level, name, "one-shot", msg); break;
+        case periodic: bfdebug_subtext(level, name, "periodic", msg); break;
+        case tsc_deadline: bfdebug_subtext(level, name, "TSC-deadline", msg); break;
+        default: bferror_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
-
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
-
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    namespace timer_mode
-    {
-        constexpr const auto mask = 0x0000000000060000ULL;
-        constexpr const auto from = 17ULL;
-        constexpr const auto name = "timer_mode";
-
-        constexpr const auto one_shot = 0U;
-        constexpr const auto periodic = 1U;
-        constexpr const auto tsc_deadline = 2U;
-
-        inline auto get()
-        { return get_bits(_read_msr(addr), mask) >> from; }
-
-        inline auto get(value_type msr)
-        { return get_bits(msr, mask) >> from; }
-
-        inline void set(value_type val)
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
-
-        inline auto set(value_type msr, value_type val)
-        { return set_bits(msr, mask, val << from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case one_shot: bfdebug_subtext(level, name, "one-shot", msg); break;
-                case periodic: bfdebug_subtext(level, name, "periodic", msg); break;
-                case tsc_deadline: bfdebug_subtext(level, name, "TSC-deadline", msg); break;
-                default: bferror_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        vector::dump(level, msg);
-        delivery_status::dump(level, msg);
-        mask_bit::dump(level, msg);
-        timer_mode::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    vector::dump(level, msg);
+    delivery_status::dump(level, msg);
+    mask_bit::dump(level, msg);
+    timer_mode::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_thermal
 {
-    constexpr const auto addr = 0x00000833U;
-    constexpr const auto name = "ia32_x2apic_lvt_thermal";
+constexpr const auto addr = 0x00000833U;
+constexpr const auto name = "ia32_x2apic_lvt_thermal";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
-    }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_mode::dump(level, msg);
-        delivery_status::dump(level, msg);
-        mask_bit::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_mode::dump(level, msg);
+    delivery_status::dump(level, msg);
+    mask_bit::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_pmi
 {
-    constexpr const auto addr = 0x00000834U;
-    constexpr const auto name = "ia32_x2apic_lvt_pmi";
+constexpr const auto addr = 0x00000834U;
+constexpr const auto name = "ia32_x2apic_lvt_pmi";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
-    }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_mode::dump(level, msg);
-        delivery_status::dump(level, msg);
-        mask_bit::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_mode::dump(level, msg);
+    delivery_status::dump(level, msg);
+    mask_bit::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_lint0
 {
-    constexpr const auto addr = 0x00000835U;
-    constexpr const auto name = "ia32_x2apic_lvt_lint0";
+constexpr const auto addr = 0x00000835U;
+constexpr const auto name = "ia32_x2apic_lvt_lint0";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace polarity
+{
+constexpr const auto mask = 0x0000000000002000ULL;
+constexpr const auto from = 13ULL;
+constexpr const auto name = "polarity";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto active_high = 0U;
+constexpr const auto active_low = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case active_high: bfdebug_subtext(level, name, "active_high", msg); break;
+        case active_low: bfdebug_subtext(level, name, "active_low", msg); break;
     }
+}
+}
 
-    namespace polarity
-    {
-        constexpr const auto mask = 0x0000000000002000ULL;
-        constexpr const auto from = 13ULL;
-        constexpr const auto name = "polarity";
+namespace remote_irr
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "remote_irr";
 
-        constexpr const auto active_high = 0U;
-        constexpr const auto active_low = 1U;
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+constexpr const auto edge_mode = 0U;
+constexpr const auto level_mode = 1U;
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case active_high: bfdebug_subtext(level, name, "active_high", msg); break;
-                case active_low: bfdebug_subtext(level, name, "active_low", msg); break;
-            }
-        }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
+        case level_mode: bfdebug_subtext(level, name, "level", msg); break;
     }
+}
+}
 
-    namespace remote_irr
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "remote_irr";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        constexpr const auto edge_mode = 0U;
-        constexpr const auto level_mode = 1U;
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
-                case level_mode: bfdebug_subtext(level, name, "level", msg); break;
-            }
-        }
-    }
-
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
-
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
-
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_status::dump(level, msg);
-        polarity::dump(level, msg);
-        remote_irr::dump(level, msg);
-        trigger_mode::dump(level, msg);
-        mask_bit::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_status::dump(level, msg);
+    polarity::dump(level, msg);
+    remote_irr::dump(level, msg);
+    trigger_mode::dump(level, msg);
+    mask_bit::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_lint1
 {
-    constexpr const auto addr = 0x00000836U;
-    constexpr const auto name = "ia32_x2apic_lvt_lint1";
+constexpr const auto addr = 0x00000836U;
+constexpr const auto name = "ia32_x2apic_lvt_lint1";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_mode
+{
+constexpr const auto mask = 0x0000000000000700ULL;
+constexpr const auto from = 8ULL;
+constexpr const auto name = "delivery_mode";
+
+constexpr const auto fixed = 0U;
+constexpr const auto smi = 2U;
+constexpr const auto nmi = 4U;
+constexpr const auto init = 5U;
+constexpr const auto extint = 7U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
+        case smi: bfdebug_subtext(level, name, "smi", msg); break;
+        case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
+        case init: bfdebug_subtext(level, name, "init", msg); break;
+        case extint: bfdebug_subtext(level, name, "extint", msg); break;
+        default: bfalert_subtext(level, name, "RESERVED", msg); break;
     }
+}
+}
 
-    namespace delivery_mode
-    {
-        constexpr const auto mask = 0x0000000000000700ULL;
-        constexpr const auto from = 8ULL;
-        constexpr const auto name = "delivery_mode";
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
 
-        constexpr const auto fixed = 0U;
-        constexpr const auto smi = 2U;
-        constexpr const auto nmi = 4U;
-        constexpr const auto init = 5U;
-        constexpr const auto extint = 7U;
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case fixed: bfdebug_subtext(level, name, "fixed", msg); break;
-                case smi: bfdebug_subtext(level, name, "smi", msg); break;
-                case nmi: bfdebug_subtext(level, name, "nmi", msg); break;
-                case init: bfdebug_subtext(level, name, "init", msg); break;
-                case extint: bfdebug_subtext(level, name, "extint", msg); break;
-                default: bfalert_subtext(level, name, "RESERVED", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
+namespace polarity
+{
+constexpr const auto mask = 0x0000000000002000ULL;
+constexpr const auto from = 13ULL;
+constexpr const auto name = "polarity";
 
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
+constexpr const auto active_high = 0U;
+constexpr const auto active_low = 1U;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case active_high: bfdebug_subtext(level, name, "active_high", msg); break;
+        case active_low: bfdebug_subtext(level, name, "active_low", msg); break;
     }
+}
+}
 
-    namespace polarity
-    {
-        constexpr const auto mask = 0x0000000000002000ULL;
-        constexpr const auto from = 13ULL;
-        constexpr const auto name = "polarity";
+namespace remote_irr
+{
+constexpr const auto mask = 0x0000000000004000ULL;
+constexpr const auto from = 14ULL;
+constexpr const auto name = "remote_irr";
 
-        constexpr const auto active_high = 0U;
-        constexpr const auto active_low = 1U;
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+namespace trigger_mode
+{
+constexpr const auto mask = 0x0000000000008000ULL;
+constexpr const auto from = 15ULL;
+constexpr const auto name = "trigger_mode";
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+constexpr const auto edge_mode = 0U;
+constexpr const auto level_mode = 1U;
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case active_high: bfdebug_subtext(level, name, "active_high", msg); break;
-                case active_low: bfdebug_subtext(level, name, "active_low", msg); break;
-            }
-        }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
+        case level_mode: bfdebug_subtext(level, name, "level", msg); break;
     }
+}
+}
 
-    namespace remote_irr
-    {
-        constexpr const auto mask = 0x0000000000004000ULL;
-        constexpr const auto from = 14ULL;
-        constexpr const auto name = "remote_irr";
+namespace mask_bit
+{
+constexpr const auto mask = 0x0000000000010000ULL;
+constexpr const auto from = 16ULL;
+constexpr const auto name = "mask_bit";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto is_enabled()
+{ return is_bit_set(_read_msr(addr), from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto is_enabled(value_type msr)
+{ return is_bit_set(msr, from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
-    }
+inline auto is_disabled()
+{ return is_bit_cleared(_read_msr(addr), from); }
 
-    namespace trigger_mode
-    {
-        constexpr const auto mask = 0x0000000000008000ULL;
-        constexpr const auto from = 15ULL;
-        constexpr const auto name = "trigger_mode";
+inline auto is_disabled(value_type msr)
+{ return is_bit_cleared(msr, from); }
 
-        constexpr const auto edge_mode = 0U;
-        constexpr const auto level_mode = 1U;
+inline void enable()
+{ _write_msr(addr, set_bit(_read_msr(addr), from)); }
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto enable(value_type msr)
+{ return set_bit(msr, from); }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline void disable()
+{ _write_msr(addr, clear_bit(_read_msr(addr), from)); }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline auto disable(value_type msr)
+{ return clear_bit(msr, from); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subbool(level, name, is_enabled(), msg); }
+}
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case edge_mode: bfdebug_subtext(level, name, "edge", msg); break;
-                case level_mode: bfdebug_subtext(level, name, "level", msg); break;
-            }
-        }
-    }
-
-    namespace mask_bit
-    {
-        constexpr const auto mask = 0x0000000000010000ULL;
-        constexpr const auto from = 16ULL;
-        constexpr const auto name = "mask_bit";
-
-        inline auto is_enabled()
-        { return is_bit_set(_read_msr(addr), from); }
-
-        inline auto is_enabled(value_type msr)
-        { return is_bit_set(msr, from); }
-
-        inline auto is_disabled()
-        { return is_bit_cleared(_read_msr(addr), from); }
-
-        inline auto is_disabled(value_type msr)
-        { return is_bit_cleared(msr, from); }
-
-        inline void enable()
-        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
-
-        inline auto enable(value_type msr)
-        { return set_bit(msr, from); }
-
-        inline void disable()
-        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
-
-        inline auto disable(value_type msr)
-        { return clear_bit(msr, from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subbool(level, name, is_enabled(), msg); }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_status::dump(level, msg);
-        polarity::dump(level, msg);
-        remote_irr::dump(level, msg);
-        trigger_mode::dump(level, msg);
-        mask_bit::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_status::dump(level, msg);
+    polarity::dump(level, msg);
+    remote_irr::dump(level, msg);
+    trigger_mode::dump(level, msg);
+    mask_bit::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_lvt_error
 {
-    constexpr const auto addr = 0x00000837U;
-    constexpr const auto name = "ia32_x2apic_lvt_error";
+constexpr const auto addr = 0x00000837U;
+constexpr const auto name = "ia32_x2apic_lvt_error";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        { bfdebug_subnhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_subnhex(level, name, get(), msg); }
+}
+
+namespace delivery_status
+{
+constexpr const auto mask = 0x0000000000001000ULL;
+constexpr const auto from = 12ULL;
+constexpr const auto name = "delivery_status";
+
+constexpr const auto idle = 0U;
+constexpr const auto send_pending = 1U;
+
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
+
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
+
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case idle: bfdebug_subtext(level, name, "idle", msg); break;
+        case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
     }
+}
+}
 
-    namespace delivery_status
-    {
-        constexpr const auto mask = 0x0000000000001000ULL;
-        constexpr const auto from = 12ULL;
-        constexpr const auto name = "delivery_status";
-
-        constexpr const auto idle = 0U;
-        constexpr const auto send_pending = 1U;
-
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
-
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
-
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
-
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
-
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case idle: bfdebug_subtext(level, name, "idle", msg); break;
-                case send_pending: bfdebug_subtext(level, name, "send pending", msg); break;
-            }
-        }
-    }
-
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(),  msg);
-        vector::dump(level, msg);
-        delivery_status::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(),  msg);
+    vector::dump(level, msg);
+    delivery_status::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_init_count
 {
-    constexpr const auto addr = 0x00000838U;
-    constexpr const auto name = "ia32_x2apic_init_count";
+constexpr const auto addr = 0x00000838U;
+constexpr const auto name = "ia32_x2apic_init_count";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_cur_count
 {
-    constexpr const auto addr = 0x00000839U;
-    constexpr const auto name = "ia32_x2apic_cur_count";
+constexpr const auto addr = 0x00000839U;
+constexpr const auto name = "ia32_x2apic_cur_count";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void dump(int level, std::string *msg = nullptr)
-    { bfdebug_nhex(level, name, get(), msg); }
+inline void dump(int level, std::string *msg = nullptr)
+{ bfdebug_nhex(level, name, get(), msg); }
 }
 
 namespace ia32_x2apic_div_conf
 {
-    constexpr const auto addr = 0x0000083EU;
-    constexpr const auto name = "ia32_x2apic_div_conf";
+constexpr const auto addr = 0x0000083EU;
+constexpr const auto name = "ia32_x2apic_div_conf";
 
-    inline auto get() noexcept
-    { return _read_msr(addr); }
+inline auto get() noexcept
+{ return _read_msr(addr); }
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace div_val
-    {
-        constexpr const auto mask = 0x000000000000000BULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "div_val";
+namespace div_val
+{
+constexpr const auto mask = 0x000000000000000BULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "div_val";
 
-        constexpr const auto div_by_2 = 0ULL;
-        constexpr const auto div_by_4 = 1ULL;
-        constexpr const auto div_by_8 = 2ULL;
-        constexpr const auto div_by_16 = 3ULL;
-        constexpr const auto div_by_32 = 8ULL;
-        constexpr const auto div_by_64 = 9ULL;
-        constexpr const auto div_by_128 = 10ULL;
-        constexpr const auto div_by_1 = 11ULL;
+constexpr const auto div_by_2 = 0ULL;
+constexpr const auto div_by_4 = 1ULL;
+constexpr const auto div_by_8 = 2ULL;
+constexpr const auto div_by_16 = 3ULL;
+constexpr const auto div_by_32 = 8ULL;
+constexpr const auto div_by_64 = 9ULL;
+constexpr const auto div_by_128 = 10ULL;
+constexpr const auto div_by_1 = 11ULL;
 
-        inline auto get() noexcept
-        { return get_bits(_read_msr(addr), mask) >> from; }
+inline auto get() noexcept
+{ return get_bits(_read_msr(addr), mask) >> from; }
 
-        inline auto get(value_type msr) noexcept
-        { return get_bits(msr, mask) >> from; }
+inline auto get(value_type msr) noexcept
+{ return get_bits(msr, mask) >> from; }
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
 
-        inline void dump(int level, std::string *msg = nullptr)
-        {
-            switch (get()) {
-                case div_by_2: bfdebug_subtext(level, name, "div_by_2", msg); break;
-                case div_by_4: bfdebug_subtext(level, name, "div_by_4", msg); break;
-                case div_by_8: bfdebug_subtext(level, name, "div_by_8", msg); break;
-                case div_by_16: bfdebug_subtext(level, name, "div_by_16", msg); break;
-                case div_by_32: bfdebug_subtext(level, name, "div_by_32", msg); break;
-                case div_by_64: bfdebug_subtext(level, name, "div_by_64", msg); break;
-                case div_by_128: bfdebug_subtext(level, name, "div_by_128", msg); break;
-                case div_by_1: bfdebug_subtext(level, name, "div_by_1", msg); break;
-            }
-        }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    switch (get()) {
+        case div_by_2: bfdebug_subtext(level, name, "div_by_2", msg); break;
+        case div_by_4: bfdebug_subtext(level, name, "div_by_4", msg); break;
+        case div_by_8: bfdebug_subtext(level, name, "div_by_8", msg); break;
+        case div_by_16: bfdebug_subtext(level, name, "div_by_16", msg); break;
+        case div_by_32: bfdebug_subtext(level, name, "div_by_32", msg); break;
+        case div_by_64: bfdebug_subtext(level, name, "div_by_64", msg); break;
+        case div_by_128: bfdebug_subtext(level, name, "div_by_128", msg); break;
+        case div_by_1: bfdebug_subtext(level, name, "div_by_1", msg); break;
     }
+}
+}
 
-    inline void dump(int level, std::string *msg = nullptr)
-    {
-        bfdebug_nhex(level, name, get(), msg);
-        div_val::dump(level, msg);
-    }
+inline void dump(int level, std::string *msg = nullptr)
+{
+    bfdebug_nhex(level, name, get(), msg);
+    div_val::dump(level, msg);
+}
 }
 
 namespace ia32_x2apic_self_ipi
 {
-    constexpr const auto addr = 0x0000083FU;
-    constexpr const auto name = "ia32_x2apic_self_ipi";
+constexpr const auto addr = 0x0000083FU;
+constexpr const auto name = "ia32_x2apic_self_ipi";
 
-    inline void set(value_type val) noexcept
-    { _write_msr(addr, val); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, val); }
 
-    namespace vector
-    {
-        constexpr const auto mask = 0x00000000000000FFULL;
-        constexpr const auto from = 0ULL;
-        constexpr const auto name = "vector";
+namespace vector
+{
+constexpr const auto mask = 0x00000000000000FFULL;
+constexpr const auto from = 0ULL;
+constexpr const auto name = "vector";
 
-        inline void set(value_type val) noexcept
-        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+inline void set(value_type val) noexcept
+{ _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
 
-        inline auto set(value_type msr, value_type val) noexcept
-        { return set_bits(msr, mask, val << from); }
-    }
+inline auto set(value_type msr, value_type val) noexcept
+{ return set_bits(msr, mask, val << from); }
+}
 }
 }
 
 namespace lapic
 {
-    inline auto x2apic_supported() noexcept
-    {
-        return cpuid::feature_information::ecx::x2apic::is_enabled();
-    }
+inline auto x2apic_supported() noexcept
+{
+    return cpuid::feature_information::ecx::x2apic::is_enabled();
+}
 }
 }
 

--- a/bfintrinsics/tests/arch/intel_x64/test_cpuid.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/test_cpuid.cpp
@@ -88,9 +88,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_stepping_id")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::stepping_id::get() ==
-            (eax::stepping_id::mask >> eax::stepping_id::from));
+          (eax::stepping_id::mask >> eax::stepping_id::from));
     CHECK(eax::stepping_id::get(eax::stepping_id::mask) ==
-            (eax::stepping_id::mask >> eax::stepping_id::from));
+          (eax::stepping_id::mask >> eax::stepping_id::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_eax_model")
@@ -99,9 +99,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_model")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::model::get() ==
-            (eax::model::mask >> eax::model::from));
+          (eax::model::mask >> eax::model::from));
     CHECK(eax::model::get(eax::model::mask) ==
-            (eax::model::mask >> eax::model::from));
+          (eax::model::mask >> eax::model::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_eax_family_id")
@@ -110,9 +110,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_family_id")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::family_id::get() ==
-            (eax::family_id::mask >> eax::family_id::from));
+          (eax::family_id::mask >> eax::family_id::from));
     CHECK(eax::family_id::get(eax::family_id::mask) ==
-            (eax::family_id::mask >> eax::family_id::from));
+          (eax::family_id::mask >> eax::family_id::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_eax_processor_type")
@@ -121,9 +121,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_processor_type")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::processor_type::get() ==
-            (eax::processor_type::mask >> eax::processor_type::from));
+          (eax::processor_type::mask >> eax::processor_type::from));
     CHECK(eax::processor_type::get(eax::processor_type::mask) ==
-            (eax::processor_type::mask >> eax::processor_type::from));
+          (eax::processor_type::mask >> eax::processor_type::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_eax_extended_model_id")
@@ -132,9 +132,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_extended_model_id")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::extended_model_id::get() ==
-            (eax::extended_model_id::mask >> eax::extended_model_id::from));
+          (eax::extended_model_id::mask >> eax::extended_model_id::from));
     CHECK(eax::extended_model_id::get(eax::extended_model_id::mask) ==
-            (eax::extended_model_id::mask >> eax::extended_model_id::from));
+          (eax::extended_model_id::mask >> eax::extended_model_id::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_eax_extended_family_id")
@@ -143,9 +143,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_eax_extended_family_id")
 
     g_eax_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(eax::extended_family_id::get() ==
-            (eax::extended_family_id::mask >> eax::extended_family_id::from));
+          (eax::extended_family_id::mask >> eax::extended_family_id::from));
     CHECK(eax::extended_family_id::get(eax::extended_family_id::mask) ==
-            (eax::extended_family_id::mask >> eax::extended_family_id::from));
+          (eax::extended_family_id::mask >> eax::extended_family_id::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_ebx")
@@ -162,9 +162,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_ebx_brand_index")
 
     g_ebx_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(ebx::brand_index::get() ==
-            (ebx::brand_index::mask >> ebx::brand_index::from));
+          (ebx::brand_index::mask >> ebx::brand_index::from));
     CHECK(ebx::brand_index::get(ebx::brand_index::mask) ==
-            (ebx::brand_index::mask >> ebx::brand_index::from));
+          (ebx::brand_index::mask >> ebx::brand_index::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_ebx_clflush_line_size")
@@ -173,9 +173,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_ebx_clflush_line_size")
 
     g_ebx_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(ebx::clflush_line_size::get() ==
-            (ebx::clflush_line_size::mask >> ebx::clflush_line_size::from));
+          (ebx::clflush_line_size::mask >> ebx::clflush_line_size::from));
     CHECK(ebx::clflush_line_size::get(ebx::clflush_line_size::mask) ==
-            (ebx::clflush_line_size::mask >> ebx::clflush_line_size::from));
+          (ebx::clflush_line_size::mask >> ebx::clflush_line_size::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_ebx_max_addressable_ids")
@@ -184,9 +184,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_ebx_max_addressable_ids")
 
     g_ebx_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(ebx::max_addressable_ids::get() ==
-            (ebx::max_addressable_ids::mask >> ebx::max_addressable_ids::from));
+          (ebx::max_addressable_ids::mask >> ebx::max_addressable_ids::from));
     CHECK(ebx::max_addressable_ids::get(ebx::max_addressable_ids::mask) ==
-            (ebx::max_addressable_ids::mask >> ebx::max_addressable_ids::from));
+          (ebx::max_addressable_ids::mask >> ebx::max_addressable_ids::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_ebx_initial_apic_id")
@@ -195,9 +195,9 @@ TEST_CASE("intrinsics: cpuid_feature_information_ebx_initial_apic_id")
 
     g_ebx_cpuid[addr] = 0xFFFFFFFFULL;
     CHECK(ebx::initial_apic_id::get() ==
-            (ebx::initial_apic_id::mask >> ebx::initial_apic_id::from));
+          (ebx::initial_apic_id::mask >> ebx::initial_apic_id::from));
     CHECK(ebx::initial_apic_id::get(ebx::initial_apic_id::mask) ==
-            (ebx::initial_apic_id::mask >> ebx::initial_apic_id::from));
+          (ebx::initial_apic_id::mask >> ebx::initial_apic_id::from));
 }
 
 TEST_CASE("intrinsics: cpuid_feature_information_ecx")

--- a/bfruntime/tests/crt/test_crt.cpp
+++ b/bfruntime/tests/crt/test_crt.cpp
@@ -60,7 +60,7 @@ TEST_CASE("bfmain and mock_main")
     try {
         mock_abort();
     }
-    catch(...)
+    catch (...)
     { }
 }
 

--- a/bfsdk/include/bfdebug.h
+++ b/bfsdk/include/bfdebug.h
@@ -104,7 +104,17 @@ unsafe_write_cstr(const char *cstr, size_t len);
 #define CALLED() \
     { \
         const char *str_text = "\033[1;32mDEBUG\033[0m: function called = "; \
-        const char *str_func = __PRETTY_FUNCTION__; \
+        const char *str_func = __BFFUNC__; \
+        const char *str_endl = "\n"; \
+        unsafe_write_cstr(str_text, strlen(str_text)); \
+        unsafe_write_cstr(str_func, strlen(str_func)); \
+        unsafe_write_cstr(str_endl, strlen(str_endl)); \
+    }
+
+#define WARNING(a) \
+    { \
+        const char *str_text = "\033[1;33mWARNING\033[0m: " a " = "; \
+        const char *str_func = __BFFUNC__; \
         const char *str_endl = "\n"; \
         unsafe_write_cstr(str_text, strlen(str_text)); \
         unsafe_write_cstr(str_func, strlen(str_func)); \
@@ -114,7 +124,7 @@ unsafe_write_cstr(const char *cstr, size_t len);
 #define UNHANDLED() \
     { \
         const char *str_text = "\033[1;33mWARNING\033[0m: unsupported function called = "; \
-        const char *str_func = __PRETTY_FUNCTION__; \
+        const char *str_func = __BFFUNC__; \
         const char *str_endl = "\n"; \
         unsafe_write_cstr(str_text, strlen(str_text)); \
         unsafe_write_cstr(str_func, strlen(str_func)); \
@@ -124,7 +134,7 @@ unsafe_write_cstr(const char *cstr, size_t len);
 #define ARG_UNSUPPORTED(a) \
     { \
         const char *str_text = "\033[1;33mWARNING\033[0m: " a " not supported for function called = "; \
-        const char *str_func = __PRETTY_FUNCTION__; \
+        const char *str_func = __BFFUNC__; \
         const char *str_endl = "\n"; \
         unsafe_write_cstr(str_text, strlen(str_text)); \
         unsafe_write_cstr(str_func, strlen(str_func)); \

--- a/bfvmm/include/memory_manager/buddy_allocator.h
+++ b/bfvmm/include/memory_manager/buddy_allocator.h
@@ -1,0 +1,534 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef BUDDY_ALLOCATOR_H
+#define BUDDY_ALLOCATOR_H
+
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfexception.h>
+
+#include <mutex>
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+#ifndef BUDDY_ALLOCATOR_DEBUG
+#define BUDDY_ALLOCATOR_DEBUG 5
+#endif
+
+#ifndef BUDDY_ALLOCATOR_PAGE_SIZE
+#define BUDDY_ALLOCATOR_PAGE_SIZE 0x1000
+#endif
+
+/// Round to Next Power of 2
+///
+/// http://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+///
+inline auto
+next_power_2(uint64_t size)
+{
+    size--;
+    size |= size >> 1;
+    size |= size >> 2;
+    size |= size >> 4;
+    size |= size >> 8;
+    size |= size >> 16;
+    size |= size >> 32;
+    size++;
+
+    return size;
+}
+
+
+// -----------------------------------------------------------------------------
+// Buddy Allocator Definition
+// -----------------------------------------------------------------------------
+
+/// Buddy Allocator
+///
+/// The goals of this allocator includes:
+/// - O(log2n) allocation time
+/// - O(log2n) deallocation time
+/// - No external fragmentation (internal fragmentation is allowed, and can
+///   be high depending on the size of the object)
+/// - All allocations are a multiple of a page
+///
+/// To support these features, this allocator uses 2 buffers.
+/// - buffer: this is the main buffer that is allocated and returned. This
+///   buffer must be page aligned, and a power of 2^k.
+/// - node tree buffer: The node tree buffer stores the binary tree that keeps
+///   track of each allocation.
+///
+class buddy_allocator
+{
+public:
+
+    using pointer = void *;                 ///< Pointer type
+    using integer_pointer = uintptr_t;      ///< Integer pointer type
+    using size_type = std::size_t;          ///< Size type
+
+private:
+
+    /// @struct node
+    ///
+    /// This node is used to define the binary tree. child0 and child1 define
+    /// the child nodes (left or right) in the binary tree. ptr stores the
+    /// location in the provided buffer that this node refers to, and size
+    /// defines the size of the allocation. Note that bits 62-63 in the size
+    /// field define the type of node. 00 == unused, 01 == leaf and
+    /// 10 == parent. This binary tree doesn't set child0 and child1 to 0
+    /// on deallocation, but instead changes the node type in the field size.
+    /// This is done to prevent the need to recycle nodes. Once a node is
+    /// created, it remains in place, and the node type is used to determine
+    /// its state. This greatly simplifies the overall design of the buddy
+    /// allocator, and reduces the amount of memory that is needed for
+    /// bookkeeping. A deallocation consists of simply setting the node type to
+    /// from 1 (all allocations are leaf nodes) to 0 (for unused). Finally
+    /// the adjacent node's type is checked. If the adjacent node is also
+    /// unused, the parent node's type is changed to unused, and the process
+    /// is repeated. The nodes remain in place, and future allocations simply
+    /// change the node type to represent an allocation. Finally, type 11
+    /// means the node is full. This is an optimization to speed up allocations
+    /// by preventing a search from occuring on nodes that do not have
+    /// available memory.
+    ///
+    struct node_t {
+        node_t *child0;
+        node_t *child1;
+        integer_pointer ptr;
+        size_type size;
+    };
+
+    auto get_size(node_t *node) const
+    { return get_bits(node->size, 0x0FFFFFFFFFFFFFFF); }
+
+    auto is_unused(node_t *node) const
+    { return get_bits(node->size, 0xC000000000000000) == 0x0000000000000000; }
+
+    auto is_leaf(node_t *node) const
+    { return get_bits(node->size, 0xC000000000000000) == 0x4000000000000000; }
+
+    auto is_parent(node_t *node) const
+    { return get_bits(node->size, 0xC000000000000000) == 0x8000000000000000; }
+
+    auto is_full(node_t *node) const
+    { return get_bits(node->size, 0xC000000000000000) == 0xC000000000000000; }
+
+    node_t *set_unused(node_t *node)
+    {
+        node->size = set_bits(node->size, 0xC000000000000000, 0x0000000000000000);
+        return node;
+    }
+
+    node_t *set_leaf(node_t *node)
+    {
+        node->size = set_bits(node->size, 0xC000000000000000, 0x4000000000000000);
+        return node;
+    }
+
+    node_t *set_parent(node_t *node)
+    {
+        node->size = set_bits(node->size, 0xC000000000000000, 0x8000000000000000);
+        return node;
+    }
+
+    node_t *set_full(node_t *node)
+    {
+        node->size = set_bits(node->size, 0xC000000000000000, 0xC000000000000000);
+        return node;
+    }
+
+public:
+
+    /// Pointer Constructor
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param buffer the buffer that the buddy allocator will manage. Note
+    ///     that the buddy allocator will never dereference the address
+    ///     provided here, allowing it to be used for virtual memory allocation
+    /// @param k the size of the buffer using the formula:
+    ///     (1ULL << k) * BUDDY_ALLOCATOR_PAGE_SIZE
+    /// @param node_tree the buffer that will be used to store the buddy
+    ///     allocators binary tree. This buffer is assume to be
+    ///     buddy_allocator::node_tree_size(k).
+    ///
+    buddy_allocator(
+        pointer buffer, size_type k, void *node_tree
+    ) noexcept :
+        buddy_allocator(
+            reinterpret_cast<integer_pointer>(buffer), k, node_tree
+        )
+    { }
+
+    /// Integer Pointer Constructor
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param buffer the buffer that the buddy allocator will manage. Note
+    ///     that the buddy allocator will never dereference the address
+    ///     provided here, allowing it to be used for virtual memory allocation
+    /// @param k the size of the buffer using the formula:
+    ///     (1ULL << k) * BUDDY_ALLOCATOR_PAGE_SIZE
+    /// @param node_tree the buffer that will be used to store the buddy
+    ///     allocators binary tree. This buffer is assume to be
+    ///     buddy_allocator::node_tree_size(k).
+    ///
+    buddy_allocator(
+        integer_pointer buffer, size_type k, void *node_tree) noexcept
+    {
+        m_buffer = buffer;
+        m_buffer_size = this->buffer_size(k);
+
+        m_nodes = static_cast<node_t *>(node_tree);
+        m_nodes_view = gsl::span<node_t>(m_nodes, this->node_tree_size(k));
+
+        m_root = &m_nodes_view[m_node_index++];
+        m_root->ptr = m_buffer;
+        m_root->size = m_buffer_size;
+    }
+
+    /// Destructor
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @note The destructor has to be a default as the buddy allocator could
+    ///     be used as a global resource, and global destructors are not
+    ///     fully supported.
+    ///
+    ~buddy_allocator() noexcept = default;
+
+    /// Allocate
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param size the size of the allocation
+    /// @return an allocated object. Throws otherwise
+    ///
+    pointer allocate(size_type size)
+    {
+        if (size > m_buffer_size || size == 0) {
+            throw std::bad_alloc();
+        }
+
+        if (get_bits(size, BUDDY_ALLOCATOR_PAGE_SIZE - 1) != 0x0) {
+            size = BUDDY_ALLOCATOR_PAGE_SIZE;
+        }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (auto ptr = this->private_allocate(next_power_2(size), nullptr, m_root)) {
+            return ptr;
+        }
+
+        throw std::bad_alloc();
+    }
+
+    /// Deallocate
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param ptr a pointer to a previously allocated object to be deallocated
+    ///
+    void deallocate(pointer ptr)
+    {
+        auto uintptr = reinterpret_cast<integer_pointer>(ptr);
+
+        if (ptr == nullptr) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        this->private_deallocate(uintptr, nullptr, m_root);
+    }
+
+    /// Size
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param ptr a pointer to a previously allocated object
+    /// @return the size of ptr
+    ///
+    size_type size(pointer ptr) const
+    {
+        auto uintptr = reinterpret_cast<integer_pointer>(ptr);
+
+        if (ptr == nullptr) {
+            return 0;
+        }
+
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return this->private_size(uintptr, nullptr, m_root);
+    }
+
+    /// Contains Address
+    ///
+    /// Returns true if this buddy allocator contains this address, returns
+    /// false otherwise.
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param ptr to lookup
+    /// @return true if the buddy allocator contains ptr, false otherwise
+    ///
+    bool
+    contains(integer_pointer ptr) const noexcept
+    { return (ptr >= m_buffer && ptr < m_buffer + m_buffer_size); }
+
+    /// Buffer Size
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param k the size of the buffer using the formula:
+    ///     (1ULL << k) * BUDDY_ALLOCATOR_PAGE_SIZE
+    /// @return the size of buffer given size k
+    ///
+    constexpr static size_type buffer_size(size_type k)
+    { return (1ULL << k) * BUDDY_ALLOCATOR_PAGE_SIZE; }
+
+    /// Node Tree Size
+    ///
+    /// @expects none
+    /// @ensures none
+    ///
+    /// @param k the size of the buffer using the formula:
+    ///     (1ULL << k) * BUDDY_ALLOCATOR_PAGE_SIZE
+    /// @return the size of the node tree given size k
+    ///
+    constexpr static size_type node_tree_size(size_type k)
+    { return ((2ULL << k) - 1ULL) * sizeof(node_t); }
+
+private:
+
+    void get_nodes(node_t *parent)
+    {
+        auto child0 = &m_nodes_view[m_node_index++];
+        auto child1 = &m_nodes_view[m_node_index++];
+
+        child0->size = this->get_size(parent) >> 1;
+        child1->size = this->get_size(parent) >> 1;
+
+        child0->ptr = parent->ptr;
+        child1->ptr = parent->ptr + child0->size;
+
+        parent->child0 = child0;
+        parent->child1 = child1;
+    }
+
+    pointer private_allocate(
+        size_type size, node_t *parent, node_t *node)
+    {
+        if (this->is_leaf(node) || this->is_full(node)) {
+            return 0;
+        }
+
+        if (size == this->get_size(node)) {
+            if (this->is_unused(node)) {
+
+                bfdebug_transaction(1, [&](std::string * msg) {
+                    bfdebug_info(BUDDY_ALLOCATOR_DEBUG, "allocate", msg);
+                    bfdebug_subnhex(BUDDY_ALLOCATOR_DEBUG, "ptr", node->ptr, msg);
+                    bfdebug_subnhex(BUDDY_ALLOCATOR_DEBUG, "size", this->get_size(node), msg);
+                    bfdebug_brk2(BUDDY_ALLOCATOR_DEBUG, msg);
+                });
+
+                return reinterpret_cast<pointer>(this->set_leaf(node)->ptr);
+            }
+        }
+        else {
+            if (!node->child0) {
+                this->get_nodes(node);
+            }
+
+            if (size == this->get_size(node->child0)) {
+                if (this->is_unused(node->child0)) {
+                    bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child0: unused", this->get_size(node));
+                    if (auto ptr = private_allocate_next(size, node, node->child0)) {
+                        return ptr;
+                    }
+                }
+            }
+            else {
+                if (!this->is_full(node->child0) && !this->is_leaf(node->child0)) {
+                    bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child0: !full", this->get_size(node));
+                    if (auto ptr = private_allocate_next(size, node, node->child0)) {
+                        return ptr;
+                    }
+                }
+            }
+
+            if (size == this->get_size(node->child1)) {
+                if (this->is_unused(node->child1)) {
+                    bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child1: unused", this->get_size(node));
+                    if (auto ptr = private_allocate_next(size, node, node->child1)) {
+                        return ptr;
+                    }
+                }
+            }
+            else {
+                if (!this->is_full(node->child1) && !this->is_leaf(node->child1)) {
+                    bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child1: !full", this->get_size(node));
+                    if (auto ptr = private_allocate_next(size, node, node->child1)) {
+                        return ptr;
+                    }
+                }
+            }
+        }
+
+        return nullptr;
+    }
+
+    pointer private_allocate_next(
+        size_type size, node_t *parent, node_t *node)
+    {
+        auto ptr = private_allocate(size, parent, node);
+
+        if (ptr && parent) {
+            this->set_parent(parent);
+
+            if (this->is_leaf(parent->child0) && this->is_leaf(parent->child1)) {
+                this->set_full(parent);
+            }
+
+            if (this->is_leaf(parent->child0) && this->is_full(parent->child1)) {
+                this->set_full(parent);
+            }
+
+            if (this->is_full(parent->child0) && this->is_leaf(parent->child1)) {
+                this->set_full(parent);
+            }
+
+            if (this->is_full(parent->child0) && this->is_full(parent->child1)) {
+                this->set_full(parent);
+            }
+        }
+
+        return ptr;
+    }
+
+private:
+
+    bool private_deallocate(
+        integer_pointer ptr, node_t *parent, node_t *node)
+    {
+        if (this->is_leaf(node)) {
+
+            bfdebug_transaction(1, [&](std::string * msg) {
+                bfdebug_info(BUDDY_ALLOCATOR_DEBUG, "deallocate", msg);
+                bfdebug_subnhex(BUDDY_ALLOCATOR_DEBUG, "ptr", node->ptr, msg);
+                bfdebug_subnhex(BUDDY_ALLOCATOR_DEBUG, "size", this->get_size(node), msg);
+                bfdebug_brk2(BUDDY_ALLOCATOR_DEBUG, msg);
+            });
+
+            this->set_unused(node);
+            return true;
+        }
+        else {
+            if (!node->child0) {
+                return false;
+            }
+
+            if (ptr < node->child0->ptr + this->get_size(node->child0)) {
+                bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child0: equal", this->get_size(node));
+                return private_deallocate_next(ptr, node, node->child0);
+            }
+            else {
+                bfdebug_nhex(BUDDY_ALLOCATOR_DEBUG, "child0: not equal", this->get_size(node));
+                return private_deallocate_next(ptr, node, node->child1);
+            }
+        }
+
+        return false;
+    }
+
+    bool private_deallocate_next(
+        integer_pointer ptr, node_t *parent, node_t *node)
+    {
+        auto res = private_deallocate(ptr, parent, node);
+
+        if (res && parent) {
+            this->set_parent(parent);
+
+            if (this->is_unused(parent->child0) && this->is_unused(parent->child1)) {
+                this->set_unused(parent);
+            }
+        }
+
+        return res;
+    }
+
+private:
+
+    size_type private_size(
+        integer_pointer ptr, node_t *parent, node_t *node) const
+    {
+        if (this->is_leaf(node)) {
+            return this->get_size(node);
+        }
+        else {
+            if (!node->child0) {
+                return 0;
+            }
+
+            if (ptr < node->child0->ptr + this->get_size(node->child0)) {
+                return private_size(ptr, node, node->child0);
+            }
+            else {
+                return private_size(ptr, node, node->child1);
+            }
+        }
+
+        return 0;
+    }
+
+private:
+
+    integer_pointer m_buffer{0};
+    size_type m_buffer_size{0};
+
+    node_t *m_nodes{nullptr};
+    gsl::span<node_t> m_nodes_view;
+
+    node_t *m_root{nullptr};
+    size_type m_node_index{0};
+
+    mutable std::mutex m_mutex;
+
+public:
+
+    /// @cond
+
+    buddy_allocator(buddy_allocator &&) noexcept = delete;
+    buddy_allocator &operator=(buddy_allocator &&) noexcept = delete;
+
+    buddy_allocator(const buddy_allocator &) = delete;
+    buddy_allocator &operator=(const buddy_allocator &) = delete;
+
+    /// @endcond
+};
+
+#endif

--- a/bfvmm/include/memory_manager/memory_manager.h
+++ b/bfvmm/include/memory_manager/memory_manager.h
@@ -26,6 +26,7 @@
 #include <bfconstants.h>
 
 #include "mem_pool.h"
+#include "buddy_allocator.h"
 
 // -----------------------------------------------------------------------------
 // Exports
@@ -403,8 +404,9 @@ private:
     std::map<integer_pointer, attr_type> m_virt_to_attr_map;
 
     mem_pool<MAX_HEAP_POOL, 6ULL> g_heap_pool;
-    mem_pool<MAX_PAGE_POOL, 12ULL> g_page_pool;
-    mem_pool<MAX_MEM_MAP_POOL, 12ULL> g_mem_map_pool;
+
+    buddy_allocator g_page_pool;
+    buddy_allocator g_mem_map_pool;
 
 public:
 

--- a/bfvmm/src/vcpu/vcpu_manager.cpp
+++ b/bfvmm/src/vcpu/vcpu_manager.cpp
@@ -93,7 +93,7 @@ vcpu_manager::add_vcpu(vcpuid::type vcpuid, bfobject *obj)
         return vcpu;
     }
 
-    if (auto &&vcpu = m_vcpu_factory->make_vcpu(vcpuid, obj)) {
+    if (auto vcpu = m_vcpu_factory->make_vcpu(vcpuid, obj)) {
         std::lock_guard<std::mutex> guard(g_vcpu_manager_mutex);
         return m_vcpus[vcpuid] = std::move(vcpu);
     }

--- a/bfvmm/tests/memory_manager/CMakeLists.txt
+++ b/bfvmm/tests/memory_manager/CMakeLists.txt
@@ -16,21 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-cmake_minimum_required(VERSION 3.6)
-project(bfvmm_test C CXX)
-
-include(${SOURCE_CMAKE_DIR}/project.cmake)
-init_project(
-    INCLUDES ${CMAKE_CURRENT_LIST_DIR}/../include
+do_test(test_buddy_allocator
+    SOURCES test_buddy_allocator.cpp
+    DEFINES STATIC_MEMORY_MANAGER
 )
-
-add_subdirectory(../src/debug ${CMAKE_CURRENT_BINARY_DIR}/src/debug)
-add_subdirectory(../src/hve ${CMAKE_CURRENT_BINARY_DIR}/src/hve)
-add_subdirectory(../src/memory_manager ${CMAKE_CURRENT_BINARY_DIR}/src/memory_manager)
-add_subdirectory(../src/vcpu ${CMAKE_CURRENT_BINARY_DIR}/src/vcpu)
-
-add_subdirectory(debug)
-add_subdirectory(hve)
-add_subdirectory(memory_manager)
-add_subdirectory(vcpu)
-add_subdirectory(support)

--- a/bfvmm/tests/memory_manager/test_buddy_allocator.cpp
+++ b/bfvmm/tests/memory_manager/test_buddy_allocator.cpp
@@ -1,0 +1,1285 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2015 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <catch/catch.hpp>
+#include <memory_manager/buddy_allocator.h>
+
+extern "C" uint64_t
+unsafe_write_cstr(const char *cstr, size_t len)
+{ bfignored(cstr); bfignored(len); return 0; }
+
+auto k = 3ULL;
+auto node_tree_size = buddy_allocator::node_tree_size(k);
+
+TEST_CASE("buddy_allocator: next_power_2")
+{
+    CHECK(next_power_2(0x1000) == 0x1000);
+    CHECK(next_power_2(0x2000) == 0x2000);
+    CHECK(next_power_2(0x3000) == 0x4000);
+    CHECK(next_power_2(0x4000) == 0x4000);
+    CHECK(next_power_2(0x0700000000000000) == 0x0800000000000000);
+    CHECK(next_power_2(0x0800000000000000) == 0x0800000000000000);
+}
+
+TEST_CASE("buddy_allocator: buffer_size")
+{
+    CHECK(buddy_allocator::buffer_size(0) == 0x1000);
+    CHECK(buddy_allocator::buffer_size(1) == 0x2000);
+    CHECK(buddy_allocator::buffer_size(2) == 0x4000);
+}
+
+TEST_CASE("buddy_allocator: node_tree_size")
+{
+    CHECK(buddy_allocator::node_tree_size(0) == 1 * 32);
+    CHECK(buddy_allocator::node_tree_size(1) == 3 * 32);
+    CHECK(buddy_allocator::node_tree_size(2) == 7 * 32);
+}
+
+TEST_CASE("buddy_allocator: constructor pointer")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator{reinterpret_cast<void *>(0x100000ULL), k, nt.get()};
+}
+
+TEST_CASE("buddy_allocator: constructor integer pointer")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator{0x100000ULL, k, nt.get()};
+}
+
+TEST_CASE("buddy_allocator: zero allocation")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_THROWS(buddy.allocate(0));
+}
+
+TEST_CASE("buddy_allocator: huge allocation")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_THROWS(buddy.allocate(0xFFFFFFFFFFFFFFFF));
+}
+
+TEST_CASE("buddy_allocator: unaligned allocation")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(10));
+}
+
+TEST_CASE("buddy_allocator: allocation all 4k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation all in 8k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation all in 16k blocks and unalgined")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x3000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation all in 32k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x8000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 8k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 8k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 8k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 8k / 4k / 8k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 8k / 4k / 8k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 16k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 16k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 16k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 4k / 8k / 16k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 16k / 8k / 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 16k / 4k / 8k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation mixed 8k / 16k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+
+TEST_CASE("buddy_allocator: allocation mixed 16k / 8k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    CHECK_THROWS(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation, uneven 4k / 8k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation, uneven 4k / 16k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: allocation, uneven 4k / 32k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_THROWS(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: deallocation nullptr")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    buddy.deallocate(nullptr);
+}
+
+TEST_CASE("buddy_allocator: deallocation unaligned")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    buddy.deallocate(reinterpret_cast<void *>(0x100010ULL));
+}
+
+TEST_CASE("buddy_allocator: deallocation random")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    buddy.deallocate(reinterpret_cast<void *>(0x123450000ULL));
+}
+
+TEST_CASE("buddy_allocator: deallocation unallocated")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    buddy.deallocate(reinterpret_cast<void *>(0x100000ULL));
+}
+
+TEST_CASE("buddy_allocator: deallocation twice")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr1);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #1")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #2")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr2);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #3")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr3);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #4")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr4);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #5")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr5);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #6")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr6);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #7")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr7);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 4k, allocate single 4k #8")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr8);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #1/2")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #3/4")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #5/6")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #7/8")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 16k #1/2/3/4")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 16k #5/6/7/8")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #2/3 fail")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #4/5 fail")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 8k #6/7 fail")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    CHECK_THROWS(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation double 4k, allocate single 16k #3/4/5/6")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    CHECK_THROWS(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+}
+
+TEST_CASE("buddy_allocator: deallocation all 4k, allocate all 4k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+}
+
+TEST_CASE("buddy_allocator: deallocation all 4k, allocate all 8k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+}
+
+TEST_CASE("buddy_allocator: deallocation all 4k, allocate all 16k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+    CHECK_NOTHROW(buddy.allocate(0x4000));
+}
+
+TEST_CASE("buddy_allocator: deallocation all 4k, allocate all 32k")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+    buddy.deallocate(ptr5);
+    buddy.deallocate(ptr6);
+    buddy.deallocate(ptr7);
+    buddy.deallocate(ptr8);
+
+    CHECK_NOTHROW(buddy.allocate(0x8000));
+}
+
+TEST_CASE("buddy_allocator: deallocation single 8k, allocate double 4k #1")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x2000);
+    auto ptr2 = buddy.allocate(0x2000);
+    auto ptr3 = buddy.allocate(0x2000);
+    auto ptr4 = buddy.allocate(0x2000);
+
+    buddy.deallocate(ptr1);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 8k, allocate double 4k #2")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x2000);
+    auto ptr2 = buddy.allocate(0x2000);
+    auto ptr3 = buddy.allocate(0x2000);
+    auto ptr4 = buddy.allocate(0x2000);
+
+    buddy.deallocate(ptr2);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 8k, allocate double 4k #3")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x2000);
+    auto ptr2 = buddy.allocate(0x2000);
+    auto ptr3 = buddy.allocate(0x2000);
+    auto ptr4 = buddy.allocate(0x2000);
+
+    buddy.deallocate(ptr3);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 8k, allocate double 4k #4")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x2000);
+    auto ptr2 = buddy.allocate(0x2000);
+    auto ptr3 = buddy.allocate(0x2000);
+    auto ptr4 = buddy.allocate(0x2000);
+
+    buddy.deallocate(ptr4);
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+    buddy.deallocate(ptr3);
+    buddy.deallocate(ptr4);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 16k, allocate 4k, 8k #1")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x4000);
+    auto ptr2 = buddy.allocate(0x4000);
+
+    buddy.deallocate(ptr1);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+}
+
+TEST_CASE("buddy_allocator: deallocation single 16k, allocate 4k, 8k #2")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x4000);
+    auto ptr2 = buddy.allocate(0x4000);
+
+    buddy.deallocate(ptr2);
+    CHECK_NOTHROW(buddy.allocate(0x2000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+    CHECK_NOTHROW(buddy.allocate(0x1000));
+
+    buddy.deallocate(ptr1);
+    buddy.deallocate(ptr2);
+}
+
+TEST_CASE("buddy_allocator: size nullptr")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK(buddy.size(nullptr) == 0);
+}
+
+TEST_CASE("buddy_allocator: size unaligned")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK(buddy.size(reinterpret_cast<void *>(0x100010ULL)) == 0);
+}
+
+TEST_CASE("buddy_allocator: size random")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK(buddy.size(reinterpret_cast<void *>(0x123450000ULL)) == 0);
+}
+
+TEST_CASE("buddy_allocator: size unallocated")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    CHECK(buddy.size(reinterpret_cast<void *>(0x100000ULL)) == 0);
+}
+TEST_CASE("buddy_allocator: size 4k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x1000);
+    auto ptr2 = buddy.allocate(0x1000);
+    auto ptr3 = buddy.allocate(0x1000);
+    auto ptr4 = buddy.allocate(0x1000);
+    auto ptr5 = buddy.allocate(0x1000);
+    auto ptr6 = buddy.allocate(0x1000);
+    auto ptr7 = buddy.allocate(0x1000);
+    auto ptr8 = buddy.allocate(0x1000);
+
+    CHECK(buddy.size(ptr1) == 0x1000);
+    CHECK(buddy.size(ptr2) == 0x1000);
+    CHECK(buddy.size(ptr3) == 0x1000);
+    CHECK(buddy.size(ptr4) == 0x1000);
+    CHECK(buddy.size(ptr5) == 0x1000);
+    CHECK(buddy.size(ptr6) == 0x1000);
+    CHECK(buddy.size(ptr7) == 0x1000);
+    CHECK(buddy.size(ptr8) == 0x1000);
+}
+
+TEST_CASE("buddy_allocator: size 8k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x2000);
+    auto ptr2 = buddy.allocate(0x2000);
+    auto ptr3 = buddy.allocate(0x2000);
+    auto ptr4 = buddy.allocate(0x2000);
+
+    CHECK(buddy.size(ptr1) == 0x2000);
+    CHECK(buddy.size(ptr2) == 0x2000);
+    CHECK(buddy.size(ptr3) == 0x2000);
+    CHECK(buddy.size(ptr4) == 0x2000);
+}
+
+TEST_CASE("buddy_allocator: size 16k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x4000);
+    auto ptr2 = buddy.allocate(0x4000);
+
+    CHECK(buddy.size(ptr1) == 0x4000);
+    CHECK(buddy.size(ptr2) == 0x4000);
+}
+
+TEST_CASE("buddy_allocator: size 32k blocks")
+{
+    auto nt = std::make_unique<char[]>(node_tree_size);
+    buddy_allocator buddy{0x100000ULL, k, nt.get()};
+
+    auto ptr1 = buddy.allocate(0x8000);
+    CHECK(buddy.size(ptr1) == 0x8000);
+}

--- a/bfvmm/tests/support/arch/intel_x64/test_support.h
+++ b/bfvmm/tests/support/arch/intel_x64/test_support.h
@@ -324,6 +324,10 @@ physint_to_virtptr(uintptr_t ptr)
     return static_cast<void *>(g_mock_mem[g_test_addr]);
 }
 
+extern "C" uint64_t
+unsafe_write_cstr(const char *cstr, size_t len)
+{ bfignored(cstr); bfignored(len); return 0; }
+
 extern "C" void vmcs_launch(
     bfvmm::intel_x64::save_state_t *save_state) noexcept
 { bfignored(save_state); }


### PR DESCRIPTION
This patch implemented the Buddy Allocator in place of the mem pool
for page allocation and memory mapping. The memory manager has been
updated to use the buddy allocator as well.

[RFC]: https://github.com/Bareflank/hypervisor/issues/493

Signed-off-by: Rian Quinn <rianquinn@gmail.com>