### PR TITLE
Boxy Suspend Support Changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ bfdriver/src/platform/linux/.bareflank.mod.o.cmd
 bfdriver/src/platform/linux/.bareflank.o.cmd
 bfdriver/src/platform/linux/.cache.mk
 bfdriver/src/platform/linux/.entry.o.cmd
+bfdriver/src/platform/linux/.intrinsics.o.cmd
 bfdriver/src/platform/linux/.platform.o.cmd
 bfdriver/src/platform/linux/.tmp_versions/
 bfdriver/src/platform/linux/.vmcall.o.cmd
@@ -48,6 +49,7 @@ bfdriver/src/platform/linux/bareflank.mod.o
 bfdriver/src/platform/linux/bareflank.o
 bfdriver/src/platform/linux/entry.o
 bfdriver/src/platform/linux/modules.order
+bfdriver/src/platform/linux/intrinsics.o
 bfdriver/src/platform/linux/platform.o
 bfdriver/src/platform/linux/vmcall.o
 bfdriver/src/platform/linux/.cache.mk

--- a/bfdriver/src/platform/linux/Makefile
+++ b/bfdriver/src/platform/linux/Makefile
@@ -26,6 +26,7 @@ ifneq ($(KERNELRELEASE),)
 
 	$(TARGET_MODULE)-objs += entry.o
 	$(TARGET_MODULE)-objs += platform.o
+	$(TARGET_MODULE)-objs += intrinsics.o
 	$(TARGET_MODULE)-objs += ../../common.o
 
 	EXTRA_CFLAGS += -DKERNEL

--- a/bfdriver/src/platform/linux/intrinsics.S
+++ b/bfdriver/src/platform/linux/intrinsics.S
@@ -20,30 +20,24 @@
  * SOFTWARE.
  */
 
-#define INITGUID
+        .code64
+        .intel_syntax noprefix
 
-#include <ntddk.h>
-#include <wdf.h>
+        .globl  _vmcall
+        .type   _vmcall, @function
+_vmcall:
 
-#include <queue.h>
-#include <device.h>
+        push rbx
 
-#include <common.h>
+        mov r9, rdx
+        mov r8, rcx
 
-#include <bfdebug.h>
-#include <bfplatform.h>
-#include <bfdriverinterface.h>
+        mov rax, rdi
+        mov rbx, rsi
+        mov rcx, r9
+        mov rdx, r8
 
-#define STATUS_STOPPED 0
-#define STATUS_RUNNING 1
-#define STATUS_SUSPEND 2
+        vmcall
 
-EXTERN_C_START
-
-DRIVER_INITIALIZE DriverEntry;
-EVT_WDF_DRIVER_DEVICE_ADD bareflankEvtDeviceAdd;
-EVT_WDF_OBJECT_CONTEXT_CLEANUP bareflankEvtDriverContextCleanup;
-EVT_WDF_DEVICE_D0_ENTRY bareflankEvtDeviceD0Entry;
-EVT_WDF_DEVICE_D0_EXIT bareflankEvtDeviceD0Exit;
-
-EXTERN_C_END
+        pop rbx
+        ret

--- a/bfdriver/src/platform/windows/device.c
+++ b/bfdriver/src/platform/windows/device.c
@@ -48,6 +48,5 @@ bareflankCreateDevice(
         return status;
     }
 
-    BFDEBUG("bareflankCreateDevice: success\n");
     return status;
 }

--- a/bfm/src/platform/linux/ioctl.cpp
+++ b/bfm/src/platform/linux/ioctl.cpp
@@ -29,64 +29,56 @@ ioctl::ioctl() :
 void
 ioctl::open()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->open();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->open();
 }
 
 void
 ioctl::call_ioctl_add_module(const binary_data &module_data)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_add_module_length(module_data.size());
