### PR TITLE
Fix Windows Driver Issue

### DIFF
--- a/scripts/util/driver_build.sh
+++ b/scripts/util/driver_build.sh
@@ -43,17 +43,17 @@ case $(uname -s) in
 CYGWIN_NT-6.1*)
     find_msbuild
     cd $1/src/platform/windows/
-    >&2 eval "'$msbuild' /m:3 /p:Configuration=Debug /p:Platform=x64 /p:TargetVersion=Windows7 bareflank.sln"
+    >&2 eval "'$msbuild' /m:3 /p:Configuration=Release /p:Platform=x64 /p:TargetVersion=Windows7 bareflank.sln"
     ;;
 CYGWIN_NT-6.3*)
     find_msbuild
     cd $1/src/platform/windows/
-    >&2 eval "'$msbuild' /m:3 /p:Configuration=Debug /p:Platform=x64 /p:TargetVersion=WindowsV6.3 bareflank.sln"
+    >&2 eval "'$msbuild' /m:3 /p:Configuration=Release /p:Platform=x64 /p:TargetVersion=WindowsV6.3 bareflank.sln"
     ;;
 CYGWIN_NT-10.0*)
     find_msbuild
     cd $1/src/platform/windows/
-    >&2 eval "'$msbuild' /m:3 /p:Configuration=Debug /p:Platform=x64 /p:TargetVersion=Windows10 bareflank.sln"
+    >&2 eval "'$msbuild' /m:3 /p:Configuration=Release /p:Platform=x64 /p:TargetVersion=Windows10 bareflank.sln"
     ;;
 Linux)
     cd $1/src/platform/linux

--- a/scripts/util/driver_load.sh
+++ b/scripts/util/driver_load.sh
@@ -22,13 +22,33 @@
 
 # $1 == CMAKE_SOURCE_DIR
 
+certmgr_10_0_00000_0="/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/x64/certmgr"
+certmgr_10_0_17134_0="/cygdrive/c/Program Files (x86)/Windows Kits/10/bin/10.0.17134.0/x64/certmgr"
+
+find_certmgr() {
+
+    if [[ -f $certmgr_10_0_17134_0 ]]; then
+        certmgr=$certmgr_10_0_17134_0
+        return
+    fi
+
+    if [[ -f $certmgr_10_0_00000_0 ]]; then
+        certmgr=$certmgr_10_0_00000_0
+        return
+    fi
+
+    >&2 echo "ERROR: failed to find certmgr"
+    exit 1
+}
+
 case $(uname -s) in
 CYGWIN_NT*)
+    find_certmgr
     cd $1/src/platform/windows
-    >&2 /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/x64/certmgr /add x64/Debug/bareflank.cer /s /r localMachine root
-    >&2 /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/x64/certmgr /add x64/Debug/bareflank.cer /s /r localMachine trustedpublisher
+    >&2 eval "'$certmgr' /add x64/Release/bareflank.cer /s /r localMachine root"
+    >&2 eval "'$certmgr' /add x64/Release/bareflank.cer /s /r localMachine trustedpublisher"
     >&2 /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/Tools/x64/devcon remove "ROOT\bareflank"
-    >&2 /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/Tools/x64/devcon install x64/Debug/bareflank/bareflank.inf "ROOT\bareflank"
+    >&2 /cygdrive/c/Program\ Files\ \(x86\)/Windows\ Kits/10/Tools/x64/devcon install x64/Release/bareflank/bareflank.inf "ROOT\bareflank"
     ;;
 Linux)
     cd $1/src/platform/linux


### PR DESCRIPTION
The new VS and WDK have different paths and features turned on
that break our current build system. The following addresses these
issues