### PR TITLE
Fix serial drivers.

### DIFF
--- a/bfvmm/include/debug/serial/serial_ns16550a.h
+++ b/bfvmm/include/debug/serial/serial_ns16550a.h
@@ -103,12 +103,14 @@ public:
 
 public:
 
-    /// Default constructor
+    /// Constructor - uses the default port
     ///
     /// @expects none
     /// @ensures none
     ///
-    serial_ns16550a() noexcept;
+    /// @param port the IO port or MMIO address (platform-dependent)
+    ///
+    serial_ns16550a(uintptr_t port = DEFAULT_COM_PORT) noexcept;
 
     /// Destructor
     ///
@@ -233,6 +235,13 @@ private:
 
     void enable_dlab() const noexcept;
     void disable_dlab() const noexcept;
+    bool is_transmit_empty() const noexcept;
+
+    uint8_t inb(uint16_t addr) const noexcept;
+    void outb(uint16_t addr, uint8_t data) const noexcept;
+
+    /// MMIO address or IO port
+    uintptr_t m_addr;
 
 public:
 

--- a/bfvmm/include/debug/serial/serial_pl011.h
+++ b/bfvmm/include/debug/serial/serial_pl011.h
@@ -19,13 +19,11 @@
 #ifndef SERIAL_PORT_PL011_H
 #define SERIAL_PORT_PL011_H
 
-#include <string>
 #include <memory>
 
 #include <bfconstants.h>
 
 #include <intrinsics.h>
-#include "serial_port_base.h"
 
 // -----------------------------------------------------------------------------
 // Exports
@@ -49,145 +47,11 @@
 #endif
 
 // -----------------------------------------------------------------------------
