### PR TITLE
Use VMM toolchain config to build newlib

### DIFF
--- a/scripts/cmake/depends/newlib.cmake
+++ b/scripts/cmake/depends/newlib.cmake
@@ -19,6 +19,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+include(${VMM_TOOLCHAIN_PATH})
+
 if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
     message(STATUS "Including dependency: newlib")
 
@@ -28,8 +30,8 @@ if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
         URL_MD5     ${NEWLIB_URL_MD5}
     )
 
-    set(CC_FOR_TARGET clang)
-    set(CXX_FOR_TARGET clang)
+    set(CC_FOR_TARGET ${CLANG_BIN})
+    set(CXX_FOR_TARGET ${CLANG_BIN})
 
     set(AR_FOR_TARGET ar)
     set(AS_FOR_TARGET as)
@@ -39,12 +41,7 @@ if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
     set(RANLIB_FOR_TARGET ranlib)
     set(READELF_FOR_TARGET readelf)
     set(STRIP_FOR_TARGET strip)
-
-    if(DEFINED ENV{LD_BIN})
-        set(LD_FOR_TARGET $ENV{LD_BIN})
-    else()
-        set(LD_FOR_TARGET ${VMM_PREFIX_PATH}/bin/ld)
-    endif()
+    set(LD_FOR_TARGET ${LD_BIN})
 
     generate_flags(
         vmm

--- a/scripts/cmake/toolchain/clang_x86_64_vmm.cmake
+++ b/scripts/cmake/toolchain/clang_x86_64_vmm.cmake
@@ -45,7 +45,7 @@ endif()
 if(DEFINED ENV{LD_BIN})
     set(LD_BIN $ENV{LD_BIN})
 else()
-    set(LD_BIN ${CMAKE_INSTALL_PREFIX}/bin/ld)
+    set(LD_BIN ${VMM_PREFIX_PATH}/bin/ld)
 endif()
 
 string(CONCAT LD_FLAGS


### PR DESCRIPTION
Here's an attempt at issue 753. I think the VMM compiler and linker should be used to compile and link newlib since it is strictly a VMM dependency. In this pull request the compiler and linker for the VMM are pulled from the VMM_TOOLCHAIN_PATH. Once I tried this, newlib failed to compile since `${CMAKE_INSTALL_PREFIX}/bin/ld` did not point to a valid linker, so I changed the default VMM toolchain file to use `${VMM_PREFIX_PATH}/bin/ld` instead. This is the path that currently gets used by default in master. Newlib should now build with a developer-specified compiler and linker.