### PR TITLE
Control Register Bug Fixes

### DIFF
--- a/bfintrinsics/include/arch/intel_x64/crs.h
+++ b/bfintrinsics/include/arch/intel_x64/crs.h
@@ -100,13 +100,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -135,13 +135,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -169,13 +169,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -203,13 +203,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -237,13 +237,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -271,13 +271,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -305,13 +305,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -339,13 +339,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -373,13 +373,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -407,13 +407,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -441,13 +441,13 @@ namespace cr0
         { _write_cr0(set_bit(_read_cr0(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr0(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr0(clear_bit(_read_cr0(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr0(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -536,13 +536,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -570,13 +570,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -604,13 +604,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -638,13 +638,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -672,13 +672,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -706,13 +706,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -740,13 +740,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -774,13 +774,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -808,13 +808,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -842,13 +842,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -876,13 +876,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -910,13 +910,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -944,13 +944,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -978,13 +978,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -1012,13 +1012,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -1046,13 +1046,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -1080,13 +1080,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -1114,13 +1114,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }
@@ -1148,13 +1148,13 @@ namespace cr4
         { _write_cr4(set_bit(_read_cr4(), from)); }
 
         inline void enable(value_type &cr)
-        { _write_cr4(set_bit(cr, from)); }
+        { cr = set_bit(cr, from); }
 
         inline void disable()
         { _write_cr4(clear_bit(_read_cr4(), from)); }
 
         inline void disable(value_type &cr)
-        { _write_cr4(clear_bit(cr, from)); }
+        { cr = clear_bit(cr, from); }
 
         inline void dump(int level, std::string *msg = nullptr)
         { bfdebug_subbool(level, name, is_enabled(), msg); }

--- a/bfvmm/include/hve/arch/intel_x64/vcpu_global_state.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu_global_state.h
@@ -33,7 +33,8 @@ namespace bfvmm::intel_x64
 struct vcpu_global_state_t {
 
     uint64_t ia32_vmx_cr0_fixed0 {
-        ::intel_x64::msrs::ia32_vmx_cr0_fixed0::get()
+        ::intel_x64::msrs::ia32_vmx_cr0_fixed0::get() |
+        ::intel_x64::cr0::extension_type::mask
     };
 
     uint64_t ia32_vmx_cr4_fixed0 {

--- a/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
@@ -317,9 +317,9 @@ vcpu::write_guest_state()
     guest_ldtr_base::set(ldtr_index != 0 ? guest_gdt.base(ldtr_index) : 0);
     guest_tr_base::set(tr_index != 0 ? guest_gdt.base(tr_index) : 0);
 
-    guest_cr0::set(cr0::get() | ::intel_x64::msrs::ia32_vmx_cr0_fixed0::get());
+    this->set_cr0(cr0::get());
     guest_cr3::set(cr3::get());
-    guest_cr4::set(cr4::get() | ::intel_x64::msrs::ia32_vmx_cr4_fixed0::get());
+    this->set_cr4(cr4::get());
     guest_dr7::set(dr7::get());
 
     guest_rflags::set(::x64::rflags::get());
@@ -1344,6 +1344,11 @@ void
 vcpu::set_cr0(uint64_t val) noexcept
 {
     vmcs_n::cr0_read_shadow::set(val);
+
+    ::intel_x64::cr0::extension_type::enable(val);
+    ::intel_x64::cr0::not_write_through::disable(val);
+    ::intel_x64::cr0::cache_disable::disable(val);
+
     vmcs_n::guest_cr0::set(val | m_global_state->ia32_vmx_cr0_fixed0);
 }
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/control_register.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/control_register.cpp
@@ -307,9 +307,12 @@ void
 control_register_handler::enable_wrcr0_exiting(
     vmcs_n::value_type mask)
 {
-    vmcs_n::cr0_guest_host_mask::set(
-        mask | m_vcpu->global_state()->ia32_vmx_cr0_fixed0
-    );
+    mask |= ::intel_x64::cr0::extension_type::mask;
+    mask |= ::intel_x64::cr0::not_write_through::mask;
+    mask |= ::intel_x64::cr0::cache_disable::mask;
+
+    mask |= m_vcpu->global_state()->ia32_vmx_cr0_fixed0;
+    vmcs_n::cr0_guest_host_mask::set(mask);
 }
 
 void
@@ -330,9 +333,8 @@ void
 control_register_handler::enable_wrcr4_exiting(
     vmcs_n::value_type mask)
 {
-    vmcs_n::cr4_guest_host_mask::set(
-        mask | m_vcpu->global_state()->ia32_vmx_cr4_fixed0
-    );
+    mask |= m_vcpu->global_state()->ia32_vmx_cr4_fixed0;
+    vmcs_n::cr4_guest_host_mask::set(mask);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
This patch fixes multiple issues with the control register
logic:
- the intrincis has a bug which wrote to each control register
  when a value was provided when it should just return the
  resulting value
- the CR0 CD, NW and ET bits were not being trapped and
  cleaned up if a vCPU attempted to turn these to unsupported
  setting. Since the VMCS doesn't track these bits, the base
  must track changes to these and handle as needed