-        d->call_ioctl_add_module(module_data.data());
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_add_module_length(module_data.size());
+    d->call_ioctl_add_module(module_data.data());
 }
 
 void
 ioctl::call_ioctl_load_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_load_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_load_vmm();
 }
 
 void
 ioctl::call_ioctl_unload_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_unload_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_unload_vmm();
 }
 
 void
 ioctl::call_ioctl_start_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_start_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_start_vmm();
 }
 
 void
 ioctl::call_ioctl_stop_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_stop_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_stop_vmm();
 }
 
 void
 ioctl::call_ioctl_dump_vmm(gsl::not_null<drr_pointer> drr, vcpuid_type vcpuid)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_dump_vmm(drr, vcpuid);
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_dump_vmm(drr, vcpuid);
 }
 
 void
 ioctl::call_ioctl_vmm_status(gsl::not_null<status_pointer> status)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_vmm_status(status);
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_vmm_status(status);
 }

--- a/bfm/src/platform/windows/ioctl.cpp
+++ b/bfm/src/platform/windows/ioctl.cpp
@@ -29,63 +29,55 @@ ioctl::ioctl() :
 void
 ioctl::open()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->open();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->open();
 }
 
 void
 ioctl::call_ioctl_add_module(const binary_data &module_data)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_add_module(module_data.data(), module_data.size());
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_add_module(module_data.data(), module_data.size());
 }
 
 void
 ioctl::call_ioctl_load_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_load_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_load_vmm();
 }
 
 void
 ioctl::call_ioctl_unload_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_unload_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_unload_vmm();
 }
 
 void
 ioctl::call_ioctl_start_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_start_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_start_vmm();
 }
 
 void
 ioctl::call_ioctl_stop_vmm()
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_stop_vmm();
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_stop_vmm();
 }
 
 void
 ioctl::call_ioctl_dump_vmm(gsl::not_null<drr_pointer> drr, vcpuid_type vcpuid)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_dump_vmm(drr, vcpuid);
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_dump_vmm(drr, vcpuid);
 }
 
 void
 ioctl::call_ioctl_vmm_status(gsl::not_null<status_pointer> status)
 {
-    if (auto d = dynamic_cast<ioctl_private *>(m_d.get())) {
-        d->call_ioctl_vmm_status(status);
-    }
+    auto d = static_cast<ioctl_private *>(m_d.get());
+    d->call_ioctl_vmm_status(status);
 }

