### PR TITLE
Add EFI boot interface

### DIFF
--- a/bfdriver/src/platform/efi/efi_base/platform.c
+++ b/bfdriver/src/platform/efi/efi_base/platform.c
@@ -25,9 +25,7 @@
 #include <bfsupport.h>
 #include "efi.h"
 #include "efilib.h"
-#include "boot.h"
 #include "mp_service.h"
-
 
 void *platform_alloc(uint64_t len, EFI_MEMORY_TYPE type)
 {
@@ -164,16 +162,19 @@ int64_t
 platform_populate_info(struct platform_info_t *info)
 {
     if (info) {
-        platform_memcpy(info, &boot_platform_info, sizeof(struct platform_info_t));
+        platform_memset(info, 0, sizeof(struct platform_info_t));
     }
 
+    info->efi.enabled = 1;
     return BF_SUCCESS;
 }
 
 void
 platform_unload_info(struct platform_info_t *info)
 {
-    (void) info;
+    if (info) {
+        platform_memset(info, 0, sizeof(struct platform_info_t));
+    }
 }
 
 int printf(const char *format, ...)

--- a/bfdriver/src/platform/efi/efi_main/boot.c
+++ b/bfdriver/src/platform/efi/efi_main/boot.c
@@ -21,7 +21,6 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-
 #include "boot.h"
 
 static boot_fn_t _prestart_fns[NR_START_FNS] = {0};

--- a/bfdriver/src/platform/efi/efi_main/boot.h
+++ b/bfdriver/src/platform/efi/efi_main/boot.h
@@ -1,0 +1,94 @@
+/*
+ * Bareflank Hypervisor
+ * Copyright (C) 2018 Assured Information Security, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ */
+
+#ifndef BF_BOOT_H
+#define BF_BOOT_H
+
+#include <bftypes.h>
+#include <bferrorcodes.h>
+#include <bfelf_loader.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int64_t boot_ret_t;
+typedef boot_ret_t (*boot_fn_t)();
+
+#define BOOT_FAIL             ( 0L )
+#define BOOT_SUCCESS          ( 1L )
+
+#define BOOT_CONTINUE         ( 1L << 1)
+#define BOOT_INTERRUPT_STAGE  ( 2L << 1)
+#define BOOT_ABORT            ( 3L << 1)
+#define BOOT_NOT_FOUND        ( 4L << 1)
+
+#ifndef NR_START_FNS
+#define NR_START_FNS ( 8U )
+#endif
+
+/**
+ * boot_add_prestart_fn()
+ *
+ * Register a prestart function. A prestart function is run
+ * in UEFI context, before VMX is enabled.
+ *
+ * @param fn the prestart function to add
+ * @return boot_ret_t BOOT_SUCCESS on success
+ */
+boot_ret_t boot_add_prestart_fn(boot_fn_t fn);
+
+/**
+ * boot_add_start_fn()
+ *
+ * Register a start function. On success, the start function
+ * will execute during boot_start and return with VMX enabled.
+ *
+ * @param fn the start function to execute during boot_start
+ * @return boot_ret_t BOOT_SUCCESS on success
+ */
+boot_ret_t boot_set_start_fn(boot_fn_t fn);
+
+/**
+ * boot_add_poststart_fn()
+ *
+ * Register a poststart function. The poststart function runs
+ * after the start_fn returns, and will execute in VMX-nonroot mode.
+ *
+ * @param fn the poststart function to add
+ * @return boot_ret_t BOOT_SUCCESS on success
+ */
+boot_ret_t boot_add_poststart_fn(boot_fn_t fn);
+
+/**
+ * boot_start()
+ *
+ * Register a poststart function. The poststart function runs
+ * after the start_fn returns, and will execute in VMX-nonroot mode.
+ *
+ * @param fn the poststart function to add
+ * @return boot_ret_t BOOT_CONTINUE on success
+ */
+boot_ret_t boot_start();
+
+#endif

--- a/bfdriver/src/platform/linux/platform.c
+++ b/bfdriver/src/platform/linux/platform.c
@@ -229,16 +229,12 @@ platform_populate_info(struct platform_info_t *info)
         platform_memset(info, 0, sizeof(struct platform_info_t));
     }
 
-    info->xapic_virt = fix_to_virt(FIX_APIC_BASE);
     return BF_SUCCESS;
 }
 
 void
 platform_unload_info(struct platform_info_t *info)
 {
-    if (info->xapic_virt) {
-        info->xapic_virt = 0;
-    }
 }
 
 

--- a/bfdriver/tests/test_support.cpp
+++ b/bfdriver/tests/test_support.cpp
@@ -19,8 +19,9 @@
 // TIDY_EXCLUSION=-cert-err58-cpp
 //
 // Reason:
