### PR TITLE
Patchs to simplify our extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,11 +20,17 @@ cmake_minimum_required(VERSION 3.6)
 project(hypervisor)
 
 # ------------------------------------------------------------------------------
-# Config / Targets
+# Config
 # ------------------------------------------------------------------------------
 
-include(scripts/cmake/config/default.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/scripts/cmake/config/default.cmake)
 include_external_config()
+
+# ------------------------------------------------------------------------------
+# Project File
+# ------------------------------------------------------------------------------
+
+add_project_include(${SOURCE_CMAKE_DIR}/macros.cmake)
 
 # ------------------------------------------------------------------------------
 # BFM VMM
@@ -43,19 +49,19 @@ include(scripts/cmake/targets.cmake)
 # General Dependencies
 # ------------------------------------------------------------------------------
 
-include_dependency(gsl)
-include_dependency(json)
-include_dependency(astyle)
-include_dependency(clang_tidy)
-include_dependency(catch)
-include_dependency(hippomocks)
-include_dependency(python)
+include_dependency(SOURCE_DEPENDS_DIR gsl)
+include_dependency(SOURCE_DEPENDS_DIR json)
+include_dependency(SOURCE_DEPENDS_DIR astyle)
+include_dependency(SOURCE_DEPENDS_DIR clang_tidy)
+include_dependency(SOURCE_DEPENDS_DIR catch)
+include_dependency(SOURCE_DEPENDS_DIR hippomocks)
+include_dependency(SOURCE_DEPENDS_DIR python)
 
 # ------------------------------------------------------------------------------
 # EFI Cleanup
 # ------------------------------------------------------------------------------
 
-if (ENABLE_BUILD_EFI)
+if(ENABLE_BUILD_EFI)
     file(MAKE_DIRECTORY ${EFI_OUTPUT_DIR})
     file(REMOVE ${EFI_MODULE_H})
     file(REMOVE ${EFI_SOURCES_CMAKE})
@@ -86,7 +92,7 @@ endif()
 # VMM Components
 # ------------------------------------------------------------------------------
 
-include_dependency(binutils)
+include_dependency(SOURCE_DEPENDS_DIR binutils)
 
 if(NOT WIN32)
     if(NOT ENABLE_BUILD_BINUTILS)
@@ -103,10 +109,10 @@ if(NOT WIN32)
     endif()
 endif()
 
-include_dependency(newlib)
-include_dependency(llvm)
-include_dependency(libcxxabi)
-include_dependency(libcxx)
+include_dependency(SOURCE_DEPENDS_DIR newlib)
+include_dependency(SOURCE_DEPENDS_DIR llvm)
+include_dependency(SOURCE_DEPENDS_DIR libcxxabi)
+include_dependency(SOURCE_DEPENDS_DIR libcxx)
 
 if(ENABLE_BUILD_VMM OR (ENABLE_BUILD_TEST AND NOT WIN32))
     add_subproject(
@@ -232,7 +238,7 @@ endif()
 # ------------------------------------------------------------------------------
 
 if (ENABLE_BUILD_EFI)
-    include_dependency(gnuefi)
+    include_dependency(SOURCE_DEPENDS_DIR gnuefi)
 
     add_subproject(
         efi_main vmm

--- a/scripts/cmake/config/default.cmake
+++ b/scripts/cmake/config/default.cmake
@@ -86,11 +86,6 @@ set(SOURCE_CONFIG_DIR ${CMAKE_SOURCE_DIR}/scripts/cmake/config
     "Cmake configurations directory"
 )
 
-set(SOURCE_CONFIG_DIR ${CMAKE_SOURCE_DIR}/scripts/cmake/config
-    CACHE INTERNAL
-    "Cmake configurations directory"
-)
-
 set(SOURCE_DEPENDS_DIR ${CMAKE_SOURCE_DIR}/scripts/cmake/depends
     CACHE INTERNAL
     "Cmake dependencies directory"

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -118,6 +118,16 @@ macro(add_config)
 endmacro(add_config)
 
 # ------------------------------------------------------------------------------
+# Macro File List
+# ------------------------------------------------------------------------------
+
+# Private
+#
+macro(add_project_include FILE)
+    set(PROJECT_INCLUDE_LIST "${PROJECT_INCLUDE_LIST}|${FILE}")
+endmacro(add_project_include)
+
+# ------------------------------------------------------------------------------
 # include_external_config
 # ------------------------------------------------------------------------------
 
@@ -273,8 +283,8 @@ endfunction(generate_flags)
 
 # Private
 #
-function(include_dependency NAME)
-    include(${SOURCE_DEPENDS_DIR}/${NAME}.cmake)
+function(include_dependency DIR NAME)
+    include(${${DIR}}/${NAME}.cmake)
 endfunction(include_dependency)
 
 # ------------------------------------------------------------------------------
@@ -876,6 +886,7 @@ function(add_subproject NAME PREFIX)
         -DCMAKE_TOOLCHAIN_FILE=${TOOLCHAIN}
         -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
         -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+        -DPROJECT_INCLUDE_LIST=${PROJECT_INCLUDE_LIST}
     )
 
     if(NOT WIN32 AND NOT CMAKE_GENERATOR STREQUAL "Ninja")
@@ -942,7 +953,8 @@ endfunction(add_efi_module)
 
 function(vmm_extension NAME)
     list(APPEND ARGN
-        DEPENDS bfvmm bfintrinsics
+        DEPENDS bfvmm
+        DEPENDS bfintrinsics
     )
 
     add_subproject(
@@ -953,7 +965,6 @@ function(vmm_extension NAME)
     if(ENABLE_BUILD_EFI)
         add_dependencies(efi_main_${VMM_PREFIX} ${NAME}_${VMM_PREFIX})
     endif()
-
 endfunction(vmm_extension)
 
 function(userspace_extension NAME)

--- a/scripts/cmake/project.cmake
+++ b/scripts/cmake/project.cmake
@@ -16,4 +16,7 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-include(${SOURCE_CMAKE_DIR}/macros.cmake)
+string(REPLACE "|" ";" PROJECT_INCLUDE_LIST "${PROJECT_INCLUDE_LIST}")
+foreach(file ${PROJECT_INCLUDE_LIST})
+    include(${file})
+endforeach(file)


### PR DESCRIPTION
This patch allows extensions to register additional APIs for child
extensions to build from, preventing the need for extensions of
extensions to know about its parent libraries and depends

[ISSUE]: https://github.com/Bareflank/hypervisor/issues/696

Signed-off-by: Rian Quinn <rianquinn@gmail.com>