--- a/bfsdk/include/bfdriverinterface.h
+++ b/bfsdk/include/bfdriverinterface.h
@@ -60,6 +60,28 @@ extern "C" {
 #define IOCTL_DUMP_VMM_CMD 0x807
 #define IOCTL_VMM_STATUS_CMD 0x808
 #define IOCTL_SET_VCPUID_CMD 0x80A
+#define IOCTL_VMCALL_CMD 0x810
+
+/**
+ * @struct ioctl_vmcall_args_t
+ *
+ * Stores the general registers for a vmcall
+ *
+ * @var ioctl_vmcall_args_t::reg1
+ *     general register #1
+ * @var ioctl_vmcall_args_t::reg2
+ *     general register #2
+ * @var ioctl_vmcall_args_t::reg3
+ *     general register #3
+ * @var ioctl_vmcall_args_t::reg4
+ *     general register #4
+ */
+struct ioctl_vmcall_args_t {
+    uint64_t reg1;
+    uint64_t reg2;
+    uint64_t reg3;
+    uint64_t reg4;
+};
 
 /* -------------------------------------------------------------------------- */
 /* Linux Interfaces                                                           */
@@ -76,6 +98,7 @@ extern "C" {
 #define IOCTL_DUMP_VMM _IOR(BAREFLANK_MAJOR, IOCTL_DUMP_VMM_CMD, struct debug_ring_resources_t *)
 #define IOCTL_VMM_STATUS _IOR(BAREFLANK_MAJOR, IOCTL_VMM_STATUS_CMD, int64_t *)
 #define IOCTL_SET_VCPUID _IOW(BAREFLANK_MAJOR, IOCTL_SET_VCPUID_CMD, uint64_t *)
+#define IOCTL_VMCALL _IOWR(BAREFLANK_MAJOR, IOCTL_VMCALL_CMD, struct ioctl_vmcall_args_t *)
 
 #endif
 
@@ -109,6 +132,7 @@ DEFINE_GUID(
 #define IOCTL_DUMP_VMM CTL_CODE(BAREFLANK_DEVICETYPE, IOCTL_DUMP_VMM_CMD, METHOD_OUT_DIRECT, FILE_READ_DATA)
 #define IOCTL_VMM_STATUS CTL_CODE(BAREFLANK_DEVICETYPE, IOCTL_VMM_STATUS_CMD, METHOD_BUFFERED, FILE_READ_DATA)
 #define IOCTL_SET_VCPUID CTL_CODE(BAREFLANK_DEVICETYPE, IOCTL_SET_VCPUID_CMD, METHOD_IN_DIRECT, FILE_WRITE_DATA)
+#define IOCTL_VMCALL CTL_CODE(BAREFLANK_DEVICETYPE, IOCTL_VMCALL_CMD, METHOD_IN_DIRECT, FILE_READ_WRITE_DATA)
 
 #endif
 

--- a/bfsdk/include/bferrorcodes.h
+++ b/bfsdk/include/bferrorcodes.h
@@ -33,6 +33,7 @@
 
 #define SUCCESS 0
 #define FAILURE 0xFFFFFFFFFFFFFFFF
+#define SUSPEND 0xFFFFFFFFFFFFFFFE
 
 /* -------------------------------------------------------------------------- */
 /* Entry Error Codes                                                          */

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/monitor_trap.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/monitor_trap.h
@@ -61,31 +61,6 @@ class EXPORT_HVE monitor_trap_handler
 {
 public:
 
-    /// Info
-    ///
-    /// This struct is created by monitor_trap_handler::handle before being
-    /// passed to each registered handler.
-    ///
-    struct info_t {
-
-        /// Ignore clear
-        ///
-        /// If true, do not disable the monitor trap flag after your
-        /// registered handler returns true.
-        ///
-        /// default: false
-        ///
-        bool ignore_clear;
-    };
-
-    /// Handler delegate type
-    ///
-    /// The type of delegate clients must use when registering
-    /// handlers
-    ///
-    using handler_delegate_t =
-        delegate<bool(vcpu *, info_t &)>;
-
     /// Constructor
     ///
     /// @expects
@@ -112,7 +87,7 @@ public:
     ///
     /// @param d the handler to call when an exit occurs
     ///
-    void add_handler(const handler_delegate_t &d);
+    void add_handler(const ::handler_delegate_t &d);
 
     /// Enable
     ///
@@ -137,7 +112,7 @@ public:
 private:
 
     vcpu *m_vcpu;
-    std::list<handler_delegate_t> m_handlers;
+    std::list<::handler_delegate_t> m_handlers;
 
 public:
 
@@ -151,8 +126,6 @@ public:
 
     /// @endcond
 };
-
-using monitor_trap_handler_delegate_t = monitor_trap_handler::handler_delegate_t;
 
 }
 

--- a/bfvmm/include/test/hve.h
+++ b/bfvmm/include/test/hve.h
@@ -150,7 +150,8 @@ setup_vcpu(MockRepository &mocks, ::intel_x64::vmcs::value_type reason = 0)
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_fini_delegate);
 
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::run_delegate);
-    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::hlt_delegate);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_launch_delegate);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_resume_delegate);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::load);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::promote);
 

--- a/bfvmm/include/vcpu/vcpu.h
+++ b/bfvmm/include/vcpu/vcpu.h
@@ -58,10 +58,7 @@
 // Delegate Types
 // -----------------------------------------------------------------------------
 
-using run_delegate_t = delegate<void(bfobject *)>;      ///< Run delegate type
-using hlt_delegate_t = delegate<void(bfobject *)>;      ///< Halt delegate type
-using init_delegate_t = delegate<void(bfobject *)>;     ///< Init delegate type
-using fini_delegate_t = delegate<void(bfobject *)>;     ///< Fini delegate type
+using vcpu_delegate_t = delegate<void(bfobject *)>;      ///< vCPU delegate type
 
 // -----------------------------------------------------------------------------
 // Definitions
@@ -299,7 +296,7 @@ public:
     ///
     /// @param d the delegate to add to the vcpu
     ///
