### PR TITLE
VT-d Intrinsics

### DIFF
--- a/bfintrinsics/include/arch/intel_x64/vtd/context_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/context_entry.h
@@ -1,0 +1,174 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_CONTEXT_ENTRY_H
+#define VTD_CONTEXT_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace context_entry
+{
+	constexpr const auto name = "context_entry";
+
+	using value_type = struct value_type { uint64_t data[2]{0}; };
+
+	namespace p
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &context_entry) noexcept
+		{ return is_bit_set(context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &context_entry) noexcept
+		{ return !is_bit_set(context_entry.data[index], from); }
+
+		inline void enable(value_type &context_entry) noexcept
+		{ context_entry.data[index] = set_bit(context_entry.data[index], from); }
+
+		inline void disable(value_type &context_entry) noexcept
+		{ context_entry.data[index] = clear_bit(context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(context_entry), msg); }
+	}
+
+	namespace fpd
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "fault_processing_disable";
+
+		inline auto is_enabled(const value_type &context_entry) noexcept
+		{ return is_bit_set(context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &context_entry) noexcept
+		{ return !is_bit_set(context_entry.data[index], from); }
+
+		inline void enable(value_type &context_entry) noexcept
+		{ context_entry.data[index] = set_bit(context_entry.data[index], from); }
+
+		inline void disable(value_type &context_entry) noexcept
+		{ context_entry.data[index] = clear_bit(context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(context_entry), msg); }
+	}
+
+	namespace t
+	{
+		constexpr const auto mask = 0xCULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "translation_type";
+
+		inline auto get(const value_type &context_entry) noexcept
+		{ return get_bits(context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &context_entry, uint64_t val) noexcept
+		{ context_entry.data[index] = set_bits(context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(context_entry), msg); }
+	}
+
+	namespace slptptr
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "second_level_page_translation_pointer";
+
+		inline auto get(const value_type &context_entry) noexcept
+		{ return get_bits(context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &context_entry, uint64_t val) noexcept
+		{ context_entry.data[index] = set_bits(context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(context_entry), msg); }
+	}
+
+	namespace aw
+	{
+		constexpr const auto mask = 0x7ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "address_width";
+
+		inline auto get(const value_type &context_entry) noexcept
+		{ return get_bits(context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &context_entry, uint64_t val) noexcept
+		{ context_entry.data[index] = set_bits(context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(context_entry), msg); }
+	}
+
+	namespace did
+	{
+		constexpr const auto mask = 0xFFFF00ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "domain_identifier";
+
+		inline auto get(const value_type &context_entry) noexcept
+		{ return get_bits(context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &context_entry, uint64_t val) noexcept
+		{ context_entry.data[index] = set_bits(context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(context_entry), msg); }
+	}
+
+	inline void dump(int level, const value_type &context_entry, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "context_entry[63:0]", context_entry.data[0], msg);
+		bfdebug_nhex(level, "context_entry[127:64]", context_entry.data[1], msg);
+
+		p::dump(level, context_entry, msg);
+		fpd::dump(level, context_entry, msg);
+		t::dump(level, context_entry, msg);
+		slptptr::dump(level, context_entry, msg);
+		aw::dump(level, context_entry, msg);
+		did::dump(level, context_entry, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/extended_context_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/extended_context_entry.h
@@ -1,0 +1,578 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_EXTENDED_CONTEXT_ENTRY_H
+#define VTD_EXTENDED_CONTEXT_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace extended_context_entry
+{
+	constexpr const auto name = "extended_context_entry";
+
+	using value_type = struct value_type { uint64_t data[4]{0}; };
+
+	namespace p
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace fpd
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "fault_processing_disable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace t
+	{
+		constexpr const auto mask = 0x1CULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "translation_type";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace emt
+	{
+		constexpr const auto mask = 0xE0ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "extended_memory_type";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace dinve
+	{
+		constexpr const auto mask = 0x100ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "deferred_invalidate_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace pre
+	{
+		constexpr const auto mask = 0x200ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 9ULL;
+		constexpr const auto name = "page_request_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace neste
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "nested_translation_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace paside
+	{
+		constexpr const auto mask = 0x800ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 11ULL;
+		constexpr const auto name = "pasid_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace slptptr
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "second_level_page_translation_pointer";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace aw
+	{
+		constexpr const auto mask = 0x7ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "address_width";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace pge
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_global_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace nxe
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "no_execute_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace wpe
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "write_protect_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace cd
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "cache_disable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace emte
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "extended_memory_type_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace did
+	{
+		constexpr const auto mask = 0xFFFF00ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "domain_identifier";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace smep
+	{
+		constexpr const auto mask = 0x1000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 24ULL;
+		constexpr const auto name = "supervisor_mode_execute_protection";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace eafe
+	{
+		constexpr const auto mask = 0x2000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 25ULL;
+		constexpr const auto name = "extended_access_flag_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace ere
+	{
+		constexpr const auto mask = 0x4000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 26ULL;
+		constexpr const auto name = "execute_requests_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace slee
+	{
+		constexpr const auto mask = 0x8000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 27ULL;
+		constexpr const auto name = "second_level_execute_enable";
+
+		inline auto is_enabled(const value_type &extended_context_entry) noexcept
+		{ return is_bit_set(extended_context_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_context_entry) noexcept
+		{ return !is_bit_set(extended_context_entry.data[index], from); }
+
+		inline void enable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = set_bit(extended_context_entry.data[index], from); }
+
+		inline void disable(value_type &extended_context_entry) noexcept
+		{ extended_context_entry.data[index] = clear_bit(extended_context_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_context_entry), msg); }
+	}
+
+	namespace pat
+	{
+		constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "page_attribute_table";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace pts
+	{
+		constexpr const auto mask = 0xFULL;
+		constexpr const auto index = 2ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "pasid_table_size";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace pasidptr
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 2ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "pasid_table_pointer";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	namespace pasidstptr
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 3ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "pasid_state_table_pointer";
+
+		inline auto get(const value_type &extended_context_entry) noexcept
+		{ return get_bits(extended_context_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_context_entry, uint64_t val) noexcept
+		{ extended_context_entry.data[index] = set_bits(extended_context_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_context_entry), msg); }
+	}
+
+	inline void dump(int level, const value_type &extended_context_entry, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "extended_context_entry[63:0]", extended_context_entry.data[0], msg);
+		bfdebug_nhex(level, "extended_context_entry[127:64]", extended_context_entry.data[1], msg);
+		bfdebug_nhex(level, "extended_context_entry[191:128]", extended_context_entry.data[2], msg);
+		bfdebug_nhex(level, "extended_context_entry[255:192]", extended_context_entry.data[3], msg);
+
+		p::dump(level, extended_context_entry, msg);
+		fpd::dump(level, extended_context_entry, msg);
+		t::dump(level, extended_context_entry, msg);
+		emt::dump(level, extended_context_entry, msg);
+		dinve::dump(level, extended_context_entry, msg);
+		pre::dump(level, extended_context_entry, msg);
+		neste::dump(level, extended_context_entry, msg);
+		paside::dump(level, extended_context_entry, msg);
+		slptptr::dump(level, extended_context_entry, msg);
+		aw::dump(level, extended_context_entry, msg);
+		pge::dump(level, extended_context_entry, msg);
+		nxe::dump(level, extended_context_entry, msg);
+		wpe::dump(level, extended_context_entry, msg);
+		cd::dump(level, extended_context_entry, msg);
+		emte::dump(level, extended_context_entry, msg);
+		did::dump(level, extended_context_entry, msg);
+		smep::dump(level, extended_context_entry, msg);
+		eafe::dump(level, extended_context_entry, msg);
+		ere::dump(level, extended_context_entry, msg);
+		slee::dump(level, extended_context_entry, msg);
+		pat::dump(level, extended_context_entry, msg);
+		pts::dump(level, extended_context_entry, msg);
+		pasidptr::dump(level, extended_context_entry, msg);
+		pasidstptr::dump(level, extended_context_entry, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/extended_root_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/extended_root_entry.h
@@ -1,0 +1,138 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_EXTENDED_ROOT_ENTRY_H
+#define VTD_EXTENDED_ROOT_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace extended_root_entry
+{
+	constexpr const auto name = "extended_root_entry";
+
+	using value_type = struct value_type { uint64_t data[2]{0}; };
+
+	namespace lp
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "lower_present";
+
+		inline auto is_enabled(const value_type &extended_root_entry) noexcept
+		{ return is_bit_set(extended_root_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_root_entry) noexcept
+		{ return !is_bit_set(extended_root_entry.data[index], from); }
+
+		inline void enable(value_type &extended_root_entry) noexcept
+		{ extended_root_entry.data[index] = set_bit(extended_root_entry.data[index], from); }
+
+		inline void disable(value_type &extended_root_entry) noexcept
+		{ extended_root_entry.data[index] = clear_bit(extended_root_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_root_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_root_entry), msg); }
+	}
+
+	namespace lctp
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "lower_context_table_pointer";
+
+		inline auto get(const value_type &extended_root_entry) noexcept
+		{ return get_bits(extended_root_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_root_entry, uint64_t val) noexcept
+		{ extended_root_entry.data[index] = set_bits(extended_root_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_root_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_root_entry), msg); }
+	}
+
+	namespace up
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "upper_present";
+
+		inline auto is_enabled(const value_type &extended_root_entry) noexcept
+		{ return is_bit_set(extended_root_entry.data[index], from); }
+
+		inline auto is_disabled(const value_type &extended_root_entry) noexcept
+		{ return !is_bit_set(extended_root_entry.data[index], from); }
+
+		inline void enable(value_type &extended_root_entry) noexcept
+		{ extended_root_entry.data[index] = set_bit(extended_root_entry.data[index], from); }
+
+		inline void disable(value_type &extended_root_entry) noexcept
+		{ extended_root_entry.data[index] = clear_bit(extended_root_entry.data[index], from); }
+
+		inline void dump(int level, const value_type &extended_root_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(extended_root_entry), msg); }
+	}
+
+	namespace uctp
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "upper_context_table_pointer";
+
+		inline auto get(const value_type &extended_root_entry) noexcept
+		{ return get_bits(extended_root_entry.data[index], mask) >> from; }
+
+		inline void set(value_type &extended_root_entry, uint64_t val) noexcept
+		{ extended_root_entry.data[index] = set_bits(extended_root_entry.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &extended_root_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(extended_root_entry), msg); }
+	}
+
+	inline void dump(int level, const value_type &extended_root_entry, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "extended_root_entry[63:0]", extended_root_entry.data[0], msg);
+		bfdebug_nhex(level, "extended_root_entry[127:64]", extended_root_entry.data[1], msg);
+
+		lp::dump(level, extended_root_entry, msg);
+		lctp::dump(level, extended_root_entry, msg);
+		up::dump(level, extended_root_entry, msg);
+		uctp::dump(level, extended_root_entry, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/fault_record.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/fault_record.h
@@ -1,0 +1,240 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_FAULT_RECORD_H
+#define VTD_FAULT_RECORD_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace fault_record
+{
+	constexpr const auto name = "fault_record";
+
+	using value_type = struct value_type { uint64_t data[2]{0}; };
+
+	namespace fi
+	{
+		constexpr const auto mask = 0xFFFFFFFFFFFFF000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "fault_information";
+
+		inline auto get(const value_type &fault_record) noexcept
+		{ return get_bits(fault_record.data[index], mask) >> from; }
+
+		inline void set(value_type &fault_record, uint64_t val) noexcept
+		{ fault_record.data[index] = set_bits(fault_record.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(fault_record), msg); }
+	}
+
+	namespace sid
+	{
+		constexpr const auto mask = 0xFFFFULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "source_identifier";
+
+		inline auto get(const value_type &fault_record) noexcept
+		{ return get_bits(fault_record.data[index], mask) >> from; }
+
+		inline void set(value_type &fault_record, uint64_t val) noexcept
+		{ fault_record.data[index] = set_bits(fault_record.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(fault_record), msg); }
+	}
+
+	namespace priv
+	{
+		constexpr const auto mask = 0x20000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 29ULL;
+		constexpr const auto name = "priviledge_mode_requested";
+
+		inline auto is_enabled(const value_type &fault_record) noexcept
+		{ return is_bit_set(fault_record.data[index], from); }
+
+		inline auto is_disabled(const value_type &fault_record) noexcept
+		{ return !is_bit_set(fault_record.data[index], from); }
+
+		inline void enable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = set_bit(fault_record.data[index], from); }
+
+		inline void disable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = clear_bit(fault_record.data[index], from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(fault_record), msg); }
+	}
+
+	namespace exe
+	{
+		constexpr const auto mask = 0x40000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 30ULL;
+		constexpr const auto name = "execute_permission_requested";
+
+		inline auto is_enabled(const value_type &fault_record) noexcept
+		{ return is_bit_set(fault_record.data[index], from); }
+
+		inline auto is_disabled(const value_type &fault_record) noexcept
+		{ return !is_bit_set(fault_record.data[index], from); }
+
+		inline void enable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = set_bit(fault_record.data[index], from); }
+
+		inline void disable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = clear_bit(fault_record.data[index], from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(fault_record), msg); }
+	}
+
+	namespace pp
+	{
+		constexpr const auto mask = 0x80000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 31ULL;
+		constexpr const auto name = "pasid_present";
+
+		inline auto is_enabled(const value_type &fault_record) noexcept
+		{ return is_bit_set(fault_record.data[index], from); }
+
+		inline auto is_disabled(const value_type &fault_record) noexcept
+		{ return !is_bit_set(fault_record.data[index], from); }
+
+		inline void enable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = set_bit(fault_record.data[index], from); }
+
+		inline void disable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = clear_bit(fault_record.data[index], from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(fault_record), msg); }
+	}
+
+	namespace fr
+	{
+		constexpr const auto mask = 0xFF00000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "fault_reason";
+
+		inline auto get(const value_type &fault_record) noexcept
+		{ return get_bits(fault_record.data[index], mask) >> from; }
+
+		inline void set(value_type &fault_record, uint64_t val) noexcept
+		{ fault_record.data[index] = set_bits(fault_record.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(fault_record), msg); }
+	}
+
+	namespace pv
+	{
+		constexpr const auto mask = 0xFFFFF0000000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 40ULL;
+		constexpr const auto name = "pasid_value";
+
+		inline auto get(const value_type &fault_record) noexcept
+		{ return get_bits(fault_record.data[index], mask) >> from; }
+
+		inline void set(value_type &fault_record, uint64_t val) noexcept
+		{ fault_record.data[index] = set_bits(fault_record.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(fault_record), msg); }
+	}
+
+	namespace at
+	{
+		constexpr const auto mask = 0x3000000000000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 60ULL;
+		constexpr const auto name = "address_type";
+
+		inline auto get(const value_type &fault_record) noexcept
+		{ return get_bits(fault_record.data[index], mask) >> from; }
+
+		inline void set(value_type &fault_record, uint64_t val) noexcept
+		{ fault_record.data[index] = set_bits(fault_record.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(fault_record), msg); }
+	}
+
+	namespace t
+	{
+		constexpr const auto mask = 0x4000000000000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 62ULL;
+		constexpr const auto name = "type";
+
+		inline auto is_enabled(const value_type &fault_record) noexcept
+		{ return is_bit_set(fault_record.data[index], from); }
+
+		inline auto is_disabled(const value_type &fault_record) noexcept
+		{ return !is_bit_set(fault_record.data[index], from); }
+
+		inline void enable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = set_bit(fault_record.data[index], from); }
+
+		inline void disable(value_type &fault_record) noexcept
+		{ fault_record.data[index] = clear_bit(fault_record.data[index], from); }
+
+		inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(fault_record), msg); }
+	}
+
+	inline void dump(int level, const value_type &fault_record, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "fault_record[63:0]", fault_record.data[0], msg);
+		bfdebug_nhex(level, "fault_record[127:64]", fault_record.data[1], msg);
+
+		fi::dump(level, fault_record, msg);
+		sid::dump(level, fault_record, msg);
+		priv::dump(level, fault_record, msg);
+		exe::dump(level, fault_record, msg);
+		pp::dump(level, fault_record, msg);
+		fr::dump(level, fault_record, msg);
+		pv::dump(level, fault_record, msg);
+		at::dump(level, fault_record, msg);
+		t::dump(level, fault_record, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/first_level_paging_entries.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/first_level_paging_entries.h
@@ -1,0 +1,1366 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_FIRST_LEVEL_PAGING_ENTRIES_H
+#define VTD_FIRST_LEVEL_PAGING_ENTRIES_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+namespace first_level_paging_entries
+{
+
+namespace pml5e
+{
+	constexpr const auto name = "pml5e";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace write_enable
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_enable";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace user_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "user_access";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace page_level_write_through
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace page_level_cache_disable
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace accessed_flag
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "accessed_flag";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace extended_access
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "extended_access";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pml5e) noexcept
+		{ return get_bits(pml5e, mask) >> from; }
+
+		inline void set(value_type &pml5e, uint64_t val) noexcept
+		{ pml5e = set_bits(pml5e, mask, val << from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pml5e), msg); }
+	}
+
+	namespace execute_disable
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "execute_disable";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pml5e", pml5e, msg);
+
+		present::dump(level, pml5e, msg);
+		write_enable::dump(level, pml5e, msg);
+		user_access::dump(level, pml5e, msg);
+		page_level_write_through::dump(level, pml5e, msg);
+		page_level_cache_disable::dump(level, pml5e, msg);
+		accessed_flag::dump(level, pml5e, msg);
+		extended_access::dump(level, pml5e, msg);
+		phys_addr_bits::dump(level, pml5e, msg);
+		execute_disable::dump(level, pml5e, msg);
+	}
+}
+
+namespace pml4e
+{
+	constexpr const auto name = "pml4e";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace write_enable
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_enable";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace user_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "user_access";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace page_level_write_through
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace page_level_cache_disable
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace accessed_flag
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "accessed_flag";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace extended_access
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "extended_access";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pml4e) noexcept
+		{ return get_bits(pml4e, mask) >> from; }
+
+		inline void set(value_type &pml4e, uint64_t val) noexcept
+		{ pml4e = set_bits(pml4e, mask, val << from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pml4e), msg); }
+	}
+
+	namespace execute_disable
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "execute_disable";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pml4e", pml4e, msg);
+
+		present::dump(level, pml4e, msg);
+		write_enable::dump(level, pml4e, msg);
+		user_access::dump(level, pml4e, msg);
+		page_level_write_through::dump(level, pml4e, msg);
+		page_level_cache_disable::dump(level, pml4e, msg);
+		accessed_flag::dump(level, pml4e, msg);
+		extended_access::dump(level, pml4e, msg);
+		phys_addr_bits::dump(level, pml4e, msg);
+		execute_disable::dump(level, pml4e, msg);
+	}
+}
+
+namespace pdpte
+{
+	constexpr const auto name = "pdpte";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace write_enable
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_enable";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace user_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "user_access";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace page_level_write_through
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace page_level_cache_disable
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace accessed_flag
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "accessed_flag";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace dirty_flag
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "dirty_flag";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace entry_type
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "entry_type";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace global_enable
+	{
+		constexpr const auto mask = 0x100ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "global_enable";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace extended_access
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "extended_access";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace pat
+	{
+		constexpr const auto mask = 0x1000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "pat";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pdpte) noexcept
+		{ return get_bits(pdpte, mask) >> from; }
+
+		inline void set(value_type &pdpte, uint64_t val) noexcept
+		{ pdpte = set_bits(pdpte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pdpte), msg); }
+	}
+
+	namespace execute_disable
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "execute_disable";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pdpte", pdpte, msg);
+
+		present::dump(level, pdpte, msg);
+		write_enable::dump(level, pdpte, msg);
+		user_access::dump(level, pdpte, msg);
+		page_level_write_through::dump(level, pdpte, msg);
+		page_level_cache_disable::dump(level, pdpte, msg);
+		accessed_flag::dump(level, pdpte, msg);
+		dirty_flag::dump(level, pdpte, msg);
+		entry_type::dump(level, pdpte, msg);
+		global_enable::dump(level, pdpte, msg);
+		extended_access::dump(level, pdpte, msg);
+		pat::dump(level, pdpte, msg);
+		phys_addr_bits::dump(level, pdpte, msg);
+		execute_disable::dump(level, pdpte, msg);
+	}
+}
+
+namespace pde
+{
+	constexpr const auto name = "pde";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace write_enable
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_enable";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace user_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "user_access";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace page_level_write_through
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace page_level_cache_disable
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace accessed_flag
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "accessed_flag";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace dirty_flag
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "dirty_flag";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace entry_type
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "entry_type";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace global_enable
+	{
+		constexpr const auto mask = 0x100ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "global_enable";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace extended_access
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "extended_access";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace pat
+	{
+		constexpr const auto mask = 0x1000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "pat";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pde) noexcept
+		{ return get_bits(pde, mask) >> from; }
+
+		inline void set(value_type &pde, uint64_t val) noexcept
+		{ pde = set_bits(pde, mask, val << from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pde), msg); }
+	}
+
+	namespace execute_disable
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "execute_disable";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pde", pde, msg);
+
+		present::dump(level, pde, msg);
+		write_enable::dump(level, pde, msg);
+		user_access::dump(level, pde, msg);
+		page_level_write_through::dump(level, pde, msg);
+		page_level_cache_disable::dump(level, pde, msg);
+		accessed_flag::dump(level, pde, msg);
+		dirty_flag::dump(level, pde, msg);
+		entry_type::dump(level, pde, msg);
+		global_enable::dump(level, pde, msg);
+		extended_access::dump(level, pde, msg);
+		pat::dump(level, pde, msg);
+		phys_addr_bits::dump(level, pde, msg);
+		execute_disable::dump(level, pde, msg);
+	}
+}
+
+namespace pte
+{
+	constexpr const auto name = "pte";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace write_enable
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_enable";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace user_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "user_access";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace page_level_write_through
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace page_level_cache_disable
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace accessed_flag
+	{
+		constexpr const auto mask = 0x20ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "accessed_flag";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace dirty_flag
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "dirty_flag";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace pat
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "pat";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace global_enable
+	{
+		constexpr const auto mask = 0x100ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "global_enable";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace extended_access
+	{
+		constexpr const auto mask = 0x400ULL;
+		constexpr const auto from = 10ULL;
+		constexpr const auto name = "extended_access";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pte) noexcept
+		{ return get_bits(pte, mask) >> from; }
+
+		inline void set(value_type &pte, uint64_t val) noexcept
+		{ pte = set_bits(pte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pte), msg); }
+	}
+
+	namespace execute_disable
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "execute_disable";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pte", pte, msg);
+
+		present::dump(level, pte, msg);
+		write_enable::dump(level, pte, msg);
+		user_access::dump(level, pte, msg);
+		page_level_write_through::dump(level, pte, msg);
+		page_level_cache_disable::dump(level, pte, msg);
+		accessed_flag::dump(level, pte, msg);
+		dirty_flag::dump(level, pte, msg);
+		pat::dump(level, pte, msg);
+		global_enable::dump(level, pte, msg);
+		extended_access::dump(level, pte, msg);
+		phys_addr_bits::dump(level, pte, msg);
+		execute_disable::dump(level, pte, msg);
+	}
+}
+
+}
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/irte.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/irte.h
@@ -1,0 +1,402 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_IRTE_H
+#define VTD_IRTE_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace irte
+{
+	constexpr const auto name = "irte";
+
+	using value_type = struct value_type { uint64_t data[2]{0}; };
+
+	namespace p
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace fpd
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "fault_processing_disable";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace dm
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "destination_mode";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace rh
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "redirection_hint";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace tm
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "trigger_mode";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace dlm
+	{
+		constexpr const auto mask = 0xE0ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 5ULL;
+		constexpr const auto name = "delivery_mode";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace avail
+	{
+		constexpr const auto mask = 0xF00ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 8ULL;
+		constexpr const auto name = "available";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace urg
+	{
+		constexpr const auto mask = 0x4000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 14ULL;
+		constexpr const auto name = "urgent";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace im
+	{
+		constexpr const auto mask = 0x8000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 15ULL;
+		constexpr const auto name = "irte_mode";
+
+		inline auto is_enabled(const value_type &irte) noexcept
+		{ return is_bit_set(irte.data[index], from); }
+
+		inline auto is_disabled(const value_type &irte) noexcept
+		{ return !is_bit_set(irte.data[index], from); }
+
+		inline void enable(value_type &irte) noexcept
+		{ irte.data[index] = set_bit(irte.data[index], from); }
+
+		inline void disable(value_type &irte) noexcept
+		{ irte.data[index] = clear_bit(irte.data[index], from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(irte), msg); }
+	}
+
+	namespace v
+	{
+		constexpr const auto mask = 0xFF0000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 16ULL;
+		constexpr const auto name = "vector";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace vv
+	{
+		constexpr const auto mask = 0xFF0000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 16ULL;
+		constexpr const auto name = "virtual_vector";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace dst
+	{
+		constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "destination_id";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace pdal
+	{
+		constexpr const auto mask = 0xFFFFFFC000000000ULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 38ULL;
+		constexpr const auto name = "posted_descriptor_address_low";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace sid
+	{
+		constexpr const auto mask = 0xFFFFULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "source_identifier";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace sq
+	{
+		constexpr const auto mask = 0x30000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 16ULL;
+		constexpr const auto name = "source_id_qualifier";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace svt
+	{
+		constexpr const auto mask = 0xC0000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 18ULL;
+		constexpr const auto name = "source_validation_type";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	namespace pdah
+	{
+		constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+		constexpr const auto index = 1ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "posted_descriptor_address_high";
+
+		inline auto get(const value_type &irte) noexcept
+		{ return get_bits(irte.data[index], mask) >> from; }
+
+		inline void set(value_type &irte, uint64_t val) noexcept
+		{ irte.data[index] = set_bits(irte.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(irte), msg); }
+	}
+
+	inline void dump(int level, const value_type &irte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "irte[63:0]", irte.data[0], msg);
+		bfdebug_nhex(level, "irte[127:64]", irte.data[1], msg);
+
+		p::dump(level, irte, msg);
+		fpd::dump(level, irte, msg);
+		dm::dump(level, irte, msg);
+		rh::dump(level, irte, msg);
+		tm::dump(level, irte, msg);
+		dlm::dump(level, irte, msg);
+		avail::dump(level, irte, msg);
+		urg::dump(level, irte, msg);
+		im::dump(level, irte, msg);
+		v::dump(level, irte, msg);
+		vv::dump(level, irte, msg);
+		dst::dump(level, irte, msg);
+		pdal::dump(level, irte, msg);
+		sid::dump(level, irte, msg);
+		sq::dump(level, irte, msg);
+		svt::dump(level, irte, msg);
+		pdah::dump(level, irte, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/pasid_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/pasid_entry.h
@@ -1,0 +1,179 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_PASID_ENTRY_H
+#define VTD_PASID_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace pasid_entry
+{
+	constexpr const auto name = "pasid_entry";
+
+	using value_type = uint64_t;
+
+	namespace p
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &pasid_entry) noexcept
+		{ return is_bit_set(pasid_entry, from); }
+
+		inline auto is_disabled(const value_type &pasid_entry) noexcept
+		{ return !is_bit_set(pasid_entry, from); }
+
+		inline void enable(value_type &pasid_entry) noexcept
+		{ pasid_entry = set_bit(pasid_entry, from); }
+
+		inline void disable(value_type &pasid_entry) noexcept
+		{ pasid_entry = clear_bit(pasid_entry, from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pasid_entry), msg); }
+	}
+
+	namespace pwt
+	{
+		constexpr const auto mask = 0x8ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "page_level_write_through";
+
+		inline auto is_enabled(const value_type &pasid_entry) noexcept
+		{ return is_bit_set(pasid_entry, from); }
+
+		inline auto is_disabled(const value_type &pasid_entry) noexcept
+		{ return !is_bit_set(pasid_entry, from); }
+
+		inline void enable(value_type &pasid_entry) noexcept
+		{ pasid_entry = set_bit(pasid_entry, from); }
+
+		inline void disable(value_type &pasid_entry) noexcept
+		{ pasid_entry = clear_bit(pasid_entry, from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pasid_entry), msg); }
+	}
+
+	namespace pcd
+	{
+		constexpr const auto mask = 0x10ULL;
+		constexpr const auto from = 4ULL;
+		constexpr const auto name = "page_level_cache_disable";
+
+		inline auto is_enabled(const value_type &pasid_entry) noexcept
+		{ return is_bit_set(pasid_entry, from); }
+
+		inline auto is_disabled(const value_type &pasid_entry) noexcept
+		{ return !is_bit_set(pasid_entry, from); }
+
+		inline void enable(value_type &pasid_entry) noexcept
+		{ pasid_entry = set_bit(pasid_entry, from); }
+
+		inline void disable(value_type &pasid_entry) noexcept
+		{ pasid_entry = clear_bit(pasid_entry, from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pasid_entry), msg); }
+	}
+
+	namespace flpm
+	{
+		constexpr const auto mask = 0x600ULL;
+		constexpr const auto from = 9ULL;
+		constexpr const auto name = "first_level_paging_mode";
+
+		inline auto get(const value_type &pasid_entry) noexcept
+		{ return get_bits(pasid_entry, mask) >> from; }
+
+		inline void set(value_type &pasid_entry, uint64_t val) noexcept
+		{ pasid_entry = set_bits(pasid_entry, mask, val << from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pasid_entry), msg); }
+	}
+
+	namespace sre
+	{
+		constexpr const auto mask = 0x800ULL;
+		constexpr const auto from = 11ULL;
+		constexpr const auto name = "supervisor_request_enable";
+
+		inline auto is_enabled(const value_type &pasid_entry) noexcept
+		{ return is_bit_set(pasid_entry, from); }
+
+		inline auto is_disabled(const value_type &pasid_entry) noexcept
+		{ return !is_bit_set(pasid_entry, from); }
+
+		inline void enable(value_type &pasid_entry) noexcept
+		{ pasid_entry = set_bit(pasid_entry, from); }
+
+		inline void disable(value_type &pasid_entry) noexcept
+		{ pasid_entry = clear_bit(pasid_entry, from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pasid_entry), msg); }
+	}
+
+	namespace flptptr
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "first_level_page_table_translation_pointer";
+
+		inline auto get(const value_type &pasid_entry) noexcept
+		{ return get_bits(pasid_entry, mask) >> from; }
+
+		inline void set(value_type &pasid_entry, uint64_t val) noexcept
+		{ pasid_entry = set_bits(pasid_entry, mask, val << from); }
+
+		inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pasid_entry), msg); }
+	}
+
+	inline void dump(int level, const value_type &pasid_entry, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pasid_entry", pasid_entry, msg);
+
+		p::dump(level, pasid_entry, msg);
+		pwt::dump(level, pasid_entry, msg);
+		pcd::dump(level, pasid_entry, msg);
+		flpm::dump(level, pasid_entry, msg);
+		sre::dump(level, pasid_entry, msg);
+		flptptr::dump(level, pasid_entry, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/pasid_state_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/pasid_state_entry.h
@@ -1,0 +1,93 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_PASID_STATE_ENTRY_H
+#define VTD_PASID_STATE_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace pasid_state_entry
+{
+	constexpr const auto name = "pasid_state_entry";
+
+	using value_type = uint64_t;
+
+	namespace arefcnt
+	{
+		constexpr const auto mask = 0xFFFF00000000ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "active_reference_count";
+
+		inline auto get(const value_type &pasid_state_entry) noexcept
+		{ return get_bits(pasid_state_entry, mask) >> from; }
+
+		inline void set(value_type &pasid_state_entry, uint64_t val) noexcept
+		{ pasid_state_entry = set_bits(pasid_state_entry, mask, val << from); }
+
+		inline void dump(int level, const value_type &pasid_state_entry, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pasid_state_entry), msg); }
+	}
+
+	namespace dinv
+	{
+		constexpr const auto mask = 0x8000000000000000ULL;
+		constexpr const auto from = 63ULL;
+		constexpr const auto name = "deferred_invalidate";
+
+		inline auto is_enabled(const value_type &pasid_state_entry) noexcept
+		{ return is_bit_set(pasid_state_entry, from); }
+
+		inline auto is_disabled(const value_type &pasid_state_entry) noexcept
+		{ return !is_bit_set(pasid_state_entry, from); }
+
+		inline void enable(value_type &pasid_state_entry) noexcept
+		{ pasid_state_entry = set_bit(pasid_state_entry, from); }
+
+		inline void disable(value_type &pasid_state_entry) noexcept
+		{ pasid_state_entry = clear_bit(pasid_state_entry, from); }
+
+		inline void dump(int level, const value_type &pasid_state_entry, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pasid_state_entry), msg); }
+	}
+
+	inline void dump(int level, const value_type &pasid_state_entry, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pasid_state_entry", pasid_state_entry, msg);
+
+		arefcnt::dump(level, pasid_state_entry, msg);
+		dinv::dump(level, pasid_state_entry, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/pid.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/pid.h
@@ -1,0 +1,162 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_POSTED_INTERRUPT_DESCRIPTOR_H
+#define VTD_POSTED_INTERRUPT_DESCRIPTOR_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace pid
+{
+	constexpr const auto name = "pid";
+
+	using value_type = struct value_type { uint64_t data[8]{0}; };
+
+	namespace pir
+	{
+		constexpr const auto mask = 0xFFFFFFFFFFFFFFFFULL;
+		constexpr const auto index = 0ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "posted_interrupt_requests";
+
+		inline auto get(const value_type &pid) noexcept
+		{ return get_bits(pid.data[index], mask) >> from; }
+
+		inline void set(value_type &pid, uint64_t val) noexcept
+		{ pid.data[index] = set_bits(pid.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pid), msg); }
+	}
+
+	namespace on
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto index = 4ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "outstanding_notification";
+
+		inline auto is_enabled(const value_type &pid) noexcept
+		{ return is_bit_set(pid.data[index], from); }
+
+		inline auto is_disabled(const value_type &pid) noexcept
+		{ return !is_bit_set(pid.data[index], from); }
+
+		inline void enable(value_type &pid) noexcept
+		{ pid.data[index] = set_bit(pid.data[index], from); }
+
+		inline void disable(value_type &pid) noexcept
+		{ pid.data[index] = clear_bit(pid.data[index], from); }
+
+		inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pid), msg); }
+	}
+
+	namespace sn
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto index = 4ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "supress_notification";
+
+		inline auto is_enabled(const value_type &pid) noexcept
+		{ return is_bit_set(pid.data[index], from); }
+
+		inline auto is_disabled(const value_type &pid) noexcept
+		{ return !is_bit_set(pid.data[index], from); }
+
+		inline void enable(value_type &pid) noexcept
+		{ pid.data[index] = set_bit(pid.data[index], from); }
+
+		inline void disable(value_type &pid) noexcept
+		{ pid.data[index] = clear_bit(pid.data[index], from); }
+
+		inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pid), msg); }
+	}
+
+	namespace nv
+	{
+		constexpr const auto mask = 0xFF0000ULL;
+		constexpr const auto index = 4ULL;
+		constexpr const auto from = 16ULL;
+		constexpr const auto name = "notification_vector";
+
+		inline auto get(const value_type &pid) noexcept
+		{ return get_bits(pid.data[index], mask) >> from; }
+
+		inline void set(value_type &pid, uint64_t val) noexcept
+		{ pid.data[index] = set_bits(pid.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pid), msg); }
+	}
+
+	namespace ndst
+	{
+		constexpr const auto mask = 0xFFFFFFFF00000000ULL;
+		constexpr const auto index = 4ULL;
+		constexpr const auto from = 32ULL;
+		constexpr const auto name = "notification_destination";
+
+		inline auto get(const value_type &pid) noexcept
+		{ return get_bits(pid.data[index], mask) >> from; }
+
+		inline void set(value_type &pid, uint64_t val) noexcept
+		{ pid.data[index] = set_bits(pid.data[index], mask, val << from); }
+
+		inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pid), msg); }
+	}
+
+	inline void dump(int level, const value_type &pid, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pid[63:0]", pid.data[0], msg);
+		bfdebug_nhex(level, "pid[127:64]", pid.data[1], msg);
+		bfdebug_nhex(level, "pid[191:128]", pid.data[2], msg);
+		bfdebug_nhex(level, "pid[255:192]", pid.data[3], msg);
+		bfdebug_nhex(level, "pid[319:256]", pid.data[4], msg);
+		bfdebug_nhex(level, "pid[383:320]", pid.data[5], msg);
+		bfdebug_nhex(level, "pid[447:384]", pid.data[6], msg);
+		bfdebug_nhex(level, "pid[511:448]", pid.data[7], msg);
+
+		pir::dump(level, pid, msg);
+		on::dump(level, pid, msg);
+		sn::dump(level, pid, msg);
+		nv::dump(level, pid, msg);
+		ndst::dump(level, pid, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/root_entry.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/root_entry.h
@@ -1,0 +1,93 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_ROOT_TABLE_ENTRY_H
+#define VTD_ROOT_TABLE_ENTRY_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+
+namespace rte
+{
+	constexpr const auto name = "rte";
+
+	using value_type = uint64_t;
+
+	namespace present
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "present";
+
+		inline auto is_enabled(const value_type &rte) noexcept
+		{ return is_bit_set(rte, from); }
+
+		inline auto is_disabled(const value_type &rte) noexcept
+		{ return !is_bit_set(rte, from); }
+
+		inline void enable(value_type &rte) noexcept
+		{ rte = set_bit(rte, from); }
+
+		inline void disable(value_type &rte) noexcept
+		{ rte = clear_bit(rte, from); }
+
+		inline void dump(int level, const value_type &rte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(rte), msg); }
+	}
+
+	namespace context_table_pointer
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "context_table_pointer";
+
+		inline auto get(const value_type &rte) noexcept
+		{ return get_bits(rte, mask) >> from; }
+
+		inline void set(value_type &rte, uint64_t val) noexcept
+		{ rte = set_bits(rte, mask, val << from); }
+
+		inline void dump(int level, const value_type &rte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(rte), msg); }
+	}
+
+	inline void dump(int level, const value_type &rte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "rte", rte, msg);
+
+		present::dump(level, rte, msg);
+		context_table_pointer::dump(level, rte, msg);
+	}
+}
+
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/arch/intel_x64/vtd/second_level_paging_entries.h
+++ b/bfintrinsics/include/arch/intel_x64/vtd/second_level_paging_entries.h
@@ -1,0 +1,865 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+//
+
+#ifndef VTD_SECOND_LEVEL_PAGING_ENTRIES_H
+#define VTD_SECOND_LEVEL_PAGING_ENTRIES_H
+
+#include <stdint.h>
+#include <bfgsl.h>
+#include <bfbitmanip.h>
+#include <bfdebug.h>
+
+// *INDENT-OFF*
+
+namespace intel_x64
+{
+namespace vtd
+{
+namespace second_level_paging_entries
+{
+
+namespace pml5e
+{
+	constexpr const auto name = "pml5e";
+
+	using value_type = uint64_t;
+
+	namespace read_access
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "read_access";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace write_access
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_access";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace execute_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "execute_access";
+
+		inline auto is_enabled(const value_type &pml5e) noexcept
+		{ return is_bit_set(pml5e, from); }
+
+		inline auto is_disabled(const value_type &pml5e) noexcept
+		{ return !is_bit_set(pml5e, from); }
+
+		inline void enable(value_type &pml5e) noexcept
+		{ pml5e = set_bit(pml5e, from); }
+
+		inline void disable(value_type &pml5e) noexcept
+		{ pml5e = clear_bit(pml5e, from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml5e), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pml5e) noexcept
+		{ return get_bits(pml5e, mask) >> from; }
+
+		inline void set(value_type &pml5e, uint64_t val) noexcept
+		{ pml5e = set_bits(pml5e, mask, val << from); }
+
+		inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pml5e), msg); }
+	}
+
+	inline void dump(int level, const value_type &pml5e, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pml5e", pml5e, msg);
+
+		read_access::dump(level, pml5e, msg);
+		write_access::dump(level, pml5e, msg);
+		execute_access::dump(level, pml5e, msg);
+		phys_addr_bits::dump(level, pml5e, msg);
+	}
+}
+
+namespace pml4e
+{
+	constexpr const auto name = "pml4e";
+
+	using value_type = uint64_t;
+
+	namespace read_access
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "read_access";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace write_access
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_access";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace execute_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "execute_access";
+
+		inline auto is_enabled(const value_type &pml4e) noexcept
+		{ return is_bit_set(pml4e, from); }
+
+		inline auto is_disabled(const value_type &pml4e) noexcept
+		{ return !is_bit_set(pml4e, from); }
+
+		inline void enable(value_type &pml4e) noexcept
+		{ pml4e = set_bit(pml4e, from); }
+
+		inline void disable(value_type &pml4e) noexcept
+		{ pml4e = clear_bit(pml4e, from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pml4e), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pml4e) noexcept
+		{ return get_bits(pml4e, mask) >> from; }
+
+		inline void set(value_type &pml4e, uint64_t val) noexcept
+		{ pml4e = set_bits(pml4e, mask, val << from); }
+
+		inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pml4e), msg); }
+	}
+
+	inline void dump(int level, const value_type &pml4e, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pml4e", pml4e, msg);
+
+		read_access::dump(level, pml4e, msg);
+		write_access::dump(level, pml4e, msg);
+		execute_access::dump(level, pml4e, msg);
+		phys_addr_bits::dump(level, pml4e, msg);
+	}
+}
+
+namespace pdpte
+{
+	constexpr const auto name = "pdpte";
+
+	using value_type = uint64_t;
+
+	namespace read_access
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "read_access";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace write_access
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_access";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace execute_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "execute_access";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace extended_memory_type
+	{
+		constexpr const auto mask = 0x38ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "extended_memory_type";
+
+		inline auto get(const value_type &pdpte) noexcept
+		{ return get_bits(pdpte, mask) >> from; }
+
+		inline void set(value_type &pdpte, uint64_t val) noexcept
+		{ pdpte = set_bits(pdpte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pdpte), msg); }
+	}
+
+	namespace ignore_pat
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "ignore_pat";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace entry_type
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "entry_type";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace snoop
+	{
+		constexpr const auto mask = 0x800ULL;
+		constexpr const auto from = 11ULL;
+		constexpr const auto name = "snoop";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pdpte) noexcept
+		{ return get_bits(pdpte, mask) >> from; }
+
+		inline void set(value_type &pdpte, uint64_t val) noexcept
+		{ pdpte = set_bits(pdpte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pdpte), msg); }
+	}
+
+	namespace transient_mapping
+	{
+		constexpr const auto mask = 0x4000000000000000ULL;
+		constexpr const auto from = 62ULL;
+		constexpr const auto name = "transient_mapping";
+
+		inline auto is_enabled(const value_type &pdpte) noexcept
+		{ return is_bit_set(pdpte, from); }
+
+		inline auto is_disabled(const value_type &pdpte) noexcept
+		{ return !is_bit_set(pdpte, from); }
+
+		inline void enable(value_type &pdpte) noexcept
+		{ pdpte = set_bit(pdpte, from); }
+
+		inline void disable(value_type &pdpte) noexcept
+		{ pdpte = clear_bit(pdpte, from); }
+
+		inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pdpte), msg); }
+	}
+
+	inline void dump(int level, const value_type &pdpte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pdpte", pdpte, msg);
+
+		read_access::dump(level, pdpte, msg);
+		write_access::dump(level, pdpte, msg);
+		execute_access::dump(level, pdpte, msg);
+		extended_memory_type::dump(level, pdpte, msg);
+		ignore_pat::dump(level, pdpte, msg);
+		entry_type::dump(level, pdpte, msg);
+		snoop::dump(level, pdpte, msg);
+		phys_addr_bits::dump(level, pdpte, msg);
+		transient_mapping::dump(level, pdpte, msg);
+	}
+}
+
+namespace pde
+{
+	constexpr const auto name = "pde";
+
+	using value_type = uint64_t;
+
+	namespace read_access
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "read_access";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace write_access
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_access";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace execute_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "execute_access";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace extended_memory_type
+	{
+		constexpr const auto mask = 0x38ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "extended_memory_type";
+
+		inline auto get(const value_type &pde) noexcept
+		{ return get_bits(pde, mask) >> from; }
+
+		inline void set(value_type &pde, uint64_t val) noexcept
+		{ pde = set_bits(pde, mask, val << from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pde), msg); }
+	}
+
+	namespace ignore_pat
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "ignore_pat";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace entry_type
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "entry_type";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace snoop
+	{
+		constexpr const auto mask = 0x800ULL;
+		constexpr const auto from = 11ULL;
+		constexpr const auto name = "snoop";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pde) noexcept
+		{ return get_bits(pde, mask) >> from; }
+
+		inline void set(value_type &pde, uint64_t val) noexcept
+		{ pde = set_bits(pde, mask, val << from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pde), msg); }
+	}
+
+	namespace transient_mapping
+	{
+		constexpr const auto mask = 0x4000000000000000ULL;
+		constexpr const auto from = 62ULL;
+		constexpr const auto name = "transient_mapping";
+
+		inline auto is_enabled(const value_type &pde) noexcept
+		{ return is_bit_set(pde, from); }
+
+		inline auto is_disabled(const value_type &pde) noexcept
+		{ return !is_bit_set(pde, from); }
+
+		inline void enable(value_type &pde) noexcept
+		{ pde = set_bit(pde, from); }
+
+		inline void disable(value_type &pde) noexcept
+		{ pde = clear_bit(pde, from); }
+
+		inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pde), msg); }
+	}
+
+	inline void dump(int level, const value_type &pde, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pde", pde, msg);
+
+		read_access::dump(level, pde, msg);
+		write_access::dump(level, pde, msg);
+		execute_access::dump(level, pde, msg);
+		extended_memory_type::dump(level, pde, msg);
+		ignore_pat::dump(level, pde, msg);
+		entry_type::dump(level, pde, msg);
+		snoop::dump(level, pde, msg);
+		phys_addr_bits::dump(level, pde, msg);
+		transient_mapping::dump(level, pde, msg);
+	}
+}
+
+namespace pte
+{
+	constexpr const auto name = "pte";
+
+	using value_type = uint64_t;
+
+	namespace read_access
+	{
+		constexpr const auto mask = 0x1ULL;
+		constexpr const auto from = 0ULL;
+		constexpr const auto name = "read_access";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace write_access
+	{
+		constexpr const auto mask = 0x2ULL;
+		constexpr const auto from = 1ULL;
+		constexpr const auto name = "write_access";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace execute_access
+	{
+		constexpr const auto mask = 0x4ULL;
+		constexpr const auto from = 2ULL;
+		constexpr const auto name = "execute_access";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace extended_memory_type
+	{
+		constexpr const auto mask = 0x38ULL;
+		constexpr const auto from = 3ULL;
+		constexpr const auto name = "extended_memory_type";
+
+		inline auto get(const value_type &pte) noexcept
+		{ return get_bits(pte, mask) >> from; }
+
+		inline void set(value_type &pte, uint64_t val) noexcept
+		{ pte = set_bits(pte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pte), msg); }
+	}
+
+	namespace ignore_pat
+	{
+		constexpr const auto mask = 0x40ULL;
+		constexpr const auto from = 6ULL;
+		constexpr const auto name = "ignore_pat";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace entry_type
+	{
+		constexpr const auto mask = 0x80ULL;
+		constexpr const auto from = 7ULL;
+		constexpr const auto name = "entry_type";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace snoop
+	{
+		constexpr const auto mask = 0x800ULL;
+		constexpr const auto from = 11ULL;
+		constexpr const auto name = "snoop";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	namespace phys_addr_bits
+	{
+		constexpr const auto mask = 0xFFFFFFFFF000ULL;
+		constexpr const auto from = 12ULL;
+		constexpr const auto name = "phys_addr_bits";
+
+		inline auto get(const value_type &pte) noexcept
+		{ return get_bits(pte, mask) >> from; }
+
+		inline void set(value_type &pte, uint64_t val) noexcept
+		{ pte = set_bits(pte, mask, val << from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subnhex(level, name, get(pte), msg); }
+	}
+
+	namespace transient_mapping
+	{
+		constexpr const auto mask = 0x4000000000000000ULL;
+		constexpr const auto from = 62ULL;
+		constexpr const auto name = "transient_mapping";
+
+		inline auto is_enabled(const value_type &pte) noexcept
+		{ return is_bit_set(pte, from); }
+
+		inline auto is_disabled(const value_type &pte) noexcept
+		{ return !is_bit_set(pte, from); }
+
+		inline void enable(value_type &pte) noexcept
+		{ pte = set_bit(pte, from); }
+
+		inline void disable(value_type &pte) noexcept
+		{ pte = clear_bit(pte, from); }
+
+		inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+		{ bfdebug_subbool(level, name, is_enabled(pte), msg); }
+	}
+
+	inline void dump(int level, const value_type &pte, std::string *msg = nullptr)
+	{
+		bfdebug_nhex(level, "pte", pte, msg);
+
+		read_access::dump(level, pte, msg);
+		write_access::dump(level, pte, msg);
+		execute_access::dump(level, pte, msg);
+		extended_memory_type::dump(level, pte, msg);
+		ignore_pat::dump(level, pte, msg);
+		entry_type::dump(level, pte, msg);
+		snoop::dump(level, pte, msg);
+		phys_addr_bits::dump(level, pte, msg);
+		transient_mapping::dump(level, pte, msg);
+	}
+}
+
+}
+}
+}
+
+// *INDENT-ON*
+
+#endif

--- a/bfintrinsics/include/intrinsics.h
+++ b/bfintrinsics/include/intrinsics.h
@@ -62,6 +62,17 @@
 #include <arch/intel_x64/vmcs/natural_width_guest_state_fields.h>
 #include <arch/intel_x64/vmcs/natural_width_host_state_fields.h>
 #include <arch/intel_x64/vmcs/natural_width_read_only_data_fields.h>
+#include <arch/intel_x64/vtd/context_entry.h>
+#include <arch/intel_x64/vtd/extended_context_entry.h>
+#include <arch/intel_x64/vtd/extended_root_entry.h>
+#include <arch/intel_x64/vtd/fault_record.h>
+#include <arch/intel_x64/vtd/first_level_paging_entries.h>
+#include <arch/intel_x64/vtd/irte.h>
+#include <arch/intel_x64/vtd/pasid_entry.h>
+#include <arch/intel_x64/vtd/pasid_state_entry.h>
+#include <arch/intel_x64/vtd/pid.h>
+#include <arch/intel_x64/vtd/root_entry.h>
+#include <arch/intel_x64/vtd/second_level_paging_entries.h>
 #endif
 
 #ifdef BF_AARCH64


### PR DESCRIPTION
Added numerous intrinsics for manipulating Intel VT-d control structures

* root entries
* extended root entries
* context entries
* pasid entries
* pasid state entries
* first-level paging entries
* second-level paging entries
* fault records
* interrupt remapping table entries
* posted interrupt descriptors

Signed-off-by: JaredWright <jared.wright12@gmail.com>