-// Constants
+// Definition
 // -----------------------------------------------------------------------------
 
 namespace bfvmm
 {
-
-/// @cond
-
-// from ARM PrimeCell UART (PL011) Technical Reference Manual
-// http://infocenter.arm.com/help/topic/com.arm.doc.ddi0183f/DDI0183.pdf
-
-namespace serial_pl011
-{
-constexpr const serial_port_base::port_type uartdr_reg = 0x000u;
-constexpr const serial_port_base::port_type uartrsr_reg = 0x004u;
-constexpr const serial_port_base::port_type uartecr_reg = 0x004u;
-constexpr const serial_port_base::port_type uartfr_reg = 0x018u;
-constexpr const serial_port_base::port_type uartilpr_reg = 0x020u;
-constexpr const serial_port_base::port_type uartibrd_reg = 0x024u;
-constexpr const serial_port_base::port_type uartfbrd_reg = 0x028u;
-constexpr const serial_port_base::port_type uartlcr_h_reg = 0x02Cu;
-constexpr const serial_port_base::port_type uartcr_reg = 0x030u;
-constexpr const serial_port_base::port_type uartifls_reg = 0x034u;
-constexpr const serial_port_base::port_type uartimsc_reg = 0x038u;
-constexpr const serial_port_base::port_type uartris_reg = 0x03Cu;
-constexpr const serial_port_base::port_type uartmis_reg = 0x040u;
-constexpr const serial_port_base::port_type uarticr_reg = 0x044u;
-constexpr const serial_port_base::port_type uartdmacr_reg = 0x048u;
-constexpr const serial_port_base::port_type uartperiphid0_reg = 0xFE0u;
-constexpr const serial_port_base::port_type uartperiphid1_reg = 0xFE4u;
-constexpr const serial_port_base::port_type uartperiphid2_reg = 0xFE8u;
-constexpr const serial_port_base::port_type uartperiphid3_reg = 0xFECu;
-constexpr const serial_port_base::port_type uartpcellid0_reg = 0xFF0u;
-constexpr const serial_port_base::port_type uartpcellid1_reg = 0xFF4u;
-constexpr const serial_port_base::port_type uartpcellid2_reg = 0xFF8u;
-constexpr const serial_port_base::port_type uartpcellid3_reg = 0xFFCu;
-
-// Data register (UARTDR)
-constexpr const serial_port_base::value_type_32 uartdr_overrun_error = 1U << 11;
-constexpr const serial_port_base::value_type_32 uartdr_break_error = 1U << 10;
-constexpr const serial_port_base::value_type_32 uartdr_parity_error = 1U << 9;
-constexpr const serial_port_base::value_type_32 uartdr_framing_error = 1U << 8;
-constexpr const serial_port_base::value_type_32 uartdr_data_mask = 0xFFu;
-
-// Receive status register (UARTRSR)
-// Error clear register (UARTECR)
-constexpr const serial_port_base::value_type_32 uartrsr_overrun_error = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartrsr_break_error = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartrsr_parity_error = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartrsr_framing_error = 1U << 0;
-
-// Flag register (UARTFR)
-constexpr const serial_port_base::value_type_32 uartfr_ring_indicator = 1U << 8;
-constexpr const serial_port_base::value_type_32 uartfr_tx_empty = 1U << 7;
-constexpr const serial_port_base::value_type_32 uartfr_rx_full = 1U << 6;
-constexpr const serial_port_base::value_type_32 uartfr_tx_full = 1U << 5;
-constexpr const serial_port_base::value_type_32 uartfr_rx_empty = 1U << 4;
-constexpr const serial_port_base::value_type_32 uartfr_busy = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartfr_dcd = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartfr_dsr = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartfr_cts = 1U << 0;
-
-// Line control register (UARTLCR_H)
-constexpr const serial_port_base::value_type_32 uartlcr_h_wlen_mask = 3U << 5;
-constexpr const serial_port_base::value_type_32 uartlcr_h_wlen_8bit = 3U << 5;
-constexpr const serial_port_base::value_type_32 uartlcr_h_wlen_7bit = 2U << 5;
-constexpr const serial_port_base::value_type_32 uartlcr_h_wlen_6bit = 1U << 5;
-constexpr const serial_port_base::value_type_32 uartlcr_h_wlen_5bit = 0U << 5;
-constexpr const serial_port_base::value_type_32 uartlcr_h_fifo_enable = 1U << 4;
-constexpr const serial_port_base::value_type_32 uartlcr_h_stop_mask = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartlcr_h_stop_1bit = 0U << 3;
-constexpr const serial_port_base::value_type_32 uartlcr_h_stop_2bit = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartlcr_h_sps = 1U << 7;
-constexpr const serial_port_base::value_type_32 uartlcr_h_eps = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartlcr_h_pen = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_mask = uartlcr_h_sps | uartlcr_h_eps | uartlcr_h_pen;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_even = uartlcr_h_eps | uartlcr_h_pen;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_odd = uartlcr_h_pen;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_none = 0;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_one = uartlcr_h_pen | uartlcr_h_sps;
-constexpr const serial_port_base::value_type_32 uartlcr_h_parity_zero = uartlcr_h_pen | uartlcr_h_sps | uartlcr_h_eps;
-constexpr const serial_port_base::value_type_32 uartlcr_h_send_break = 1U << 0;
-
-// Control register (UARTCR)
-constexpr const serial_port_base::value_type_32 uartcr_ctse_n = 1U << 15;
-constexpr const serial_port_base::value_type_32 uartcr_rtse_n = 1U << 14;
-constexpr const serial_port_base::value_type_32 uartcr_out2 = 1U << 13;
-constexpr const serial_port_base::value_type_32 uartcr_out1 = 1U << 12;
-constexpr const serial_port_base::value_type_32 uartcr_rts = 1U << 11;
-constexpr const serial_port_base::value_type_32 uartcr_dtr = 1U << 10;
-constexpr const serial_port_base::value_type_32 uartcr_rx_en = 1U << 9;
-constexpr const serial_port_base::value_type_32 uartcr_tx_en = 1U << 8;
-constexpr const serial_port_base::value_type_32 uartcr_loopback_en = 1U << 7;
-constexpr const serial_port_base::value_type_32 uartcr_sirlp = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartcr_siren = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartcr_uart_en = 1U << 0;
-
-// Interrupt FIFO level select register (UARTIFLS)
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_mask = 7U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_1_8 = 0U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_1_4 = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_1_2 = 2U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_3_4 = 3U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_rxiflsel_7_8 = 4U << 3;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_mask = 7U << 0;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_1_8 = 0U << 0;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_1_4 = 1U << 0;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_1_2 = 2U << 0;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_3_4 = 3U << 0;
-constexpr const serial_port_base::value_type_32 uartifls_txiflsel_7_8 = 4U << 0;
-
-// Interrupt mask set/clear register (UARTIMSC)
-// Raw interrupt status register (UARTRIS)
-// Masked interrupt status register (UARTMIS)
-// Interrupt clear register (UARTICR)
-constexpr const serial_port_base::value_type_32 uartinterrupt_oe = 1U << 10;
-constexpr const serial_port_base::value_type_32 uartinterrupt_be = 1U << 9;
-constexpr const serial_port_base::value_type_32 uartinterrupt_pe = 1U << 8;
-constexpr const serial_port_base::value_type_32 uartinterrupt_fe = 1U << 7;
-constexpr const serial_port_base::value_type_32 uartinterrupt_rt = 1U << 6;
-constexpr const serial_port_base::value_type_32 uartinterrupt_tx = 1U << 5;
-constexpr const serial_port_base::value_type_32 uartinterrupt_rx = 1U << 4;
-constexpr const serial_port_base::value_type_32 uartinterrupt_dsrm = 1U << 3;
-constexpr const serial_port_base::value_type_32 uartinterrupt_dcdm = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartinterrupt_ctsm = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartinterrupt_rim = 1U << 0;
-
-// DMA control register (UARTDMACR)
-constexpr const serial_port_base::value_type_32 uartdmacr_dmaonerr = 1U << 2;
-constexpr const serial_port_base::value_type_32 uartdmacr_txdma_en = 1U << 1;
-constexpr const serial_port_base::value_type_32 uartdmacr_rxdma_en = 1U << 0;
-
-}
-
-/// @endcond
-
-// -----------------------------------------------------------------------------
-// Definitions
-// -----------------------------------------------------------------------------
 
 /// Serial Port (ARM PrimeCell PL011)
 ///
@@ -197,70 +61,192 @@ constexpr const serial_port_base::value_type_32 uartdmacr_rxdma_en = 1U << 0;
 /// Note that by default, a FIFO is used / required, and interrupts are
 /// disabled.
 ///
-class EXPORT_DEBUG serial_port_pl011 : public serial_port_base
+class EXPORT_DEBUG serial_pl011
 {
-public:
-
 public:
 
     /// @cond
 
-    enum data_bits_t : value_type_32 {
-        char_length_5 = serial_pl011::uartlcr_h_wlen_5bit,
-        char_length_6 = serial_pl011::uartlcr_h_wlen_6bit,
-        char_length_7 = serial_pl011::uartlcr_h_wlen_7bit,
-        char_length_8 = serial_pl011::uartlcr_h_wlen_8bit,
-    };
+    // from ARM PrimeCell UART (PL011) Technical Reference Manual
+    // http://infocenter.arm.com/help/topic/com.arm.doc.ddi0183f/DDI0183.pdf
 
-    enum stop_bits_t : value_type_32 {
-        stop_bits_1 = serial_pl011::uartlcr_h_stop_1bit,
-        stop_bits_2 = serial_pl011::uartlcr_h_stop_2bit,
-    };
+    static constexpr ptrdiff_t uartdr_reg = 0x000u;
+    static constexpr ptrdiff_t uartrsr_reg = 0x004u;
+    static constexpr ptrdiff_t uartecr_reg = 0x004u;
+    static constexpr ptrdiff_t uartfr_reg = 0x018u;
+    static constexpr ptrdiff_t uartilpr_reg = 0x020u;
+    static constexpr ptrdiff_t uartibrd_reg = 0x024u;
+    static constexpr ptrdiff_t uartfbrd_reg = 0x028u;
+    static constexpr ptrdiff_t uartlcr_h_reg = 0x02Cu;
+    static constexpr ptrdiff_t uartcr_reg = 0x030u;
+    static constexpr ptrdiff_t uartifls_reg = 0x034u;
+    static constexpr ptrdiff_t uartimsc_reg = 0x038u;
+    static constexpr ptrdiff_t uartris_reg = 0x03Cu;
+    static constexpr ptrdiff_t uartmis_reg = 0x040u;
+    static constexpr ptrdiff_t uarticr_reg = 0x044u;
+    static constexpr ptrdiff_t uartdmacr_reg = 0x048u;
+    static constexpr ptrdiff_t uartperiphid0_reg = 0xFE0u;
+    static constexpr ptrdiff_t uartperiphid1_reg = 0xFE4u;
+    static constexpr ptrdiff_t uartperiphid2_reg = 0xFE8u;
+    static constexpr ptrdiff_t uartperiphid3_reg = 0xFECu;
+    static constexpr ptrdiff_t uartpcellid0_reg = 0xFF0u;
+    static constexpr ptrdiff_t uartpcellid1_reg = 0xFF4u;
+    static constexpr ptrdiff_t uartpcellid2_reg = 0xFF8u;
+    static constexpr ptrdiff_t uartpcellid3_reg = 0xFFCu;
 
-    enum parity_bits_t : value_type_32 {
-        parity_none = serial_pl011::uartlcr_h_parity_none,
-        parity_odd = serial_pl011::uartlcr_h_parity_odd,
-        parity_even = serial_pl011::uartlcr_h_parity_even,
-        parity_mark = serial_pl011::uartlcr_h_parity_one,
-        parity_space = serial_pl011::uartlcr_h_parity_zero,
-    };
+    // Data register (UARTDR)
+    static constexpr uint32_t uartdr_overrun_error = 1U << 11;
+    static constexpr uint32_t uartdr_break_error = 1U << 10;
+    static constexpr uint32_t uartdr_parity_error = 1U << 9;
+    static constexpr uint32_t uartdr_framing_error = 1U << 8;
+    static constexpr uint32_t uartdr_data_mask = 0xFFu;
+
+    // Receive status register (UARTRSR)
+    // Error clear register (UARTECR)
+    static constexpr uint32_t uartrsr_overrun_error = 1U << 3;
+    static constexpr uint32_t uartrsr_break_error = 1U << 2;
+    static constexpr uint32_t uartrsr_parity_error = 1U << 1;
+    static constexpr uint32_t uartrsr_framing_error = 1U << 0;
+
+    // Flag register (UARTFR)
+    static constexpr uint32_t uartfr_ring_indicator = 1U << 8;
+    static constexpr uint32_t uartfr_tx_empty = 1U << 7;
+    static constexpr uint32_t uartfr_rx_full = 1U << 6;
+    static constexpr uint32_t uartfr_tx_full = 1U << 5;
+    static constexpr uint32_t uartfr_rx_empty = 1U << 4;
+    static constexpr uint32_t uartfr_busy = 1U << 3;
+    static constexpr uint32_t uartfr_dcd = 1U << 2;
+    static constexpr uint32_t uartfr_dsr = 1U << 1;
+    static constexpr uint32_t uartfr_cts = 1U << 0;
+
+    // Line control register (UARTLCR_H)
+    static constexpr uint32_t uartlcr_h_wlen_mask = 3U << 5;
+    static constexpr uint32_t uartlcr_h_wlen_8bit = 3U << 5;
+    static constexpr uint32_t uartlcr_h_wlen_7bit = 2U << 5;
+    static constexpr uint32_t uartlcr_h_wlen_6bit = 1U << 5;
+    static constexpr uint32_t uartlcr_h_wlen_5bit = 0U << 5;
+    static constexpr uint32_t uartlcr_h_fifo_enable = 1U << 4;
+    static constexpr uint32_t uartlcr_h_stop_mask = 1U << 3;
+    static constexpr uint32_t uartlcr_h_stop_1bit = 0U << 3;
+    static constexpr uint32_t uartlcr_h_stop_2bit = 1U << 3;
+    static constexpr uint32_t uartlcr_h_sps = 1U << 7;
+    static constexpr uint32_t uartlcr_h_eps = 1U << 2;
+    static constexpr uint32_t uartlcr_h_pen = 1U << 1;
+    static constexpr uint32_t uartlcr_h_parity_mask = uartlcr_h_sps | uartlcr_h_eps | uartlcr_h_pen;
+    static constexpr uint32_t uartlcr_h_parity_even = uartlcr_h_eps | uartlcr_h_pen;
+    static constexpr uint32_t uartlcr_h_parity_odd = uartlcr_h_pen;
+    static constexpr uint32_t uartlcr_h_parity_none = 0;
+    static constexpr uint32_t uartlcr_h_parity_one = uartlcr_h_pen | uartlcr_h_sps;
+    static constexpr uint32_t uartlcr_h_parity_zero = uartlcr_h_pen | uartlcr_h_sps | uartlcr_h_eps;
+    static constexpr uint32_t uartlcr_h_send_break = 1U << 0;
+
+    // Control register (UARTCR)
+    static constexpr uint32_t uartcr_ctse_n = 1U << 15;
+    static constexpr uint32_t uartcr_rtse_n = 1U << 14;
+    static constexpr uint32_t uartcr_out2 = 1U << 13;
+    static constexpr uint32_t uartcr_out1 = 1U << 12;
+    static constexpr uint32_t uartcr_rts = 1U << 11;
+    static constexpr uint32_t uartcr_dtr = 1U << 10;
+    static constexpr uint32_t uartcr_rx_en = 1U << 9;
+    static constexpr uint32_t uartcr_tx_en = 1U << 8;
+    static constexpr uint32_t uartcr_loopback_en = 1U << 7;
+    static constexpr uint32_t uartcr_sirlp = 1U << 2;
+    static constexpr uint32_t uartcr_siren = 1U << 1;
+    static constexpr uint32_t uartcr_uart_en = 1U << 0;
+
+    // Interrupt FIFO level select register (UARTIFLS)
+    static constexpr uint32_t uartifls_rxiflsel_mask = 7U << 3;
+    static constexpr uint32_t uartifls_rxiflsel_1_8 = 0U << 3;
+    static constexpr uint32_t uartifls_rxiflsel_1_4 = 1U << 3;
+    static constexpr uint32_t uartifls_rxiflsel_1_2 = 2U << 3;
+    static constexpr uint32_t uartifls_rxiflsel_3_4 = 3U << 3;
+    static constexpr uint32_t uartifls_rxiflsel_7_8 = 4U << 3;
+    static constexpr uint32_t uartifls_txiflsel_mask = 7U << 0;
+    static constexpr uint32_t uartifls_txiflsel_1_8 = 0U << 0;
+    static constexpr uint32_t uartifls_txiflsel_1_4 = 1U << 0;
+    static constexpr uint32_t uartifls_txiflsel_1_2 = 2U << 0;
+    static constexpr uint32_t uartifls_txiflsel_3_4 = 3U << 0;
+    static constexpr uint32_t uartifls_txiflsel_7_8 = 4U << 0;
+
+    // Interrupt mask set/clear register (UARTIMSC)
+    // Raw interrupt status register (UARTRIS)
+    // Masked interrupt status register (UARTMIS)
+    // Interrupt clear register (UARTICR)
+    static constexpr uint32_t uartinterrupt_oe = 1U << 10;
+    static constexpr uint32_t uartinterrupt_be = 1U << 9;
+    static constexpr uint32_t uartinterrupt_pe = 1U << 8;
+    static constexpr uint32_t uartinterrupt_fe = 1U << 7;
+    static constexpr uint32_t uartinterrupt_rt = 1U << 6;
+    static constexpr uint32_t uartinterrupt_tx = 1U << 5;
+    static constexpr uint32_t uartinterrupt_rx = 1U << 4;
+    static constexpr uint32_t uartinterrupt_dsrm = 1U << 3;
+    static constexpr uint32_t uartinterrupt_dcdm = 1U << 2;
+    static constexpr uint32_t uartinterrupt_ctsm = 1U << 1;
+    static constexpr uint32_t uartinterrupt_rim = 1U << 0;
+
+    // DMA control register (UARTDMACR)
+    static constexpr uint32_t uartdmacr_dmaonerr = 1U << 2;
+    static constexpr uint32_t uartdmacr_txdma_en = 1U << 1;
+    static constexpr uint32_t uartdmacr_rxdma_en = 1U << 0;
 
     /// @endcond
 
-public:
+    /// @cond
 
-    /// Default constructor - uses the default port
+    enum data_bits_t : uint32_t {
+        char_length_5 = uartlcr_h_wlen_5bit,
+        char_length_6 = uartlcr_h_wlen_6bit,
+        char_length_7 = uartlcr_h_wlen_7bit,
+        char_length_8 = uartlcr_h_wlen_8bit,
+    };
+
+    enum stop_bits_t : uint32_t {
+        stop_bits_1 = uartlcr_h_stop_1bit,
+        stop_bits_2 = uartlcr_h_stop_2bit,
+    };
+
+    enum parity_bits_t : uint32_t {
+        parity_none = uartlcr_h_parity_none,
+        parity_odd = uartlcr_h_parity_odd,
+        parity_even = uartlcr_h_parity_even,
+        parity_mark = uartlcr_h_parity_one,
+        parity_space = uartlcr_h_parity_zero,
+    };
+
+    /// Constructor - accepts a target port address
     ///
     /// @expects none
     /// @ensures none
     ///
-    serial_port_pl011() noexcept;
-
-    /// Specific constructor - accepts a target port address
-    /// @expects none
-    /// @ensures none
+    /// @param port the MMIO base address (platform-dependent)
     ///
-    /// @param port the serial port to connect to
-    ///
-    serial_port_pl011(port_type port) noexcept;
+    serial_pl011(uintptr_t port = DEFAULT_COM_PORT) noexcept;
 
     /// Destructor
     ///
     /// @expects none
     /// @ensures none
     ///
-    ~serial_port_pl011() = default;
+    ~serial_pl011() = default;
 
+#ifdef BF_AARCH64
     /// Get Instance
     ///
     /// Get an instance to the class.
     ///
+    /// Because aarch64 is currently the only architecture that supports
+    /// initializing a serial_pl011 with default constructor arguments, this
+    /// method is only available on that architecture. Other architectures
+    /// require this class to be instantiated with a specific virtual base
+    /// address.
+    ///
     /// @expects none
     /// @ensures ret != nullptr
     ///
-    /// @return a singleton instance of serial_port_pl011
+    /// @return a singleton instance of serial_pl011
     ///
-    static serial_port_pl011 *instance() noexcept;
+    static serial_pl011 *instance() noexcept;
+#endif
 
     /// Set Baud Rate Divisor
     ///
@@ -356,7 +342,7 @@ public:
     /// @expects none
     /// @ensures none
     ///
-    virtual void set_port(port_type port) noexcept override
+    virtual void set_port(uintptr_t port) noexcept
     {
         m_port = port;
     }
@@ -368,7 +354,7 @@ public:
     ///
     /// @return the serial device's port
     ///
-    virtual port_type port() const noexcept override
+    virtual uintptr_t port() const noexcept
     { return m_port; }
 
     /// Write Character
@@ -380,27 +366,27 @@ public:
     ///
     /// @param c character to write
     ///
-    virtual void write(char c) noexcept override;
-
-    using serial_port_base::write;
+    virtual void write(char c) noexcept;
 
 private:
 
     bool get_status_full_transmitter() const noexcept;
 
-    void init(port_type port) noexcept;
+    uint32_t read_32(ptrdiff_t offset) const noexcept;
 
-    port_type m_port;
+    void write_32(ptrdiff_t offset, uint32_t data) const noexcept;
+
+    uintptr_t m_port;
 
 public:
 
     /// @cond
 
-    serial_port_pl011(serial_port_pl011 &&) noexcept = default;
-    serial_port_pl011 &operator=(serial_port_pl011 &&) noexcept = default;
+    serial_pl011(serial_pl011 &&) noexcept = default;
+    serial_pl011 &operator=(serial_pl011 &&) noexcept = default;
 
-    serial_port_pl011(const serial_port_pl011 &) = delete;
-    serial_port_pl011 &operator=(const serial_port_pl011 &) = delete;
+    serial_pl011(const serial_pl011 &) = delete;
+    serial_pl011 &operator=(const serial_pl011 &) = delete;
 
     /// @endcond
 };

--- a/bfvmm/src/debug/CMakeLists.txt
+++ b/bfvmm/src/debug/CMakeLists.txt
@@ -23,7 +23,20 @@
 list(APPEND SOURCES
     debug_ring/debug_ring.cpp
     serial/serial_ns16550a.cpp
+    serial/serial_pl011.cpp
 )
+
+if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
+    list(APPEND SOURCES
+        arch/x64/serial_ns16550a.cpp
+    )
+endif()
+
+if(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
+    list(APPEND SOURCES
+        arch/aarch64/serial_ns16550a.cpp
+    )
+endif()
 
 if(NOT ENABLE_MOCKING)
     list(APPEND SOURCES

--- a/bfvmm/src/debug/arch/aarch64/serial_ns16550a.cpp
+++ b/bfvmm/src/debug/arch/aarch64/serial_ns16550a.cpp
@@ -1,0 +1,40 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <debug/serial/serial_ns16550a.h>
+
+namespace bfvmm
+{
+
+uint8_t
+serial_ns16550a::inb(uint16_t addr) const noexcept
+{
+    auto location = static_cast<uintptr_t>(addr) + m_addr;
+    auto ptr = reinterpret_cast<uint8_t const volatile *>(location);
+    return *ptr;
+}
+
+void
+serial_ns16550a::outb(uint16_t addr, uint8_t data) const noexcept
+{
+    auto location = static_cast<uintptr_t>(addr) + m_addr;
+    auto ptr = reinterpret_cast<uint8_t volatile *>(location);
+    *ptr = data;
+}
+
+}

--- a/bfvmm/src/debug/arch/x64/serial_ns16550a.cpp
+++ b/bfvmm/src/debug/arch/x64/serial_ns16550a.cpp
@@ -1,0 +1,36 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <debug/serial/serial_ns16550a.h>
+
+namespace bfvmm
+{
+
+uint8_t
+serial_ns16550a::inb(uint16_t addr) const noexcept
+{
+    return x64::portio::inb(static_cast<uint16_t>(addr + m_addr));
+}
+
+void
+serial_ns16550a::outb(uint16_t addr, uint8_t data) const noexcept
+{
+    x64::portio::outb(static_cast<uint16_t>(addr + m_addr), data);
+}
+
+}

--- a/bfvmm/src/debug/serial/serial_ns16550a.cpp
+++ b/bfvmm/src/debug/serial/serial_ns16550a.cpp
@@ -17,6 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <debug/serial/serial_ns16550a.h>
+#include <bfsupport.h>
 
 namespace bfvmm
 {
@@ -40,23 +41,26 @@ constexpr const uint8_t line_control_data_mask = 0x03;
 constexpr const uint8_t line_control_stop_mask = 0x04;
 constexpr const uint8_t line_control_parity_mask = 0x38;
 
-#define IN(addr)                                                                \
-    x64::portio::inb(static_cast<uint16_t>(addr + DEFAULT_COM_PORT))
-
-#define OUT(addr, data)                                                         \
-    x64::portio::outb(static_cast<uint16_t>(addr + DEFAULT_COM_PORT), static_cast<uint8_t>(data))
-
-serial_ns16550a::serial_ns16550a() noexcept
+serial_ns16550a::serial_ns16550a(uintptr_t port) noexcept
 {
+#ifdef BF_AARCH64
+    if (port == DEFAULT_COM_PORT) {
+        auto platform_info = get_platform_info();
+        port = platform_info->serial_address;
+    }
+#endif
+
+    m_addr = port;
+
     this->disable_dlab();
 
-    auto bits = 0U;
+    uint8_t bits = 0U;
     bits |= fifo_control_enable_fifos;
     bits |= fifo_control_clear_recieve_fifo;
     bits |= fifo_control_clear_transmit_fifo;
 
-    OUT(interrupt_en_reg, 0x00);
-    OUT(fifo_control_reg, bits);
+    outb(interrupt_en_reg, 0x00);
+    outb(fifo_control_reg, bits);
 
     this->set_baud_rate(DEFAULT_BAUD_RATE);
     this->set_data_bits(DEFAULT_DATA_BITS);
@@ -74,13 +78,13 @@ serial_ns16550a::instance() noexcept
 void
 serial_ns16550a::set_baud_rate(baud_rate_t rate) noexcept
 {
-    auto lsb = (rate & 0x000000FF) >> 0;
-    auto msb = (rate & 0x0000FF00) >> 8;
+    uint8_t lsb = gsl::narrow_cast<uint8_t>((rate & 0x000000FF) >> 0);
+    uint8_t msb = gsl::narrow_cast<uint8_t>((rate & 0x0000FF00) >> 8);
 
     this->enable_dlab();
 
-    OUT(baud_rate_lo_reg, lsb);
-    OUT(baud_rate_hi_reg, msb);
+    outb(baud_rate_lo_reg, lsb);
+    outb(baud_rate_hi_reg, msb);
 
     this->disable_dlab();
 }
@@ -90,8 +94,8 @@ serial_ns16550a::baud_rate() const noexcept
 {
     this->enable_dlab();
 
-    auto lsb = IN(baud_rate_lo_reg);
-    auto msb = IN(baud_rate_hi_reg);
+    auto lsb = inb(baud_rate_lo_reg);
+    auto msb = inb(baud_rate_hi_reg);
 
     this->disable_dlab();
 
@@ -138,18 +142,18 @@ serial_ns16550a::baud_rate() const noexcept
 void
 serial_ns16550a::set_data_bits(data_bits_t bits) noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     reg = reg & static_cast<decltype(reg)>(~line_control_data_mask);
     reg = reg | static_cast<decltype(reg)>(bits & line_control_data_mask);
 
-    OUT(line_control_reg, reg);
+    outb(line_control_reg, reg);
 }
 
 serial_ns16550a::data_bits_t
 serial_ns16550a::data_bits() const noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     switch (reg & line_control_data_mask) {
         case char_length_5:
@@ -166,18 +170,18 @@ serial_ns16550a::data_bits() const noexcept
 void
 serial_ns16550a::set_stop_bits(stop_bits_t bits) noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     reg = reg & static_cast<decltype(reg)>(~line_control_stop_mask);
     reg = reg | static_cast<decltype(reg)>(bits & line_control_stop_mask);
 
-    OUT(line_control_reg, reg);
+    outb(line_control_reg, reg);
 }
 
 serial_ns16550a::stop_bits_t
 serial_ns16550a::stop_bits() const noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     switch (reg & line_control_stop_mask) {
         case stop_bits_1:
@@ -190,18 +194,18 @@ serial_ns16550a::stop_bits() const noexcept
 void
 serial_ns16550a::set_parity_bits(parity_bits_t bits) noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     reg = reg & static_cast<decltype(reg)>(~line_control_parity_mask);
     reg = reg | static_cast<decltype(reg)>(bits & line_control_parity_mask);
 
-    OUT(line_control_reg, reg);
+    outb(line_control_reg, reg);
 }
 
 serial_ns16550a::parity_bits_t
 serial_ns16550a::parity_bits() const noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
 
     switch (reg & line_control_parity_mask) {
         case parity_odd:
@@ -217,8 +221,11 @@ serial_ns16550a::parity_bits() const noexcept
     }
 }
 
-int is_transmit_empty()
-{ return _inb(DEFAULT_COM_PORT + line_status_reg) & line_status_empty_transmitter; }
+bool
+serial_ns16550a::is_transmit_empty() const noexcept
+{
+    return (inb(line_status_reg) & line_status_empty_transmitter) != 0;
+}
 
 void
 serial_ns16550a::write(char c) const noexcept
@@ -226,23 +233,23 @@ serial_ns16550a::write(char c) const noexcept
     while (is_transmit_empty() == 0)
     { }
 
-    OUT(0, c);
+    outb(0, static_cast<uint8_t>(c));
 }
 
 void
 serial_ns16550a::enable_dlab() const noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
     reg = reg | static_cast<decltype(reg)>(dlab);
-    OUT(line_control_reg, reg);
+    outb(line_control_reg, reg);
 }
 
 void
 serial_ns16550a::disable_dlab() const noexcept
 {
-    auto reg = IN(line_control_reg);
+    auto reg = inb(line_control_reg);
     reg = reg & static_cast<decltype(reg)>(~(dlab));
-    OUT(line_control_reg, reg);
+    outb(line_control_reg, reg);
 }
 
 }

--- a/bfvmm/src/debug/unistd.cpp
+++ b/bfvmm/src/debug/unistd.cpp
@@ -21,6 +21,7 @@
 
 #include <debug/debug_ring/debug_ring.h>
 #include <debug/serial/serial_ns16550a.h>
+#include <debug/serial/serial_pl011.h>
 
 #include <mutex>
 std::mutex g_write_mutex;

--- a/bfvmm/tests/debug/CMakeLists.txt
+++ b/bfvmm/tests/debug/CMakeLists.txt
@@ -30,9 +30,9 @@ do_test(test_serial_ns16550a
     DEFINES STATIC_INTRINSICS
 )
 
-# do_test(test_serial_port_pl011
-#     SOURCES serial/test_serial_port_pl011.cpp
-#     DEPENDS bfvmm_debug
-#     DEFINES STATIC_DEBUG
-#     DEFINES STATIC_INTRINSICS
-# )
+do_test(test_serial_port_pl011
+    SOURCES serial/test_serial_pl011.cpp
+    DEPENDS bfvmm_debug
+    DEFINES STATIC_DEBUG
+    DEFINES STATIC_INTRINSICS
+)

--- a/bfvmm/tests/debug/serial/test_serial_pl011.cpp
+++ b/bfvmm/tests/debug/serial/test_serial_pl011.cpp
@@ -28,182 +28,140 @@
 
 using namespace bfvmm;
 
-static std::map<serial_pl011::port_type, serial_pl011::value_type_32> g_ports;
+static uint8_t g_mmio[0x1000];
+static const uintptr_t g_pmmio = reinterpret_cast<uintptr_t>(&g_mmio[0]);
 
-extern "C" uint8_t
-_inb(uint16_t port) noexcept
-{ return gsl::narrow_cast<uint8_t>(g_ports[port]); }
-
-extern "C" void
-_outb(uint16_t port, uint8_t val) noexcept
-{ g_ports[port] = val; }
-
-extern "C" uint32_t
-_ind(uint16_t port) noexcept
-{ return g_ports[port]; }
-
-extern "C" void
-_outd(uint16_t port, uint32_t val) noexcept
-{ g_ports[port] = val; }
-
-TEST_CASE("serial: support")
+TEST_CASE("serial: constructor")
 {
-    CHECK_NOTHROW(_inb(0));
-    CHECK_NOTHROW(_outb(0, 0));
-    CHECK_NOTHROW(_ind(0));
-    CHECK_NOTHROW(_outd(0, 0));
-}
-
-TEST_CASE("serial: constructor with specific port")
-{
-    serial_pl011 ser(0x1234);
-    CHECK(ser.port() == 0x1234);
-}
-
-TEST_CASE("serial: constructor_null_intrinsics")
-{
-    CHECK_NOTHROW(std::make_unique<serial_pl011>());
+    serial_pl011 ser(g_pmmio);
+    CHECK(ser.port() == g_pmmio);
 }
 
 TEST_CASE("serial: success")
 {
     uint32_t brd_int = 0, brd_frac = 0;
+    serial_pl011 instance(g_pmmio);
 
-    CHECK(serial_pl011::instance()->port() == DEFAULT_COM_PORT);
-    CHECK_NOTHROW(serial_pl011::instance()->baud_rate_divisor(brd_int, brd_frac));
+    CHECK(instance.port() == g_pmmio);
+    CHECK_NOTHROW(instance.baud_rate_divisor(brd_int, brd_frac));
     CHECK(brd_int == DEFAULT_BAUD_RATE_INT);
     CHECK(brd_frac == DEFAULT_BAUD_RATE_FRAC);
-    CHECK(serial_pl011::instance()->data_bits() == serial_pl011::DEFAULT_DATA_BITS);
-    CHECK(serial_pl011::instance()->stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
-    CHECK(serial_pl011::instance()->parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
+    CHECK(instance.data_bits() == serial_pl011::DEFAULT_DATA_BITS);
+    CHECK(instance.stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
+    CHECK(instance.parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
 
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartibrd_reg]) == DEFAULT_BAUD_RATE_INT);
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartfbrd_reg]) == DEFAULT_BAUD_RATE_FRAC);
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_fifo_enable) != 0);
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_wlen_mask) == serial_pl011::DEFAULT_DATA_BITS);
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_stop_mask) == serial_pl011::DEFAULT_STOP_BITS);
-    CHECK((g_ports[DEFAULT_COM_PORT + serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_parity_mask) == serial_pl011::DEFAULT_PARITY_BITS);
+    CHECK((g_mmio[serial_pl011::uartibrd_reg]) == DEFAULT_BAUD_RATE_INT);
+    CHECK((g_mmio[serial_pl011::uartfbrd_reg]) == DEFAULT_BAUD_RATE_FRAC);
+    CHECK((g_mmio[serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_fifo_enable) != 0);
+    CHECK((g_mmio[serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_wlen_mask) == serial_pl011::DEFAULT_DATA_BITS);
+    CHECK((g_mmio[serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_stop_mask) == serial_pl011::DEFAULT_STOP_BITS);
+    CHECK((g_mmio[serial_pl011::uartlcr_h_reg] & serial_pl011::uartlcr_h_parity_mask) == serial_pl011::DEFAULT_PARITY_BITS);
 }
 
 TEST_CASE("serial: port and set_port")
 {
-    auto const invport = gsl::narrow_cast<serial_pl011::port_type>(~DEFAULT_COM_PORT & 0xffff);
+    serial_pl011 instance(g_pmmio);
+    auto const invport = gsl::narrow_cast<uintptr_t>(~DEFAULT_COM_PORT & 0xffff);
 
-    serial_pl011::instance()->set_port(invport);
-    CHECK(serial_pl011::instance()->port() == invport);
+    instance.set_port(invport);
+    CHECK(instance.port() == invport);
 
-    serial_pl011::instance()->set_port(DEFAULT_COM_PORT);
-    CHECK(serial_pl011::instance()->port() == DEFAULT_COM_PORT);
+    instance.set_port(DEFAULT_COM_PORT);
+    CHECK(instance.port() == DEFAULT_COM_PORT);
 }
 
 TEST_CASE("serial: set_baud_rate_success")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
-    serial->set_baud_rate_divisor(0xffffffffu, 0xffffffffu);
+    instance.set_baud_rate_divisor(0xffffffffu, 0xffffffffu);
 
     uint32_t brd_int = 0, brd_frac = 0;
-    serial->baud_rate_divisor(brd_int, brd_frac);
+    instance.baud_rate_divisor(brd_int, brd_frac);
     CHECK(brd_int == 0xffffu);
     CHECK(brd_frac == 0x3fu);
 }
 
 TEST_CASE("serial: set_data_bits_success")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
-    serial->set_data_bits(serial_pl011::char_length_5);
-    CHECK(serial->data_bits() == serial_pl011::char_length_5);
-    serial->set_data_bits(serial_pl011::char_length_6);
-    CHECK(serial->data_bits() == serial_pl011::char_length_6);
-    serial->set_data_bits(serial_pl011::char_length_7);
-    CHECK(serial->data_bits() == serial_pl011::char_length_7);
-    serial->set_data_bits(serial_pl011::char_length_8);
-    CHECK(serial->data_bits() == serial_pl011::char_length_8);
+    instance.set_data_bits(serial_pl011::char_length_5);
+    CHECK(instance.data_bits() == serial_pl011::char_length_5);
+    instance.set_data_bits(serial_pl011::char_length_6);
+    CHECK(instance.data_bits() == serial_pl011::char_length_6);
+    instance.set_data_bits(serial_pl011::char_length_7);
+    CHECK(instance.data_bits() == serial_pl011::char_length_7);
+    instance.set_data_bits(serial_pl011::char_length_8);
+    CHECK(instance.data_bits() == serial_pl011::char_length_8);
 }
 
 TEST_CASE("serial: set_data_bits_success_extra_bits")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
     auto bits = serial_pl011::DEFAULT_DATA_BITS | ~serial_pl011::uartlcr_h_wlen_mask;
-    serial->set_data_bits(static_cast<serial_pl011::data_bits_t>(bits));
+    instance.set_data_bits(static_cast<serial_pl011::data_bits_t>(bits));
 
-    CHECK(serial->data_bits() == serial_pl011::DEFAULT_DATA_BITS);
-    CHECK(serial->stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
-    CHECK(serial->parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
+    CHECK(instance.data_bits() == serial_pl011::DEFAULT_DATA_BITS);
+    CHECK(instance.stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
+    CHECK(instance.parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
 }
 
 TEST_CASE("serial: set_stop_bits_success")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
-    serial->set_stop_bits(serial_pl011::stop_bits_1);
-    CHECK(serial->stop_bits() == serial_pl011::stop_bits_1);
-    serial->set_stop_bits(serial_pl011::stop_bits_2);
-    CHECK(serial->stop_bits() == serial_pl011::stop_bits_2);
+    instance.set_stop_bits(serial_pl011::stop_bits_1);
+    CHECK(instance.stop_bits() == serial_pl011::stop_bits_1);
+    instance.set_stop_bits(serial_pl011::stop_bits_2);
+    CHECK(instance.stop_bits() == serial_pl011::stop_bits_2);
 }
 
 TEST_CASE("serial: set_stop_bits_success_extra_bits")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
     auto bits = serial_pl011::DEFAULT_STOP_BITS | ~serial_pl011::uartlcr_h_stop_mask;
-    serial->set_stop_bits(static_cast<serial_pl011::stop_bits_t>(bits));
+    instance.set_stop_bits(static_cast<serial_pl011::stop_bits_t>(bits));
 
-    CHECK(serial->data_bits() == serial_pl011::DEFAULT_DATA_BITS);
-    CHECK(serial->stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
-    CHECK(serial->parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
+    CHECK(instance.data_bits() == serial_pl011::DEFAULT_DATA_BITS);
+    CHECK(instance.stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
+    CHECK(instance.parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
 }
 
 TEST_CASE("serial: set_parity_bits_success")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
-    serial->set_parity_bits(serial_pl011::parity_none);
-    CHECK(serial->parity_bits() == serial_pl011::parity_none);
-    serial->set_parity_bits(serial_pl011::parity_odd);
-    CHECK(serial->parity_bits() == serial_pl011::parity_odd);
-    serial->set_parity_bits(serial_pl011::parity_even);
-    CHECK(serial->parity_bits() == serial_pl011::parity_even);
-    serial->set_parity_bits(serial_pl011::parity_mark);
-    CHECK(serial->parity_bits() == serial_pl011::parity_mark);
-    serial->set_parity_bits(serial_pl011::parity_space);
-    CHECK(serial->parity_bits() == serial_pl011::parity_space);
+    instance.set_parity_bits(serial_pl011::parity_none);
+    CHECK(instance.parity_bits() == serial_pl011::parity_none);
+    instance.set_parity_bits(serial_pl011::parity_odd);
+    CHECK(instance.parity_bits() == serial_pl011::parity_odd);
+    instance.set_parity_bits(serial_pl011::parity_even);
+    CHECK(instance.parity_bits() == serial_pl011::parity_even);
+    instance.set_parity_bits(serial_pl011::parity_mark);
+    CHECK(instance.parity_bits() == serial_pl011::parity_mark);
+    instance.set_parity_bits(serial_pl011::parity_space);
+    CHECK(instance.parity_bits() == serial_pl011::parity_space);
 }
 
 TEST_CASE("serial: set_parity_bits_success_extra_bits")
 {
-    auto serial = std::make_unique<serial_pl011>();
+    serial_pl011 instance(g_pmmio);
 
     auto bits = serial_pl011::DEFAULT_PARITY_BITS | ~serial_pl011::uartlcr_h_parity_mask;
-    serial->set_parity_bits(static_cast<serial_pl011::parity_bits_t>(bits));
+    instance.set_parity_bits(static_cast<serial_pl011::parity_bits_t>(bits));
 
-    CHECK(serial->data_bits() == serial_pl011::DEFAULT_DATA_BITS);
-    CHECK(serial->stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
-    CHECK(serial->parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
+    CHECK(instance.data_bits() == serial_pl011::DEFAULT_DATA_BITS);
+    CHECK(instance.stop_bits() == serial_pl011::DEFAULT_STOP_BITS);
+    CHECK(instance.parity_bits() == serial_pl011::DEFAULT_PARITY_BITS);
 }
 
 TEST_CASE("serial: write character")
 {
-    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
+    g_mmio[serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
 
-    auto serial = std::make_unique<serial_pl011>();
-    serial->write('c');
-}
-
-TEST_CASE("serial: write string")
-{
-    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
-
-    auto serial = std::make_unique<serial_pl011>();
-    serial->write("hello world");
-}
-
-TEST_CASE("serial: write char buffer")
-{
-    g_ports[DEFAULT_COM_PORT + serial_pl011::uartfr_reg] = serial_pl011::uartfr_tx_empty;
-
-    auto serial = std::make_unique<serial_pl011>();
-    serial->write("hello world", 12);
+    serial_pl011 instance(g_pmmio);
+    instance.write('c');
 }


### PR DESCRIPTION
- Matching serial_ns16550a, rework serial_pl011 to avoid inheritance
- Update serial_pl011 tests
- Return to platform-independent serial_ns16550a as NS16550A is sometimes used on ARM too.
- Disable `serial_pl011::instance()` on non-ARM — as a MMIO-only peripheral, it requires a virtual base address, and on x64 we have no way to get this at runtime so a default constructor isn't possible.(*)
- Slight reworking of constructors to allow full test coverage.

(*) The mechanism using `platform_info_t` could certainly be extended to x64, but this seems pointless to me as I don't think we'll ever need MMIO-based serial on that system.