-    VIRTUAL void add_run_delegate(const run_delegate_t &d) noexcept
+    VIRTUAL void add_run_delegate(const vcpu_delegate_t &d) noexcept
     { m_run_delegates.push_front(std::move(d)); }
 
     /// Add Halt Delegate
@@ -313,7 +310,7 @@ public:
     ///
     /// @param d the delegate to add to the vcpu
     ///
-    VIRTUAL void add_hlt_delegate(const hlt_delegate_t &d) noexcept
+    VIRTUAL void add_hlt_delegate(const vcpu_delegate_t &d) noexcept
     { m_hlt_delegates.push_front(std::move(d)); }
 
     /// Add Init Delegate
@@ -327,7 +324,7 @@ public:
     ///
     /// @param d the delegate to add to the vcpu
     ///
-    VIRTUAL void add_init_delegate(const init_delegate_t &d) noexcept
+    VIRTUAL void add_init_delegate(const vcpu_delegate_t &d) noexcept
     { m_init_delegates.push_front(std::move(d)); }
 
     /// Add Fini Delegate
@@ -341,7 +338,7 @@ public:
     ///
     /// @param d the delegate to add to the vcpu
     ///
-    VIRTUAL void add_fini_delegate(const fini_delegate_t &d) noexcept
+    VIRTUAL void add_fini_delegate(const vcpu_delegate_t &d) noexcept
     { m_fini_delegates.push_front(std::move(d)); }
 
     /// Get User Data
@@ -383,10 +380,10 @@ private:
     bool m_is_running{false};
     bool m_is_initialized{false};
 
-    std::list<run_delegate_t> m_run_delegates;
-    std::list<hlt_delegate_t> m_hlt_delegates;
-    std::list<init_delegate_t> m_init_delegates;
-    std::list<fini_delegate_t> m_fini_delegates;
+    std::list<vcpu_delegate_t> m_run_delegates;
+    std::list<vcpu_delegate_t> m_hlt_delegates;
+    std::list<vcpu_delegate_t> m_init_delegates;
+    std::list<vcpu_delegate_t> m_fini_delegates;
 
     std::any m_data;
 

--- a/bfvmm/integration/arch/intel_x64/ept/enable_ept.cpp
+++ b/bfvmm/integration/arch/intel_x64/ept/enable_ept.cpp
@@ -64,7 +64,7 @@ public:
         });
 
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->set_eptp(g_guest_map);

--- a/bfvmm/integration/arch/intel_x64/ept/remap_page.cpp
+++ b/bfvmm/integration/arch/intel_x64/ept/remap_page.cpp
@@ -70,7 +70,7 @@ public:
         );
 
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         for (auto &elem : buffer1) {

--- a/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr0.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr0.cpp
@@ -54,7 +54,7 @@ void
 vcpu_init_nonroot(vcpu_t *vcpu)
 {
     vcpu->add_hlt_delegate(
-        hlt_delegate_t::create<test_hlt_delegate>()
+        vcpu_delegate_t::create<test_hlt_delegate>()
     );
 
     vcpu->add_wrcr0_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr3.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr3.cpp
@@ -66,7 +66,7 @@ void
 vcpu_init_nonroot(vcpu_t *vcpu)
 {
     vcpu->add_hlt_delegate(
-        hlt_delegate_t::create<test_hlt_delegate>()
+        vcpu_delegate_t::create<test_hlt_delegate>()
     );
 
     vcpu->add_rdcr3_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr4.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/control_register/trap_cr4.cpp
@@ -54,7 +54,7 @@ void
 vcpu_init_nonroot(vcpu_t *vcpu)
 {
     vcpu->add_hlt_delegate(
-        hlt_delegate_t::create<test_hlt_delegate>()
+        vcpu_delegate_t::create<test_hlt_delegate>()
     );
 
     vcpu->add_wrcr4_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/cpuid/trap_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/cpuid/trap_cpuid.cpp
@@ -69,7 +69,7 @@ public:
         bfvmm::intel_x64::vcpu{id}
     {
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->add_cpuid_emulator(

--- a/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_execute_violation.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_execute_violation.cpp
@@ -64,7 +64,7 @@ public:
         });
 
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->add_ept_execute_violation_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_read_violation.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_read_violation.cpp
@@ -66,7 +66,7 @@ public:
         });
 
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->add_ept_read_violation_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_write_violation.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/ept_violation/trap_ept_write_violation.cpp
@@ -66,7 +66,7 @@ public:
         });
 
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->add_ept_write_violation_handler(

--- a/bfvmm/integration/arch/intel_x64/vmexit/monitor_trap/single_step_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/monitor_trap/single_step_cpuid.cpp
@@ -48,7 +48,7 @@ public:
         );
 
         this->add_monitor_trap_handler(
-            monitor_trap_handler::handler_delegate_t::create<vcpu, &vcpu::monitor_trap_handler>(this)
+            ::handler_delegate_t::create<vcpu, &vcpu::monitor_trap_handler>(this)
         );
     }
 