-//     This triggers on g_filenames_xxx which is only used for testing. This
-//     is not a false positive, but it can be safely ignored.
+//     The operator+ may throw an exception, and since these vectors
+//     have static storage, tidy raises this error. This is unlikely to happen,
+//     and if it does, it will only happen in the bfdriver unittests
 //
 
 #include <vector>

--- a/bfintrinsics/include/arch/intel_x64/apic/ioapic.h
+++ b/bfintrinsics/include/arch/intel_x64/apic/ioapic.h
@@ -206,7 +206,7 @@ namespace ioapic
                     return;
                 }
 
-                ::intel_x64::lapic::dump_delivery_mode(lev, get(val), msg);
+                ::intel_x64::lapic::dump_lvt_delivery_mode(lev, get(val), msg);
             }
         }
 

--- a/bfintrinsics/include/arch/intel_x64/apic/x2apic.h
+++ b/bfintrinsics/include/arch/intel_x64/apic/x2apic.h
@@ -1985,10 +1985,10 @@ namespace ia32_x2apic_cur_count
     { bfdebug_nhex(level, name, get(), msg); }
 }
 
-namespace ia32_x2apic_div_conf
+namespace ia32_x2apic_dcr
 {
     constexpr const auto addr = 0x0000083EU;
-    constexpr const auto name = "ia32_x2apic_div_conf";
+    constexpr const auto name = "ia32_x2apic_dcr";
 
     inline auto get() noexcept
     { return _read_msr(addr); }

--- a/bfintrinsics/include/arch/intel_x64/bit.h
+++ b/bfintrinsics/include/arch/intel_x64/bit.h
@@ -19,6 +19,8 @@
 #ifndef BIT_INTEL_X64_H
 #define BIT_INTEL_X64_H
 
+#include <cstdint>
+
 // -----------------------------------------------------------------------------
 // Exports
 // -----------------------------------------------------------------------------
@@ -40,6 +42,7 @@
 // -----------------------------------------------------------------------------
 
 extern "C" uint64_t _bsf(uint64_t value) noexcept;
+extern "C" uint64_t _bsr(uint64_t value) noexcept;
 extern "C" uint64_t _popcnt(uint64_t value) noexcept;
 
 // *INDENT-OFF*
@@ -50,6 +53,9 @@ namespace bit
 {
     inline uint64_t bsf(uint64_t value) noexcept
     { return _bsf(value); }
+
+    inline uint64_t bsr(uint64_t value) noexcept
+    { return _bsr(value); }
 
     inline uint64_t popcnt(uint64_t value) noexcept
     { return _popcnt(value); }

--- a/bfintrinsics/include/arch/intel_x64/pause.h
+++ b/bfintrinsics/include/arch/intel_x64/pause.h
@@ -16,8 +16,8 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-#ifndef BARRIER_INTEL_X64_H
-#define BARRIER_INTEL_X64_H
+#ifndef PAUSE_INTEL_X64_H
+#define PAUSE_INTEL_X64_H
 
 // -----------------------------------------------------------------------------
 // Exports
@@ -39,18 +39,16 @@
 // Definitions
 // -----------------------------------------------------------------------------
 
-extern "C" void _sfence(void) noexcept;
+extern "C" void _pause(void) noexcept;
 
 // *INDENT-OFF*
 
 namespace intel_x64
 {
-namespace barrier
-{
-    inline void sfence() noexcept
-    { _sfence(); }
+    inline auto pause() noexcept
+    { _pause(); }
 }
-}
+
 // *INDENT-ON*
 
 #endif

--- a/bfintrinsics/src/CMakeLists.txt
+++ b/bfintrinsics/src/CMakeLists.txt
@@ -35,12 +35,11 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/x64/rflags.asm
         arch/x64/srs.asm
         arch/x64/tlb.asm
-        arch/intel_x64/barrier.asm
         arch/intel_x64/bit.asm
         arch/intel_x64/crs.asm
         arch/intel_x64/drs.asm
+        arch/intel_x64/pause.asm
         arch/intel_x64/vmx.asm
-        arch/intel_x64/apic/lapic.cpp
     )
 elseif(${BUILD_TARGET_ARCH} STREQUAL "aarch64")
     message(WARNING "Unimplemented")

--- a/bfintrinsics/src/arch/intel_x64/bit.asm
+++ b/bfintrinsics/src/arch/intel_x64/bit.asm
@@ -30,3 +30,8 @@ global _bsf:function
 _bsf:
     bsf rax, rdi
     ret
+
+global _bsr:function
+_bsr:
+    bsr rax, rdi
+    ret

--- a/bfintrinsics/src/arch/intel_x64/pause.asm
+++ b/bfintrinsics/src/arch/intel_x64/pause.asm
@@ -21,7 +21,7 @@ default rel
 
 section .text
 
-global _sfence:function
-_sfence:
-    sfence
+global _pause:function
+_pause:
+    pause
     ret

--- a/bfsdk/include/bfsupport.h
+++ b/bfsdk/include/bfsupport.h
@@ -132,8 +132,6 @@ struct efi_data_t {
  *      Struct signature
  * @var platform_info_t::version
  *      Struct version
- * @var platform_info_t::xapic_virt
- *      Driver's virtual address of the xAPIC
  * @var platform_info_t::efi
  *      Data specifying EFI booting behavior
  * @var platform_info_t::extension_data
@@ -144,7 +142,6 @@ struct efi_data_t {
 struct platform_info_t {
     uint8_t signature[4];
     uint8_t version[4];
-    uintptr_t xapic_virt;
     struct efi_data_t efi;
     void *extension_data;
     int _dummy;

--- a/bfvmm/src/hve/CMakeLists.txt
+++ b/bfvmm/src/hve/CMakeLists.txt
@@ -24,6 +24,7 @@ if(${BUILD_TARGET_ARCH} STREQUAL "x86_64")
         arch/intel_x64/exit_handler/exit_handler.cpp
         arch/intel_x64/vmcs/vmcs.cpp
         arch/intel_x64/vmx/vmx.cpp
+        arch/intel_x64/apic/lapic.cpp
     )
 
     if(NOT WIN32 AND NOT ENABLE_MOCKING)

--- a/bfvmm/src/hve/arch/intel_x64/apic/lapic.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/apic/lapic.cpp
@@ -1,0 +1,90 @@
+//
+// Bareflank Hypervisor
+// Copyright (C) 2018 Assured Information Security, Inc.
+//
+// This library is free software; you can redistribute it and/or
+// modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+//
+// This library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public
+// License along with this library; if not, write to the Free Software
+// Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+#include <arch/intel_x64/apic/lapic.h>
+
+namespace intel_x64
+{
+namespace lapic
+{
+
+std::unordered_map<uint32_t, attr_t> attributes;
+
+namespace offset
+{
+
+/// Lapic register offsets
+std::array<uint32_t, 47> list = {
+    {
+        id,
+        version,
+        tpr,
+        apr,
+        ppr,
+        eoi,
+        ldr,
+        dfr,
+        svr,
+
+        isr0,
+        isr1,
+        isr2,
+        isr3,
+        isr4,
+        isr5,
+        isr6,
+        isr7,
+
+        tmr0,
+        tmr1,
+        tmr2,
+        tmr3,
+        tmr4,
+        tmr5,
+        tmr6,
+        tmr7,
+
+        irr0,
+        irr1,
+        irr2,
+        irr3,
+        irr4,
+        irr5,
+        irr6,
+        irr7,
+
+        esr,
+        lvt_cmci,
+        icr0,
+        icr1,
+        lvt_timer,
+        lvt_thermal,
+        lvt_pmi,
+        lvt_lint0,
+        lvt_lint1,
+        lvt_error,
+        init_count,
+        cur_count,
+        dcr,
+        self_ipi
+    }
+};
+
+}
+}
+}

--- a/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/exit_handler/exit_handler.cpp
@@ -331,8 +331,9 @@ exit_handler::exit_handler(
     m_host_gdt.set(4, nullptr, 0xFFFFFFFF, ::x64::access_rights::ring0_gs_descriptor);
     m_host_gdt.set(5, &m_host_tss, sizeof(m_host_tss), ::x64::access_rights::ring0_tr_descriptor);
 
-    if (vcpuid::is_bootstrap_vcpu(id)) {
+    static bool need_init = true;
 
+    if (need_init) {
         s_ia32_efer_msr |= ::intel_x64::msrs::ia32_efer::lme::mask;
         s_ia32_efer_msr |= ::intel_x64::msrs::ia32_efer::lma::mask;
         s_ia32_efer_msr |= ::intel_x64::msrs::ia32_efer::nxe::mask;
@@ -371,6 +372,8 @@ exit_handler::exit_handler(
         if (::intel_x64::cpuid::extended_feature_flags::subleaf0::ebx::smap::is_enabled()) {
             s_cr4 |= ::intel_x64::cr4::smap_enable_bit::mask;
         }
+
+        need_init = false;
     }
 
     this->write_host_state();

--- a/bfvmm/tests/hve/CMakeLists.txt
+++ b/bfvmm/tests/hve/CMakeLists.txt
@@ -49,6 +49,11 @@ do_test(test_check_vmcs_host_fields
     ${ARGN}
 )
 
+do_test(test_lapic
+    SOURCES arch/intel_x64/apic/test_lapic.cpp
+    ${ARGN}
+)
+
 do_test(test_check
     SOURCES arch/intel_x64/check/test_check.cpp
     ${ARGN}

--- a/bfvmm/tests/hve/arch/intel_x64/apic/test_lapic.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/apic/test_lapic.cpp
@@ -16,15 +16,17 @@
 // License along with this library; if not, write to the Free Software
 // Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+#include <catch/catch.hpp>
+#include <hippomocks.h>
 #include <arch/intel_x64/apic/lapic.h>
 
-namespace intel_x64
-{
-namespace lapic
-{
+#include <test/support.h>
 
-/// Lapic register attributes
-std::array<attr_t, count> attributes;
+#ifdef _HIPPOMOCKS__ENABLE_CFUNC_MOCKING_SUPPORT
 
+TEST_CASE("offsets")
+{
+    CHECK(::intel_x64::lapic::offset::list.size() == 47U);
 }
-}
+
+#endif

--- a/scripts/util/bareflank_astyle_format.sh
+++ b/scripts/util/bareflank_astyle_format.sh
@@ -23,9 +23,9 @@ get_changed_files() {
     if [[ "$1" == "all" ]]; then
         files=$(git ls-files | grep -Ee "\.(cpp|h|c)$" || true)
     elif [[ "$1" == "upstream" ]]; then
-        files=$(git diff --relative --name-only upstream/master $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+        files=$(git diff --relative --name-only --diff-filter=d upstream/master $PWD | grep -Ee "\.(cpp|h|c)$" || true)
     else
-        files=$(git diff --relative --name-only origin $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+        files=$(git diff --relative --name-only --diff-filter=d origin $PWD | grep -Ee "\.(cpp|h|c)$" || true)
     fi
 }
 

--- a/scripts/util/bareflank_clang_tidy.sh
+++ b/scripts/util/bareflank_clang_tidy.sh
@@ -25,9 +25,9 @@ get_changed_files() {
     if [[ "$1" == "all" ]]; then
         files=$(git ls-files | grep -Ee "\.(cpp|h|c)$" || true)
     elif [[ "$1" == "upstream" ]]; then
-        files=$(git diff --relative --name-only upstream/master $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+        files=$(git diff --relative --name-only --diff-filter=d upstream/master $PWD | grep -Ee "\.(cpp|h|c)$" || true)
     else
-        files=$(git diff --relative --name-only origin $PWD | grep -Ee "\.(cpp|h|c)$" || true)
+        files=$(git diff --relative --name-only --diff-filter=d origin $PWD | grep -Ee "\.(cpp|h|c)$" || true)
     fi
     popd > /dev/null
 }
@@ -84,12 +84,6 @@ if [[ "$#" -lt 2 ]]; then
     exit 1
 fi
 
-if [[ ! -f "compile_commands.json" ]]; then
-    echo "ERROR: database is missing. Did you run?"
-    echo "    - cmake -DENABLE_TIDY=ON .."
-    exit 1
-fi
-
 if [[ ! -x "$(which run-clang-tidy-6.0.py)" ]]; then
     echo "ERROR: run-clang-tidy-6.0.py not in PATH"
     exit 1
@@ -106,6 +100,13 @@ if [[ -z "$files" ]]; then
     echo -e "\033[1;32m\xE2\x9C\x93 nothing changed:\033[0m $2";
     exit 0
 else
+    if [[ ! -f "compile_commands.json" ]]; then
+        echo "ERROR: database is missing. Did you run?"
+        echo "    - cmake -DENABLE_TIDY=ON .."
+        echo "    - files: $files"
+        exit 1
+    fi
+
     echo -e "\033[1;33m- processing:";
     echo -e "  \033[1;35msrc - \033[0m$2";
     echo -e "  \033[1;35mbld - \033[0m$PWD";


### PR DESCRIPTION
- Use StartupThisAP to start Bareflank from EFI
- Add EFI module interface for extensions
- Remove all code supporting xAPIC
- Add lapic offset namespace
- Add pause and bsr intrinsics
- Rather than checking is_bootstrap_vcpu in the exit_handler, use a
  static init bool. This allows EFI to bring up the APs (vcpuid > 0)
  before the BSP.
- In the tidy script, check for compile_commands.json only if there
  are .cpp, .c, or .h files to check. This allows all .asm src
  directories (like bfintrinsics) to be ignored by tidy.