### PR TITLE
Update Vagrant to Ubuntu 17.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,8 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 build/
-build_ubuntu17_04/
+build_ubuntu17_10/
+ubuntu-artful-17.10-cloudimg-console.log
 doc
 doxygen_warnings.txt
 .vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,6 +1,6 @@
 #
 # Bareflank Hypervisor
-# Copyright (C) 2015 Assured Information Security, Inc.
+# Copyright (C) 2018 Assured Information Security, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -22,9 +22,9 @@ Vagrant.configure(2) do |config|
         vb.cpus = 2
     end
 
-    config.vm.define "ubuntu17_04", primary: true do |ubuntu17_04|
-        ubuntu17_04.vm.box = "ubuntu/zesty64"
-        ubuntu17_04.vm.provision "shell",
-            path: "scripts/vagrant/provision_ubuntu17_04.sh"
+    config.vm.define "ubuntu17_10", primary: true do |ubuntu17_10|
+        ubuntu17_10.vm.box = "ubuntu/artful64"
+        ubuntu17_10.vm.provision "shell",
+            path: "scripts/vagrant/provision_ubuntu17_10.sh"
     end
 end

--- a/scripts/vagrant/provision_ubuntu17_10.sh
+++ b/scripts/vagrant/provision_ubuntu17_10.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 #
 # Bareflank Hypervisor
-# Copyright (C) 2015 Assured Information Security, Inc.
+# Copyright (C) 2018 Assured Information Security, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -17,7 +17,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-VAGRANT_BUILD_DIR="/vagrant/build_ubuntu17_04"
+VAGRANT_BUILD_DIR="/vagrant/build_ubuntu17_10"
 VAGRANT_HOME_DIR="/home/ubuntu"
 
 sudo apt-get update


### PR DESCRIPTION
Ubuntu 17.04 is now EOL so the Vagrant box is no longer available.