### PR TITLE
Fix detection of the EPT switching capability

### DIFF
--- a/bfintrinsics/include/arch/intel_x64/msrs.h
+++ b/bfintrinsics/include/arch/intel_x64/msrs.h
@@ -13826,7 +13826,7 @@ namespace ia32_vmx_vmfunc
         { return is_bit_set(msr, from); }
 
         inline auto is_allowed1() noexcept
-        { return (_read_msr(addr) & (mask << 32)) != 0; }
+        { return (_read_msr(addr) & (mask)) != 0; }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }


### PR DESCRIPTION
Barefank was handling the 0x491 MSR (aka Capability Reporting Register of VM-function Controls) incorrectly. The 0x491 is a simple MSR that doesn't have separate parts for 0- and 1-settings, so we don't have to shift the mask by 32 to check if a specific VM-function, e.g., EPT switching, is supported. See section A.11 of the Intel SDM.