### PR TITLE
Add changes for xAPIC in extended APIs

### DIFF
--- a/bfdriver/src/platform/linux/platform.c
+++ b/bfdriver/src/platform/linux/platform.c
@@ -38,6 +38,7 @@
 #endif
 
 #include <asm/tlbflush.h>
+#include <asm/fixmap.h>
 
 typedef long (*set_affinity_fn)(pid_t, const struct cpumask *);
 set_affinity_fn set_cpu_affinity = 0;
@@ -228,13 +229,17 @@ platform_populate_info(struct platform_info_t *info)
         platform_memset(info, 0, sizeof(struct platform_info_t));
     }
 
+    info->xapic_virt = fix_to_virt(FIX_APIC_BASE);
     return BF_SUCCESS;
 }
 
 void
 platform_unload_info(struct platform_info_t *info)
 {
-    (void) info;
+    if (info->xapic_virt) {
+        info->xapic_virt = 0;
+    }
 }
+
 
 #endif

--- a/bfintrinsics/include/arch/intel_x64/barrier.h
+++ b/bfintrinsics/include/arch/intel_x64/barrier.h
@@ -1,0 +1,56 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef BARRIER_INTEL_X64_H
+#define BARRIER_INTEL_X64_H
+
+// -----------------------------------------------------------------------------
+// Exports
+// -----------------------------------------------------------------------------
+
+#include <bfexports.h>
+
+#ifndef STATIC_INTRINSICS
+#ifdef SHARED_INTRINSICS
+#define EXPORT_INTRINSICS EXPORT_SYM
+#else
+#define EXPORT_INTRINSICS IMPORT_SYM
+#endif
+#else
+#define EXPORT_INTRINSICS
+#endif
+
+// -----------------------------------------------------------------------------
+// Definitions
+// -----------------------------------------------------------------------------
+
+extern "C" void _sfence(void) noexcept;
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace barrier
+{
+    inline void sfence() noexcept
+    { _sfence(); }
+}
+}
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/mtrr.h
+++ b/bfintrinsics/include/arch/intel_x64/mtrr.h
@@ -1,0 +1,3826 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#ifndef MTRR_INTEL_X64_H
+#define MTRR_INTEL_X64_H
+
+#include "msrs.h"
+#include "cpuid.h"
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace mtrr
+{
+
+using value_type = ::intel_x64::msrs::value_type;
+
+constexpr const auto uncacheable = 0x00ULL;
+constexpr const auto write_combining = 0x01ULL;
+constexpr const auto write_through = 0x04ULL;
+constexpr const auto write_protected = 0x05ULL;
+constexpr const auto write_back = 0x06ULL;
+
+inline bool is_supported()
+{ return cpuid::feature_information::edx::mtrr::is_enabled(); }
+
+namespace ia32_mtrrcap
+{
+    constexpr const auto addr = 0x000000FEU;
+    constexpr const auto name = "ia32_mtrrcap";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    namespace vcnt
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "vcnt";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace fixed_support
+    {
+        constexpr const auto mask = 0x0000000000000100ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "fixed_support";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+    }
+
+    namespace wc_support
+    {
+        constexpr const auto mask = 0x0000000000000400ULL;
+        constexpr const auto from = 10ULL;
+        constexpr const auto name = "wc_support";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+    }
+
+    namespace smrr_support
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "smrr_support";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        vcnt::dump(level, msg);
+        fixed_support::dump(level, msg);
+        wc_support::dump(level, msg);
+        smrr_support::dump(level, msg);
+    }
+}
+
+namespace ia32_mtrr_def_type
+{
+    constexpr const auto addr = 0x000002FFU;
+    constexpr const auto name = "ia32_mtrr_def_type";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace fe
+    {
+        constexpr const auto mask = 0x0000000000000400ULL;
+        constexpr const auto from = 10ULL;
+        constexpr const auto name = "fe";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+    }
+
+    namespace e
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "e";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        fe::dump(level, msg);
+        e::dump(level, msg);
+    }
+}
+
+namespace physbase0
+{
+    constexpr const auto addr = 0x00000200U;
+    constexpr const auto name = "physbase0";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask0
+{
+    constexpr const auto addr = 0x00000201U;
+    constexpr const auto name = "physmask0";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase1
+{
+    constexpr const auto addr = 0x00000202U;
+    constexpr const auto name = "physbase1";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask1
+{
+    constexpr const auto addr = 0x00000203U;
+    constexpr const auto name = "physmask1";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase2
+{
+    constexpr const auto addr = 0x00000204U;
+    constexpr const auto name = "physbase2";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask2
+{
+    constexpr const auto addr = 0x00000205U;
+    constexpr const auto name = "physmask2";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase3
+{
+    constexpr const auto addr = 0x00000206U;
+    constexpr const auto name = "physbase3";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask3
+{
+    constexpr const auto addr = 0x00000207U;
+    constexpr const auto name = "physmask3";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase4
+{
+    constexpr const auto addr = 0x00000208U;
+    constexpr const auto name = "physbase4";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask4
+{
+    constexpr const auto addr = 0x00000209U;
+    constexpr const auto name = "physmask4";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase5
+{
+    constexpr const auto addr = 0x0000020AU;
+    constexpr const auto name = "physbase5";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask5
+{
+    constexpr const auto addr = 0x0000020BU;
+    constexpr const auto name = "physmask5";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase6
+{
+    constexpr const auto addr = 0x0000020CU;
+    constexpr const auto name = "physbase6";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask6
+{
+    constexpr const auto addr = 0x0000020DU;
+    constexpr const auto name = "physmask6";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase7
+{
+    constexpr const auto addr = 0x0000020EU;
+    constexpr const auto name = "physbase7";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask7
+{
+    constexpr const auto addr = 0x0000020FU;
+    constexpr const auto name = "physmask7";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase8
+{
+    constexpr const auto addr = 0x00000210U;
+    constexpr const auto name = "physbase8";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask8
+{
+    constexpr const auto addr = 0x00000211U;
+    constexpr const auto name = "physmask8";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace physbase9
+{
+    constexpr const auto addr = 0x00000212U;
+    constexpr const auto name = "physbase9";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace type
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "type";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace physbase
+    {
+        constexpr const auto mask = 0x0000000FFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physbase";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        type::dump(level, msg);
+        physbase::dump(level, msg);
+    }
+}
+
+namespace physmask9
+{
+    constexpr const auto addr = 0x00000213U;
+    constexpr const auto name = "physmask9";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace valid
+    {
+        constexpr const auto mask = 0x0000000000000800ULL;
+        constexpr const auto from = 11ULL;
+        constexpr const auto name = "valid";
+
+        inline auto is_enabled()
+        { return is_bit_set(_read_msr(addr), from); }
+
+        inline auto is_enabled(value_type msr)
+        { return is_bit_set(msr, from); }
+
+        inline auto is_disabled()
+        { return is_bit_cleared(_read_msr(addr), from); }
+
+        inline auto is_disabled(value_type msr)
+        { return is_bit_cleared(msr, from); }
+
+        inline void enable()
+        { _write_msr(addr, set_bit(_read_msr(addr), from)); }
+
+        inline auto enable(value_type msr)
+        { return set_bit(msr, from); }
+
+        inline void disable()
+        { _write_msr(addr, clear_bit(_read_msr(addr), from)); }
+
+        inline auto disable(value_type msr)
+        { return clear_bit(msr, from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subbool(level, name, is_enabled(), msg); }
+
+    }
+
+    namespace physmask
+    {
+        constexpr const auto mask = 0x000000FFFFFFF000ULL;
+        constexpr const auto from = 12ULL;
+        constexpr const auto name = "physmask";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subnhex(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        valid::dump(level, msg);
+        physmask::dump(level, msg);
+    }
+}
+
+namespace fix64k_00000
+{
+    constexpr const auto addr = 0x00000250U;
+    constexpr const auto name = "fix64k_00000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix16k_80000
+{
+    constexpr const auto addr = 0x00000258U;
+    constexpr const auto name = "fix16k_80000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix16k_A0000
+{
+    constexpr const auto addr = 0x00000259U;
+    constexpr const auto name = "fix16k_A0000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_C0000
+{
+    constexpr const auto addr = 0x00000268U;
+    constexpr const auto name = "fix04k_C0000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_C8000
+{
+    constexpr const auto addr = 0x00000269U;
+    constexpr const auto name = "fix04k_C8000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_D0000
+{
+    constexpr const auto addr = 0x0000026AU;
+    constexpr const auto name = "fix04k_D0000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_D8000
+{
+    constexpr const auto addr = 0x0000026BU;
+    constexpr const auto name = "fix04k_D8000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_E0000
+{
+    constexpr const auto addr = 0x0000026CU;
+    constexpr const auto name = "fix04k_E0000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_E8000
+{
+    constexpr const auto addr = 0x0000026DU;
+    constexpr const auto name = "fix04k_E8000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_F0000
+{
+    constexpr const auto addr = 0x0000026EU;
+    constexpr const auto name = "fix04k_F0000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+namespace fix04k_F8000
+{
+    constexpr const auto addr = 0x0000026FU;
+    constexpr const auto name = "fix04k_F8000";
+
+    inline auto get() noexcept
+    { return _read_msr(addr); }
+
+    inline auto set(value_type val) noexcept
+    { _write_msr(addr, val); }
+
+    namespace range0
+    {
+        constexpr const auto mask = 0x00000000000000FFULL;
+        constexpr const auto from = 0ULL;
+        constexpr const auto name = "range0";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range1
+    {
+        constexpr const auto mask = 0x000000000000FF00ULL;
+        constexpr const auto from = 8ULL;
+        constexpr const auto name = "range1";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range2
+    {
+        constexpr const auto mask = 0x0000000000FF0000ULL;
+        constexpr const auto from = 16ULL;
+        constexpr const auto name = "range2";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range3
+    {
+        constexpr const auto mask = 0x00000000FF000000ULL;
+        constexpr const auto from = 24ULL;
+        constexpr const auto name = "range3";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range4
+    {
+        constexpr const auto mask = 0x000000FF00000000ULL;
+        constexpr const auto from = 32ULL;
+        constexpr const auto name = "range4";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range5
+    {
+        constexpr const auto mask = 0x0000FF0000000000ULL;
+        constexpr const auto from = 40ULL;
+        constexpr const auto name = "range5";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range6
+    {
+        constexpr const auto mask = 0x00FF000000000000ULL;
+        constexpr const auto from = 48ULL;
+        constexpr const auto name = "range6";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    namespace range7
+    {
+        constexpr const auto mask = 0xFF00000000000000ULL;
+        constexpr const auto from = 56ULL;
+        constexpr const auto name = "range7";
+
+        inline auto get() noexcept
+        { return get_bits(_read_msr(addr), mask) >> from; }
+
+        inline auto get(value_type msr) noexcept
+        { return get_bits(msr, mask) >> from; }
+
+        inline void set(value_type val) noexcept
+        { _write_msr(addr, set_bits(_read_msr(addr), mask, val << from)); }
+
+        inline auto set(value_type msr, value_type val) noexcept
+        { return set_bits(msr, mask, val << from); }
+
+        inline void dump(int level, std::string *msg = nullptr)
+        { bfdebug_subndec(level, name, get(), msg); }
+    }
+
+    inline void dump(int level, std::string *msg = nullptr)
+    {
+        range0::dump(level, msg);
+        range1::dump(level, msg);
+        range2::dump(level, msg);
+        range3::dump(level, msg);
+        range4::dump(level, msg);
+        range5::dump(level, msg);
+        range6::dump(level, msg);
+        range7::dump(level, msg);
+    }
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/mtrr.h
+++ b/bfintrinsics/include/arch/intel_x64/mtrr.h
@@ -2218,10 +2218,10 @@ namespace fix16k_A0000
     }
 }
 
-namespace fix04k_C0000
+namespace fix4k_C0000
 {
     constexpr const auto addr = 0x00000268U;
-    constexpr const auto name = "fix04k_C0000";
+    constexpr const auto name = "fix4k_C0000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -2418,10 +2418,10 @@ namespace fix04k_C0000
     }
 }
 
-namespace fix04k_C8000
+namespace fix4k_C8000
 {
     constexpr const auto addr = 0x00000269U;
-    constexpr const auto name = "fix04k_C8000";
+    constexpr const auto name = "fix4k_C8000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -2618,10 +2618,10 @@ namespace fix04k_C8000
     }
 }
 
-namespace fix04k_D0000
+namespace fix4k_D0000
 {
     constexpr const auto addr = 0x0000026AU;
-    constexpr const auto name = "fix04k_D0000";
+    constexpr const auto name = "fix4k_D0000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -2818,10 +2818,10 @@ namespace fix04k_D0000
     }
 }
 
-namespace fix04k_D8000
+namespace fix4k_D8000
 {
     constexpr const auto addr = 0x0000026BU;
-    constexpr const auto name = "fix04k_D8000";
+    constexpr const auto name = "fix4k_D8000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -3018,10 +3018,10 @@ namespace fix04k_D8000
     }
 }
 
-namespace fix04k_E0000
+namespace fix4k_E0000
 {
     constexpr const auto addr = 0x0000026CU;
-    constexpr const auto name = "fix04k_E0000";
+    constexpr const auto name = "fix4k_E0000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -3218,10 +3218,10 @@ namespace fix04k_E0000
     }
 }
 
-namespace fix04k_E8000
+namespace fix4k_E8000
 {
     constexpr const auto addr = 0x0000026DU;
-    constexpr const auto name = "fix04k_E8000";
+    constexpr const auto name = "fix4k_E8000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -3418,10 +3418,10 @@ namespace fix04k_E8000
     }
 }
 
-namespace fix04k_F0000
+namespace fix4k_F0000
 {
     constexpr const auto addr = 0x0000026EU;
-    constexpr const auto name = "fix04k_F0000";
+    constexpr const auto name = "fix4k_F0000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }
@@ -3618,10 +3618,10 @@ namespace fix04k_F0000
     }
 }
 
-namespace fix04k_F8000
+namespace fix4k_F8000
 {
     constexpr const auto addr = 0x0000026FU;
-    constexpr const auto name = "fix04k_F8000";
+    constexpr const auto name = "fix4k_F8000";
 
     inline auto get() noexcept
     { return _read_msr(addr); }

--- a/bfintrinsics/include/intrinsics.h
+++ b/bfintrinsics/include/intrinsics.h
@@ -42,6 +42,7 @@
 #include <arch/intel_x64/crs.h>
 #include <arch/intel_x64/drs.h>
 #include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/mtrr.h>
 #include <arch/intel_x64/vmx.h>
 #include <arch/intel_x64/vmcs/16bit_control_fields.h>
 #include <arch/intel_x64/vmcs/16bit_guest_state_fields.h>

--- a/bfintrinsics/src/CMakeLists.txt
+++ b/bfintrinsics/src/CMakeLists.txt
@@ -35,6 +35,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/x64/rflags.asm
         arch/x64/srs.asm
         arch/x64/tlb.asm
+        arch/intel_x64/barrier.asm
         arch/intel_x64/crs.asm
         arch/intel_x64/drs.asm
         arch/intel_x64/vmx.asm

--- a/bfintrinsics/src/arch/intel_x64/barrier.asm
+++ b/bfintrinsics/src/arch/intel_x64/barrier.asm
@@ -1,0 +1,27 @@
+;
+; Bareflank Hypervisor
+; Copyright (C) 2018 Assured Information Security, Inc.
+;
+; This library is free software; you can redistribute it and/or
+; modify it under the terms of the GNU Lesser General Public
+; License as published by the Free Software Foundation; either
+; version 2.1 of the License, or (at your option) any later version.
+;
+; This library is distributed in the hope that it will be useful,
+; but WITHOUT ANY WARRANTY; without even the implied warranty of
+; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+; Lesser General Public License for more details.
+;
+; You should have received a copy of the GNU Lesser General Public
+; License along with this library; if not, write to the Free Software
+; Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+bits 64
+default rel
+
+section .text
+
+global _sfence:function
+_sfence:
+    sfence
+    ret

--- a/bfintrinsics/tests/CMakeLists.txt
+++ b/bfintrinsics/tests/CMakeLists.txt
@@ -29,6 +29,7 @@ do_test(test_cpuid_intel_x64 SOURCES arch/intel_x64/test_cpuid.cpp)
 do_test(test_crs_intel_x64 SOURCES arch/intel_x64/test_crs.cpp)
 do_test(test_drs_intel_x64 SOURCES arch/intel_x64/test_drs.cpp)
 do_test(test_msrs_intel_x64 SOURCES arch/intel_x64/test_msrs.cpp)
+do_test(test_mtrr_intel_x64 SOURCES arch/intel_x64/test_mtrr.cpp)
 do_test(test_vmx_intel_x64 SOURCES arch/intel_x64/test_vmx.cpp)
 
 do_test(test_16bit_control_fields SOURCES arch/intel_x64/vmcs/test_16bit_control_fields.cpp)

--- a/bfintrinsics/tests/arch/intel_x64/test_mtrr.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/test_mtrr.cpp
@@ -1,0 +1,1538 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <catch/catch.hpp>
+
+#include <map>
+#include <arch/intel_x64/mtrr.h>
+
+using namespace x64;
+using namespace intel_x64;
+using namespace mtrr;
+
+std::map<::intel_x64::msrs::field_type, ::intel_x64::msrs::value_type> g_msrs;
+std::map<::intel_x64::cpuid::field_type, ::intel_x64::cpuid::value_type> g_cpuid_edx;
+
+extern "C" uint64_t
+_read_msr(uint32_t addr) noexcept
+{ return g_msrs[addr]; }
+
+extern "C" void
+_write_msr(uint32_t addr, uint64_t val) noexcept
+{ g_msrs[addr] = val; }
+
+extern "C" uint32_t
+_cpuid_edx(uint32_t val) noexcept
+{ return g_cpuid_edx[val]; }
+
+TEST_CASE("mtrr::is_supported")
+{
+    g_cpuid_edx[::intel_x64::cpuid::feature_information::addr] = 0xFFFFFFFFULL;
+    CHECK(mtrr::is_supported());
+
+    g_cpuid_edx[intel_x64::cpuid::feature_information::addr] = 0x00ULL;
+    CHECK(!mtrr::is_supported());
+}
+
+TEST_CASE("mtrr::ia32_mtrrcap")
+{
+    g_msrs[ia32_mtrrcap::addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(ia32_mtrrcap::get() == 0xFFFFFFFFFFFFFFFFULL);
+    ia32_mtrrcap::dump(0);
+}
+
+TEST_CASE("mtrr::ia32_mtrrcap::vcnt")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrrcap;
+
+    g_msrs[addr] = 0xFFFFFFFFFFFFFFCCULL;
+    CHECK(vcnt::get() == 0xCCULL);
+    CHECK(vcnt::get(0xCC00ULL) == 0x0ULL);
+}
+
+TEST_CASE("mtrr::ia32_mtrrcap::fixed_support")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrrcap;
+
+    g_msrs[addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(fixed_support::is_enabled());
+    CHECK(fixed_support::is_enabled(0xF00ULL));
+
+    g_msrs[addr] = 0x0ULL;
+    CHECK(fixed_support::is_disabled());
+    CHECK(fixed_support::is_disabled(0xEFFULL));
+}
+
+TEST_CASE("mtrr::ia32_mtrrcap::wc_support")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrrcap;
+
+    g_msrs[addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(wc_support::is_enabled());
+    CHECK(wc_support::is_enabled(0xF00ULL));
+
+    g_msrs[addr] = 0x0ULL;
+    CHECK(wc_support::is_disabled());
+    CHECK(wc_support::is_disabled(0xB00ULL));
+}
+
+TEST_CASE("mtrr::ia32_mtrrcap::smrr_support")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrrcap;
+
+    g_msrs[addr] = 0xFFFFFFFFFFFFFFFFULL;
+    CHECK(smrr_support::is_enabled());
+    CHECK(smrr_support::is_enabled(0xF00ULL));
+
+    g_msrs[addr] = 0x0ULL;
+    CHECK(smrr_support::is_disabled());
+    CHECK(smrr_support::is_disabled(0x7FFULL));
+}
+
+TEST_CASE("mtrr::ia32_mtrr_def_type")
+{
+    using namespace intel_x64::mtrr::ia32_mtrr_def_type;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::ia32_mtrr_def_type::type")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrr_def_type;
+
+    type::set(0xCCULL);
+    CHECK(type::get() == 0xCCULL);
+
+    auto val = 0ULL;
+    val = type::set(val, 0x3ULL);
+    CHECK(type::get(val) == 0x3ULL);
+}
+
+TEST_CASE("mtrr::ia32_mtrr_def_type::fe")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrr_def_type;
+
+    fe::enable();
+    CHECK(fe::is_enabled());
+
+    fe::disable();
+    CHECK(fe::is_disabled());
+
+    auto val = 0ULL;
+    val = fe::enable(val);
+    CHECK(fe::is_enabled(val));
+
+    val = fe::disable(val);
+    CHECK(fe::is_disabled(val));
+}
+
+TEST_CASE("mtrr::ia32_mtrr_def_type::e")
+{
+    using namespace ::intel_x64::mtrr::ia32_mtrr_def_type;
+
+    e::enable();
+    CHECK(e::is_enabled());
+
+    e::disable();
+    CHECK(e::is_disabled());
+
+    auto val = 0ULL;
+    val = e::enable(val);
+    CHECK(e::is_enabled(val));
+
+    val = e::disable(val);
+    CHECK(e::is_disabled(val));
+}
+
+TEST_CASE("mtrr::physbase0")
+{
+    using namespace intel_x64::mtrr::physbase0;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase0::type")
+{
+    using namespace ::intel_x64::mtrr::physbase0;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase0::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase0;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase1")
+{
+    using namespace intel_x64::mtrr::physbase1;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase1::type")
+{
+    using namespace ::intel_x64::mtrr::physbase1;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase1::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase1;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase2")
+{
+    using namespace intel_x64::mtrr::physbase2;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase2::type")
+{
+    using namespace ::intel_x64::mtrr::physbase2;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase2::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase2;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase3")
+{
+    using namespace intel_x64::mtrr::physbase3;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase3::type")
+{
+    using namespace ::intel_x64::mtrr::physbase3;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase3::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase3;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase4")
+{
+    using namespace intel_x64::mtrr::physbase4;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase4::type")
+{
+    using namespace ::intel_x64::mtrr::physbase4;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase4::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase4;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase5")
+{
+    using namespace intel_x64::mtrr::physbase5;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase5::type")
+{
+    using namespace ::intel_x64::mtrr::physbase5;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase5::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase5;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase6")
+{
+    using namespace intel_x64::mtrr::physbase6;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase6::type")
+{
+    using namespace ::intel_x64::mtrr::physbase6;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase6::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase6;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase7")
+{
+    using namespace intel_x64::mtrr::physbase7;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase7::type")
+{
+    using namespace ::intel_x64::mtrr::physbase7;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase7::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase7;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase8")
+{
+    using namespace intel_x64::mtrr::physbase8;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase8::type")
+{
+    using namespace ::intel_x64::mtrr::physbase8;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase8::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase8;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physbase9")
+{
+    using namespace intel_x64::mtrr::physbase9;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physbase9::type")
+{
+    using namespace ::intel_x64::mtrr::physbase9;
+
+    type::set(::intel_x64::mtrr::uncacheable);
+    CHECK(type::get() == ::intel_x64::mtrr::uncacheable);
+
+    type::set(::intel_x64::mtrr::write_combining);
+    CHECK(type::get() == ::intel_x64::mtrr::write_combining);
+
+    type::set(::intel_x64::mtrr::write_through);
+    CHECK(type::get() == ::intel_x64::mtrr::write_through);
+
+    auto reg = 0xFFFFULL;
+    reg = type::set(reg, ::intel_x64::mtrr::write_protected);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_protected);
+
+    reg = type::set(reg, ::intel_x64::mtrr::write_back);
+    CHECK(type::get(reg) == ::intel_x64::mtrr::write_back);
+}
+
+TEST_CASE("mtrr::physbase9::physbase")
+{
+    using namespace ::intel_x64::mtrr::physbase9;
+
+    auto addr = 0xBEEF000ULL;
+    auto base = addr >> 12ULL;
+
+    physbase::set(base);
+    CHECK(physbase::get() == base);
+    CHECK(addr == (physbase::get() << 12ULL));
+
+    auto reg = 0xFFULL;
+    reg = physbase::set(reg, base);
+    CHECK(physbase::get(reg) == addr >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask0")
+{
+    using namespace intel_x64::mtrr::physmask0;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask0::valid")
+{
+    using namespace intel_x64::mtrr::physmask0;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask0::physmask")
+{
+    using namespace intel_x64::mtrr::physmask0;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask1")
+{
+    using namespace intel_x64::mtrr::physmask1;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask1::valid")
+{
+    using namespace intel_x64::mtrr::physmask1;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask1::physmask")
+{
+    using namespace intel_x64::mtrr::physmask1;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask2")
+{
+    using namespace intel_x64::mtrr::physmask2;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask2::valid")
+{
+    using namespace intel_x64::mtrr::physmask2;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask2::physmask")
+{
+    using namespace intel_x64::mtrr::physmask2;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask3")
+{
+    using namespace intel_x64::mtrr::physmask3;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask3::valid")
+{
+    using namespace intel_x64::mtrr::physmask3;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask3::physmask")
+{
+    using namespace intel_x64::mtrr::physmask3;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask4")
+{
+    using namespace intel_x64::mtrr::physmask4;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask4::valid")
+{
+    using namespace intel_x64::mtrr::physmask4;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask4::physmask")
+{
+    using namespace intel_x64::mtrr::physmask4;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask5")
+{
+    using namespace intel_x64::mtrr::physmask5;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask5::valid")
+{
+    using namespace intel_x64::mtrr::physmask5;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask5::physmask")
+{
+    using namespace intel_x64::mtrr::physmask5;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask6")
+{
+    using namespace intel_x64::mtrr::physmask6;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask6::valid")
+{
+    using namespace intel_x64::mtrr::physmask6;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask6::physmask")
+{
+    using namespace intel_x64::mtrr::physmask6;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask7")
+{
+    using namespace intel_x64::mtrr::physmask7;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask7::valid")
+{
+    using namespace intel_x64::mtrr::physmask7;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask7::physmask")
+{
+    using namespace intel_x64::mtrr::physmask7;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask8")
+{
+    using namespace intel_x64::mtrr::physmask8;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask8::valid")
+{
+    using namespace intel_x64::mtrr::physmask8;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask8::physmask")
+{
+    using namespace intel_x64::mtrr::physmask8;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::physmask9")
+{
+    using namespace intel_x64::mtrr::physmask9;
+
+    set(0xFFFFFFFFFFFFFFFFULL);
+    CHECK(get() == 0xFFFFFFFFFFFFFFFFULL);
+    dump(0);
+}
+
+TEST_CASE("mtrr::physmask9::valid")
+{
+    using namespace intel_x64::mtrr::physmask9;
+
+    valid::enable();
+    CHECK(valid::is_enabled());
+
+    valid::disable();
+    CHECK(valid::is_disabled());
+
+    auto reg = 0ULL;
+    reg = valid::enable(reg);
+    CHECK(valid::is_enabled(reg));
+
+    reg = valid::disable(reg);
+    CHECK(valid::is_disabled(reg));
+}
+
+TEST_CASE("mtrr::physmask9::physmask")
+{
+    using namespace intel_x64::mtrr::physmask9;
+
+    auto mask = 0xAFEBEEF000ULL;
+
+    physmask::set(mask >> 12ULL);
+    CHECK(physmask::get() == mask >> 12ULL);
+
+    auto reg = 0xE8ULL;
+    reg = physmask::set(reg, mask >> 12ULL);
+    CHECK(physmask::get(reg) == mask >> 12ULL);
+}
+
+TEST_CASE("mtrr::fix64k_00000")
+{
+    using namespace intel_x64::mtrr::fix64k_00000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix16k_80000")
+{
+    using namespace intel_x64::mtrr::fix16k_80000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix16k_A0000")
+{
+    using namespace intel_x64::mtrr::fix16k_A0000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_C0000")
+{
+    using namespace intel_x64::mtrr::fix04k_C0000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_C8000")
+{
+    using namespace intel_x64::mtrr::fix04k_C8000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_D0000")
+{
+    using namespace intel_x64::mtrr::fix04k_D0000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_D8000")
+{
+    using namespace intel_x64::mtrr::fix04k_D8000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_E0000")
+{
+    using namespace intel_x64::mtrr::fix04k_E0000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_E8000")
+{
+    using namespace intel_x64::mtrr::fix04k_E8000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_F0000")
+{
+    using namespace intel_x64::mtrr::fix04k_F0000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}
+
+TEST_CASE("mtrr::fix04k_F8000")
+{
+    using namespace intel_x64::mtrr::fix04k_F8000;
+
+    set(0xFFFFFFFF11111111ULL);
+    CHECK(get() == 0xFFFFFFFF11111111ULL);
+    dump(0);
+
+    range0::set(mtrr::uncacheable);
+    range1::set(mtrr::write_combining);
+    range2::set(mtrr::write_through);
+    range3::set(mtrr::write_protected);
+    range4::set(mtrr::write_back);
+    range5::set(0xFFULL);
+    range6::set(0xEEULL);
+    range7::set(0xDDULL);
+
+    CHECK(range0::get() == mtrr::uncacheable);
+    CHECK(range1::get() == mtrr::write_combining);
+    CHECK(range2::get() == mtrr::write_through);
+    CHECK(range3::get() == mtrr::write_protected);
+    CHECK(range4::get() == mtrr::write_back);
+    CHECK(range5::get() == 0xFFULL);
+    CHECK(range6::get() == 0xEEULL);
+    CHECK(range7::get() == 0xDDULL);
+
+    auto reg = 0x0ULL;
+    reg = range0::set(reg, mtrr::uncacheable);
+    reg = range1::set(reg, mtrr::write_combining);
+    reg = range2::set(reg, mtrr::write_through);
+    reg = range3::set(reg, mtrr::write_protected);
+    reg = range4::set(reg, mtrr::write_back);
+    reg = range5::set(reg, 0xFFULL);
+    reg = range6::set(reg, 0xEEULL);
+    reg = range7::set(reg, 0xDDULL);
+
+    CHECK(range0::get(reg) == mtrr::uncacheable);
+    CHECK(range1::get(reg) == mtrr::write_combining);
+    CHECK(range2::get(reg) == mtrr::write_through);
+    CHECK(range3::get(reg) == mtrr::write_protected);
+    CHECK(range4::get(reg) == mtrr::write_back);
+    CHECK(range5::get(reg) == 0xFFULL);
+    CHECK(range6::get(reg) == 0xEEULL);
+    CHECK(range7::get(reg) == 0xDDULL);
+}

--- a/bfintrinsics/tests/arch/intel_x64/test_mtrr.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/test_mtrr.cpp
@@ -1169,9 +1169,9 @@ TEST_CASE("mtrr::fix16k_A0000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_C0000")
+TEST_CASE("mtrr::fix4k_C0000")
 {
-    using namespace intel_x64::mtrr::fix04k_C0000;
+    using namespace intel_x64::mtrr::fix4k_C0000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1215,9 +1215,9 @@ TEST_CASE("mtrr::fix04k_C0000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_C8000")
+TEST_CASE("mtrr::fix4k_C8000")
 {
-    using namespace intel_x64::mtrr::fix04k_C8000;
+    using namespace intel_x64::mtrr::fix4k_C8000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1261,9 +1261,9 @@ TEST_CASE("mtrr::fix04k_C8000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_D0000")
+TEST_CASE("mtrr::fix4k_D0000")
 {
-    using namespace intel_x64::mtrr::fix04k_D0000;
+    using namespace intel_x64::mtrr::fix4k_D0000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1307,9 +1307,9 @@ TEST_CASE("mtrr::fix04k_D0000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_D8000")
+TEST_CASE("mtrr::fix4k_D8000")
 {
-    using namespace intel_x64::mtrr::fix04k_D8000;
+    using namespace intel_x64::mtrr::fix4k_D8000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1353,9 +1353,9 @@ TEST_CASE("mtrr::fix04k_D8000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_E0000")
+TEST_CASE("mtrr::fix4k_E0000")
 {
-    using namespace intel_x64::mtrr::fix04k_E0000;
+    using namespace intel_x64::mtrr::fix4k_E0000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1399,9 +1399,9 @@ TEST_CASE("mtrr::fix04k_E0000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_E8000")
+TEST_CASE("mtrr::fix4k_E8000")
 {
-    using namespace intel_x64::mtrr::fix04k_E8000;
+    using namespace intel_x64::mtrr::fix4k_E8000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1445,9 +1445,9 @@ TEST_CASE("mtrr::fix04k_E8000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_F0000")
+TEST_CASE("mtrr::fix4k_F0000")
 {
-    using namespace intel_x64::mtrr::fix04k_F0000;
+    using namespace intel_x64::mtrr::fix4k_F0000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);
@@ -1491,9 +1491,9 @@ TEST_CASE("mtrr::fix04k_F0000")
     CHECK(range7::get(reg) == 0xDDULL);
 }
 
-TEST_CASE("mtrr::fix04k_F8000")
+TEST_CASE("mtrr::fix4k_F8000")
 {
-    using namespace intel_x64::mtrr::fix04k_F8000;
+    using namespace intel_x64::mtrr::fix4k_F8000;
 
     set(0xFFFFFFFF11111111ULL);
     CHECK(get() == 0xFFFFFFFF11111111ULL);

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_control_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_control_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/16bit_control_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_guest_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_guest_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/16bit_guest_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_host_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_16bit_host_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/16bit_host_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_control_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_control_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/32bit_control_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_guest_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_guest_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/32bit_guest_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_host_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_host_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/32bit_host_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_read_only_data_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_32bit_read_only_data_fields.cpp
@@ -19,7 +19,10 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <string>
+
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/32bit_read_only_data_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_control_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_control_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/64bit_control_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_guest_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_guest_state_fields.cpp
@@ -19,7 +19,10 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+
+#include <arch/x64/cpuid.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/64bit_guest_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_host_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_host_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/64bit_host_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_read_only_data_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_64bit_read_only_data_fields.cpp
@@ -19,7 +19,9 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/64bit_read_only_data_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_control_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_control_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/natural_width_control_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_guest_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_guest_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/natural_width_guest_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_host_state_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_host_state_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/natural_width_host_state_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_read_only_data_fields.cpp
+++ b/bfintrinsics/tests/arch/intel_x64/vmcs/test_natural_width_read_only_data_fields.cpp
@@ -19,7 +19,8 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/intel_x64/msrs.h>
+#include <arch/intel_x64/vmcs/natural_width_read_only_data_fields.h>
 
 using namespace intel_x64;
 

--- a/bfintrinsics/tests/arch/x64/test_cache.cpp
+++ b/bfintrinsics/tests/arch/x64/test_cache.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/cache.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_cpuid.cpp
+++ b/bfintrinsics/tests/arch/x64/test_cpuid.cpp
@@ -19,7 +19,7 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/x64/cpuid.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_gdt.cpp
+++ b/bfintrinsics/tests/arch/x64/test_gdt.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/gdt.h>
 
 x64::gdt_reg::reg_t g_gdt_reg;
 

--- a/bfintrinsics/tests/arch/x64/test_idt.cpp
+++ b/bfintrinsics/tests/arch/x64/test_idt.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/idt.h>
 
 x64::idt_reg::reg_t g_idt_reg;
 

--- a/bfintrinsics/tests/arch/x64/test_misc.cpp
+++ b/bfintrinsics/tests/arch/x64/test_misc.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/misc.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_msrs.cpp
+++ b/bfintrinsics/tests/arch/x64/test_msrs.cpp
@@ -19,7 +19,7 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <arch/x64/msrs.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_pm.cpp
+++ b/bfintrinsics/tests/arch/x64/test_pm.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/pm.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_portio.cpp
+++ b/bfintrinsics/tests/arch/x64/test_portio.cpp
@@ -19,7 +19,10 @@
 #include <catch/catch.hpp>
 
 #include <map>
-#include <intrinsics.h>
+#include <cstring>
+
+#include <bfgsl.h>
+#include <arch/x64/portio.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_rdtsc.cpp
+++ b/bfintrinsics/tests/arch/x64/test_rdtsc.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/rdtsc.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_rflags.cpp
+++ b/bfintrinsics/tests/arch/x64/test_rflags.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/rflags.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_srs.cpp
+++ b/bfintrinsics/tests/arch/x64/test_srs.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/srs.h>
 
 using namespace x64;
 

--- a/bfintrinsics/tests/arch/x64/test_tlb.cpp
+++ b/bfintrinsics/tests/arch/x64/test_tlb.cpp
@@ -17,7 +17,7 @@
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 #include <catch/catch.hpp>
-#include <intrinsics.h>
+#include <arch/x64/tlb.h>
 
 using namespace x64;
 

--- a/bfsdk/include/bfsupport.h
+++ b/bfsdk/include/bfsupport.h
@@ -118,6 +118,9 @@ struct section_info_t {
 struct platform_info_t {
     int _dummy;
 
+    /// Driver's virtual address of the xAPIC
+    uintptr_t xapic_virt;
+
 #if defined(BF_AARCH64)
     /// Address of serial peripheral within kernel space
     uintptr_t serial_address;

--- a/bfvmm/include/memory_manager/arch/x64/map_ptr.h
+++ b/bfvmm/include/memory_manager/arch/x64/map_ptr.h
@@ -643,7 +643,7 @@ public:
     /// @param other the unique_map_ptr to copy
     /// @return reference to this
     ///
-    unique_map_ptr &operator=(unique_map_ptr other) noexcept
+    unique_map_ptr &operator=(unique_map_ptr &&other) noexcept
     {
         reset(other.release());
         return *this;


### PR DESCRIPTION
- Add MTRR intrinsics
- Include only needed headers into intrinsics unit tests rather than intrinsics.h. This is in support of the MTRR additions, which add a reference to `_cpuid_edx`. By including intrinsics.h, unrelated tests have `_cpud_edx` as an undefined symbol.
- Add move-assignment operator in bfvmm::x64::unique_map_ptr