@@ -73,11 +73,9 @@ public:
         return false;
     }
 
-    bool monitor_trap_handler(
-        vcpu_t *vcpu, monitor_trap_handler::info_t &info)
+    bool monitor_trap_handler(vcpu_t *vcpu)
     {
         bfignored(vcpu);
-        bfignored(info);
 
         bfdebug_info(0, "instrution after cpuid trapped");
         return false;

--- a/bfvmm/integration/arch/intel_x64/vpid/enable_vpid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vpid/enable_vpid.cpp
@@ -45,7 +45,7 @@ public:
         bfvmm::intel_x64::vcpu{id}
     {
         this->add_hlt_delegate(
-            hlt_delegate_t::create<test_hlt_delegate>()
+            vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
         this->enable_vpid();

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
@@ -145,11 +145,15 @@ cpuid_handler::cpuid_handler(
     );
 
     this->add_emulator(
-        0x4BF00011, handler_delegate_t::create<handle_cpuid_0x4BF00011>()
+        0x4BF00020, handler_delegate_t::create<handle_cpuid_0x4BF00020>()
     );
 
+    if (vcpu->is_guest_vm_vcpu()) {
+        return;
+    }
+
     this->add_emulator(
-        0x4BF00020, handler_delegate_t::create<handle_cpuid_0x4BF00020>()
+        0x4BF00011, handler_delegate_t::create<handle_cpuid_0x4BF00011>()
     );
 
     this->add_emulator(

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/monitor_trap.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/monitor_trap.cpp
@@ -60,19 +60,12 @@ bool
 monitor_trap_handler::handle(vcpu *vcpu)
 {
     using namespace vmcs_n;
-
-    struct info_t info = {
-        false
-    };
+    primary_processor_based_vm_execution_controls::monitor_trap_flag::disable();
 
     for (const auto &d : m_handlers) {
-        if (d(vcpu, info)) {
+        if (d(vcpu)) {
             break;
         }
-    }
-
-    if (!info.ignore_clear) {
-        primary_processor_based_vm_execution_controls::monitor_trap_flag::disable();
     }
 
     return true;

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/rdmsr.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/rdmsr.cpp
@@ -109,6 +109,10 @@ rdmsr_handler::trap_on_access(vmcs_n::value_type msr)
         return set_bit(m_msr_bitmap, (msr - 0xC0000000UL) + 0x2000);
     }
 
+    if (msr >= 0x40000000UL && msr <= 0x40001FFFUL) {
+        return;
+    }
+
     throw std::runtime_error("invalid msr: " + std::to_string(msr));
 }
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/wrmsr.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/wrmsr.cpp
@@ -119,6 +119,10 @@ wrmsr_handler::trap_on_access(vmcs_n::value_type msr)
         return set_bit(m_msr_bitmap, (msr - 0xC0000000UL) + 0x6000);
     }
 
+    if (msr >= 0x40000000UL && msr <= 0x40001FFFUL) {
+        return;
+    }
+
     throw std::runtime_error("invalid msr: " + std::to_string(msr));
 }
 

--- a/bfvmm/tests/hve/arch/intel_x64/test_exception.cpp
+++ b/bfvmm/tests/hve/arch/intel_x64/test_exception.cpp
@@ -55,7 +55,7 @@ TEST_CASE("vector_to_str")
 }
 
 bool
-ec_valid(int vector)
+ec_valid(unsigned int vector)
 {
     switch (vector) {
         case 8:

--- a/bfvmm/tests/vcpu/test_vcpu.cpp
+++ b/bfvmm/tests/vcpu/test_vcpu.cpp
@@ -274,41 +274,41 @@ test_delegate_throws(bfobject *data)
 TEST_CASE("vcpu: run_delegate")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_run_delegate(run_delegate_t::create<test_delegate>()));
+    CHECK_NOTHROW(vc->add_run_delegate(vcpu_delegate_t::create<test_delegate>()));
     CHECK_NOTHROW(vc->run());
 }
 
 TEST_CASE("vcpu: hlt_delegate")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_hlt_delegate(hlt_delegate_t::create<test_delegate>()));
