### PR TITLE
Updated CPUID API

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/delegator/cpuid.h
+++ b/bfvmm/include/hve/arch/intel_x64/delegator/cpuid.h
@@ -61,31 +61,17 @@ using leaf_t = uint64_t;
 ///
 struct info_t {
 
-    /// RAX (in/out)
+    /// Leaf (in)
     ///
-    uint64_t rax;
+    /// The CPUID leaf (eax) that caused a vmexit
+    ///
+    leaf_t leaf;
 
-    /// RBX (in/out)
+    /// Subleaf (in)
     ///
-    uint64_t rbx;
-
-    /// RCX (in/out)
+    /// The CPUID subleaf (ecx) that caused a vmexit
     ///
-    uint64_t rcx;
-
-    /// RDX (in/out)
-    ///
-    uint64_t rdx;
-
-    /// Ignore write (out)
-    ///
-    /// If true, do not update the guest's register state with the four
-    /// register values above. Set this to true if you do not want the guest
-    /// rax, rbx, rcx, or rdx to be written to after your handler completes.
-    ///
-    /// default: false
-    ///
-    bool ignore_write;
+    leaf_t subleaf;
 
     /// Ignore advance (out)
     ///
@@ -152,7 +138,6 @@ private:
 
     std::unordered_map<cpuid::leaf_t, std::list<cpuid::delegate_t>> m_handlers;
     cpuid::delegate_t m_default_handler;
-    // std::unordered_map<leaf_t, bool> m_emulate;
 
 public:
 

--- a/bfvmm/include/sdk/arch/intel_x64/cpuid.h
+++ b/bfvmm/include/sdk/arch/intel_x64/cpuid.h
@@ -25,14 +25,31 @@
 namespace bfvmm::intel_x64::cpuid
 {
 
-/// Emulate the given cpuid leaf using the given cpuid handler on
+/// Handle the given cpuid leaf using the given cpuid handler on
 /// the given vcpu
 ///
-/// @param vcpu the vcpu to apply emulation to
+/// @param vcpu the vcpu to register @param handler to
 /// @param leaf the cpuid leaf to emulate
 /// @param handler the handler to be called for the emulation of @param leaf
 ///
-void emulate(vcpu_t vcpu, leaf_t leaf, delegate_t handler);
+void handle(vcpu_t vcpu, leaf_t leaf, delegate_t handler);
+
+/// Emulate a cpuid leaf for the the given vcpu. The upper 32-bits of each
+/// emulated value are masked.
+///
+/// @param vcpu the vcpu to apply emulation to
+/// @param rax the emulated value to be returned in rax
+/// @param rbx the emulated value to be returned in rbx
+/// @param rcx the emulated value to be returned in rcx
+/// @param rdx the emulated value to be returned in rdx
+///
+void emulate(vcpu_t vcpu, uint64_t rax, uint64_t rbx, uint64_t rcx, uint64_t rdx);
+
+/// Pass through a cpuid instruction for the given vcpu, using the current state
+/// of the vcpu's rax, rbx, rcx, and rdx registers
+///
+/// @param vcpu the vcpu to pass cpuid access through for
+void pass_through(vcpu_t vcpu);
 
 }
 

--- a/bfvmm/src/hve/arch/intel_x64/delegator/cpuid.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/delegator/cpuid.cpp
@@ -122,20 +122,16 @@ delegator::add_handler(cpuid::leaf_t leaf, const cpuid::delegate_t &d)
 bool
 delegator::handle(vcpu_t vcpu)
 {
-    const auto &hdlrs = m_handlers.find(vcpu->rax());
-    struct info_t info = { 0, 0, 0, 0, false, false };
+    auto leaf = vcpu->rax();
+    auto subleaf = vcpu->rcx();
+
+    const auto &hdlrs = m_handlers.find(leaf);
+    struct info_t info = { leaf, subleaf, false };
 
     if (hdlrs != m_handlers.end()) {
 
         for (const auto &d : hdlrs->second) {
             if (d(vcpu, info)) {
-
-                if (!info.ignore_write) {
-                    vcpu->set_rax(set_bits(vcpu->rax(), 0x00000000FFFFFFFFULL, info.rax));
-                    vcpu->set_rbx(set_bits(vcpu->rbx(), 0x00000000FFFFFFFFULL, info.rbx));
-                    vcpu->set_rcx(set_bits(vcpu->rcx(), 0x00000000FFFFFFFFULL, info.rcx));
-                    vcpu->set_rdx(set_bits(vcpu->rdx(), 0x00000000FFFFFFFFULL, info.rdx));
-                }
 
                 if (!info.ignore_advance) {
                     return vcpu->advance();

--- a/bfvmm/src/sdk/arch/intel_x64/cpuid.cpp
+++ b/bfvmm/src/sdk/arch/intel_x64/cpuid.cpp
@@ -26,9 +26,32 @@
 namespace bfvmm::intel_x64::cpuid
 {
 
-void emulate(vcpu_t vcpu, leaf_t leaf, delegate_t handler)
+void handle(vcpu_t vcpu, leaf_t leaf, delegate_t handler)
 {
     vcpu->exit_handler()->cpuid_delegator()->add_handler(leaf, handler);
+}
+
+void emulate(vcpu_t vcpu, uint64_t rax, uint64_t rbx, uint64_t rcx, uint64_t rdx)
+{
+    vcpu->set_rax(set_bits(vcpu->rax(), 0x00000000FFFFFFFFULL, rax));
+    vcpu->set_rbx(set_bits(vcpu->rbx(), 0x00000000FFFFFFFFULL, rbx));
+    vcpu->set_rcx(set_bits(vcpu->rcx(), 0x00000000FFFFFFFFULL, rcx));
+    vcpu->set_rdx(set_bits(vcpu->rdx(), 0x00000000FFFFFFFFULL, rdx));
+}
+
+void pass_through(vcpu_t vcpu)
+{
+    auto ret = ::x64::cpuid::get(
+                   gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rax()),
+                   gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rbx()),
+                   gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rcx()),
+                   gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rdx())
+               );
+
+    vcpu->set_rax(ret.rax);
+    vcpu->set_rbx(ret.rbx);
+    vcpu->set_rcx(ret.rcx);
+    vcpu->set_rdx(ret.rdx);
 }
 
 }


### PR DESCRIPTION
1) Split cpuid sdk functions into handle, emulate, and pass-through
2) Removed "out" parameters from cpuid_info structure
3) Fixed bug with built-in cpuid handlers not returning any values

Signed-off-by: JaredWright <jared.wright12@gmail.com>