+    CHECK_NOTHROW(vc->add_hlt_delegate(vcpu_delegate_t::create<test_delegate>()));
     CHECK_NOTHROW(vc->hlt());
 }
 
 TEST_CASE("vcpu: init_delegate")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_init_delegate(init_delegate_t::create<test_delegate>()));
+    CHECK_NOTHROW(vc->add_init_delegate(vcpu_delegate_t::create<test_delegate>()));
     CHECK_NOTHROW(vc->init());
 }
 
 TEST_CASE("vcpu: fini_delegate")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_fini_delegate(fini_delegate_t::create<test_delegate>()));
+    CHECK_NOTHROW(vc->add_fini_delegate(vcpu_delegate_t::create<test_delegate>()));
     CHECK_NOTHROW(vc->fini());
 }
 
 TEST_CASE("vcpu: run_delegate throws")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_run_delegate(run_delegate_t::create<test_delegate_throws>()));
+    CHECK_NOTHROW(vc->add_run_delegate(vcpu_delegate_t::create<test_delegate_throws>()));
     CHECK_THROWS(vc->run());
 }
 
 TEST_CASE("vcpu: init_delegate throws")
 {
     auto vc = std::make_unique<bfvmm::vcpu>(0);
-    CHECK_NOTHROW(vc->add_init_delegate(init_delegate_t::create<test_delegate_throws>()));
+    CHECK_NOTHROW(vc->add_init_delegate(vcpu_delegate_t::create<test_delegate_throws>()));
     CHECK_THROWS(vc->init());
 }

--- a/examples/hook/vmm/main.cpp
+++ b/examples/hook/vmm/main.cpp
@@ -210,11 +210,8 @@ ept_execute_violation_handler(
 }
 
 bool
-mt_handler(
-    vcpu_t *vcpu, monitor_trap_handler::info_t &info)
+mt_handler(vcpu_t *vcpu)
 {
-    bfignored(info);
-
     // Get a reference to our per-vcpu data. Note that we need to explicitly
     // ask for a reference, similar to the std::any APIs.
     //
@@ -272,7 +269,6 @@ void
 vcpu_init_nonroot(vcpu_t *vcpu)
 {
     using namespace vmcs_n;
-    using mt_delegate_t = monitor_trap_handler::handler_delegate_t;
     using eptv_delegate_t = ept_violation_handler::handler_delegate_t;
 
     // Initialize our per-vcpu data.
@@ -293,7 +289,7 @@ vcpu_init_nonroot(vcpu_t *vcpu)
     // exists in the same physical page as our hello_world() function.
     //
     vcpu->add_monitor_trap_handler(
-        mt_delegate_t::create<mt_handler>()
+        ::handler_delegate_t::create<mt_handler>()
     );
 
     // Add an EPT violation handler (for execute access). If an EPT


### PR DESCRIPTION
This patch provides API changed need to support
suspend/resume in Boxy with guest support. Specifically this
patch does the following:
- Adds some additional handlers for launch/resume
- Ensures that clearing a VMCS will force a relaunch
- Adds a VMCall interface to the driver that can be used to
  ensure that vmcall is only called when the hypervisor is
  running