### PR TITLE
Cpuid sdk

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -41,10 +41,11 @@ parsers:
       macro: no
 
 ignore:
-  - "bfintrinsics/**"
-  - "bfm/ioctl/arch/**"
-  - "bfvmm/include/test/**"
-  - "bfdriver/**"
+  - "bfintrinsics/**"           # Not useful to unit test
+  - "bfvmm/include/test/**"     # Don't calculate coverage on unit test code
+  - "bfdriver/**"               # Not possible to unit test (OS drivers)
+  - "bfvmm/include/sdk/**"      # Covered with integration tests
+  - "bfvmm/src/sdk/**"          # Covered with integration tests
 
   # Remove Me
   - "bfelf_loader/**"

--- a/bfdriver/src/platform/linux/entry.c
+++ b/bfdriver/src/platform/linux/entry.c
@@ -311,7 +311,7 @@ ioctl_vmcall(struct ioctl_vmcall_args_t *user_args)
 
     mutex_lock(&g_status_mutex);
 
-    switch(g_status) {
+    switch (g_status) {
         case STATUS_RUNNING:
             args.reg1 = _vmcall(args.reg1, args.reg2, args.reg3, args.reg4);
             break;
@@ -464,7 +464,7 @@ int
 dev_pm(
     struct notifier_block *nb, unsigned long code, void *unused)
 {
-    switch(code) {
+    switch (code) {
         case PM_SUSPEND_PREPARE:
         case PM_HIBERNATION_PREPARE:
         case PM_RESTORE_PREPARE:

--- a/bfvmm/CMakeLists.txt
+++ b/bfvmm/CMakeLists.txt
@@ -73,6 +73,7 @@ endif()
 
 if(PREFIX STREQUAL vmm)
     add_subdirectory(src/entry)
+    add_subdirectory(src/sdk)
     add_dependencies(bfvmm bfvmm_entry)
     target_link_libraries(bfvmm INTERFACE
         --whole-archive
@@ -85,6 +86,7 @@ if(PREFIX STREQUAL vmm)
         bfvmm_vcpu
         bfvmm_memory_manager
         bfvmm_debug
+        bfvmm_sdk
         vmm::bfintrinsics
         ${CMAKE_INSTALL_PREFIX}/lib/libc++.a
         ${CMAKE_INSTALL_PREFIX}/lib/libc++abi.a

--- a/bfvmm/include/sdk/cpuid.h
+++ b/bfvmm/include/sdk/cpuid.h
@@ -1,0 +1,101 @@
+//
+// Copyright (C) 2019 Assured Information Security, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef BFVMM_SDK_CPUID_INTEL_X64_H
+#define BFVMM_SDK_CPUID_INTEL_X64_H
+
+namespace bfvmm::intel_x64::cpuid
+{
+
+using leaf_t = ::bfvmm::intel_x64::cpuid_handler::leaf_t;
+
+/// Add Handler
+///
+/// Adds a VM exit handler for a CPUID leaf.
+///
+/// @param vcpu the vcpu to add a handler to
+/// @param leaf the cpuid leaf that @param handler is registered for
+/// @param handler the handler to call when a VM exit occurs
+///
+void add_handler(vcpu *vcpu, leaf_t leaf, handler_delegate_t handler);
+
+/// Add Emulator
+///
+/// Adds a VM exit emulator for a CPUID leaf.
+///
+/// @param vcpu the vcpu to add a handler to
+/// @param leaf the cpuid leaf that @param handler is registered for
+/// @param handler the handler to call when a VM exit occurs
+///
+void add_emulator(vcpu *vcpu, leaf_t leaf, handler_delegate_t handler);
+
+/// Execute
+///
+/// Executes the CPUID instruction using the vCPU's registers as inputs and
+/// outputs
+///
+/// vCPU Inputs:    rax, rcx
+/// vCPU Outputs:   rax, rbx, rcx, rdx
+///
+/// @param vcpu the vcpu to execute CPUID on
+///
+void execute(vcpu *vcpu);
+
+/// Emulate
+///
+/// Emulates the result of a CPUID instruction on the given vcpu using the given
+/// output values (masked to 32-bits).
+///
+/// vCPU Outputs: rax, rbx, rcx, rdx
+///
+/// @param vcpu the vcpu to emulate a CPUID instruction on
+/// @param rax the emulated output value for vcpu->rax
+/// @param rbx the emulated output value for vcpu->rbx
+/// @param rcx the emulated output value for vcpu->rcx
+/// @param rdx the emulated output value for vcpu->rdx
+///
+void emulate(vcpu *vcpu, uint64_t rax, uint64_t rbx, uint64_t rcx, uint64_t rdx);
+
+/// get_leaf
+///
+/// Get the CPUID leaf (rax) that caused the current VM exit handler to run,
+/// regardless of the current value of vcpu->rax().
+///
+/// @param vcpu the vcpu on which to get the CPUID leaf that caused a VM exit
+///
+/// @return leaf_t the CPUID leaf that caused a VM exit
+///
+leaf_t get_leaf(vcpu *vcpu);
+
+/// get_subleaf
+///
+/// Get the CPUID subleaf (rcx) that caused the current VM exit handler to run,
+/// regardless of the current value of vcpu->rcx().
+///
+/// @param vcpu the vcpu on which to get the CPUID subleaf that caused a VM exit
+///
+/// @return leaf_t the CPUID subleaf that caused a VM exit
+///
+leaf_t get_subleaf(vcpu *vcpu);
+
+}
+
+#endif

--- a/bfvmm/include/vmm.h
+++ b/bfvmm/include/vmm.h
@@ -65,6 +65,8 @@
 #include "hve/arch/intel_x64/vcpu.h"
 #include "hve/arch/intel_x64/vmx.h"
 #include "hve/arch/intel_x64/vpid.h"
+
+#include "sdk/cpuid.h"
 #endif
 
 #ifdef BF_X64
@@ -81,6 +83,9 @@
 
 #ifdef BF_INTEL_X64
 using namespace bfvmm::intel_x64;
+
+#define handler_delegate(function) handler_delegate_t::create<function>()
+
 #endif
 
 #endif

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
@@ -179,9 +179,6 @@ cpuid_handler::add_emulator(
 void
 cpuid_handler::execute(gsl::not_null<vcpu *> vcpu)
 {
-    vcpu->set_gr1(vcpu->rax());
-    vcpu->set_gr2(vcpu->rcx());
-
     auto [rax, rbx, rcx, rdx] =
         ::x64::cpuid::get(
             gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rax()),
@@ -227,21 +224,20 @@ execute_emulators(vcpu *vcpu, const std::list<handler_delegate_t> &emulators)
 bool
 cpuid_handler::handle(vcpu *vcpu)
 {
-    const auto &emulators =
-        m_emulators.find(vcpu->rax());
+    vcpu->set_gr1(vcpu->rax());
+    vcpu->set_gr2(vcpu->rcx());
+
+    const auto &emulators = m_emulators.find(vcpu->rax());
 
     if (emulators != m_emulators.end()) {
         return execute_emulators(vcpu, emulators->second);
     }
 
     if (m_whitelist) {
-        vcpu->set_gr1(vcpu->rax());
-        vcpu->set_gr2(vcpu->rcx());
         return false;
     }
 
-    const auto &handlers =
-        m_handlers.find(vcpu->rax());
+    const auto &handlers = m_handlers.find(vcpu->rax());
 
     this->execute(vcpu);
 

--- a/bfvmm/src/sdk/CMakeLists.txt
+++ b/bfvmm/src/sdk/CMakeLists.txt
@@ -1,0 +1,35 @@
+#
+# Copyright (C) 2019 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+add_library(bfvmm_sdk)
+
+target_link_libraries(bfvmm_sdk PUBLIC ${PREFIX}::bfroot)
+
+target_include_directories(bfvmm_sdk PUBLIC
+    $<${BUILD_INCLUDE}:${PROJECT_ROOT}/include>
+)
+
+target_sources(bfvmm_sdk PRIVATE
+    $<${X64}:cpuid.cpp>
+)
+
+install(TARGETS bfvmm_sdk DESTINATION lib EXPORT bfvmm-${PREFIX}-targets)
+install(DIRECTORY ../../include/sdk/ DESTINATION include/bfvmm/sdk)

--- a/bfvmm/src/sdk/cpuid.cpp
+++ b/bfvmm/src/sdk/cpuid.cpp
@@ -19,57 +19,33 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#include <vmm.h>
-#include <atomic>
+#include "hve/arch/intel_x64/vcpu.h"
+#include "sdk/cpuid.h"
 
-std::atomic<uint64_t> g_count{0};
-
-void
-global_init()
+namespace bfvmm::intel_x64::cpuid
 {
-    bfdebug_info(0, "running cpuidcount example");
-    bfdebug_lnbr(0);
 
-    g_count = 0;
+void add_emulator(vcpu *vcpu, leaf_t leaf, handler_delegate_t handler)
+{ vcpu->add_cpuid_emulator(leaf, handler); }
+
+void add_handler(vcpu *vcpu, leaf_t leaf, handler_delegate_t handler)
+{ vcpu->add_cpuid_handler(leaf, handler); }
+
+void emulate(vcpu *vcpu, uint64_t rax, uint64_t rbx, uint64_t rcx, uint64_t rdx)
+{
+    vcpu->set_rax(set_bits(vcpu->rax(), 0x00000000FFFFFFFFULL, rax));
+    vcpu->set_rbx(set_bits(vcpu->rbx(), 0x00000000FFFFFFFFULL, rbx));
+    vcpu->set_rcx(set_bits(vcpu->rcx(), 0x00000000FFFFFFFFULL, rcx));
+    vcpu->set_rdx(set_bits(vcpu->rdx(), 0x00000000FFFFFFFFULL, rdx));
 }
 
-void
-global_fini()
-{ bfdebug_ndec(0, "global count", g_count); }
+void execute(vcpu *vcpu)
+{ vcpu->execute_cpuid(); }
 
-bool
-handle_cpuid(vcpu_t *vcpu)
-{
-    bfignored(vcpu);
+leaf_t get_leaf(vcpu *vcpu)
+{ return vcpu->gr1(); }
 
-    g_count++;
-    vcpu->data<uint64_t &>()++;
+leaf_t get_subleaf(vcpu *vcpu)
+{ return vcpu->gr2(); }
 
-    return false;
 }
-
-void
-vcpu_init_nonroot(vcpu_t *vcpu)
-{
-    using namespace vmcs_n::exit_reason;
-
-    vcpu->add_handler(
-        basic_exit_reason::cpuid, ::handler_delegate_t::create<handle_cpuid>()
-    );
-
-    vcpu->set_data<uint64_t>(0);
-}
-
-void
-vcpu_fini_nonroot(vcpu_t *vcpu)
-{ bfdebug_ndec(0, "vcpu count", vcpu->data<uint64_t>()); }
-
-// Expected Output (make dump)
-//
-// [0x0] DEBUG: running cpuidcount example
-// [0x0] DEBUG:
-// [0x0] DEBUG: host os is now in a vm
-// ...
-// [0x0] DEBUG: host os is not in a vm
-// [0x0] DEBUG: vcpu count                                                      xxx
-// [0x0] DEBUG: global count                                                    xxx


### PR DESCRIPTION
This patch series introduces the concept of SDK functions to the base hypervisor, using CPUID as a guinea-pig feature. The idea behind SDK functions is two-fold:

1) Attempt to decouple an extension writer's needs from the historically turbulent vCPU class. For example:

```
namespace bfvmm::intel_x64::cpuid
{

// The goal is to keep this interface stable...
void add_handler(vcpu *vcpu, leaf_t leaf, handler_delegate_t handler) 
{
    // ... while allowing this interface to remain dynamic
    vcpu->add_cpuid_handler(leaf, handler); 
}

}
```
2) Translate operations that expose a vCPU's implementation details into more intuitive "english":

```
namespace bfvmm::intel_x64::cpuid
{

// This function will strive to present intuitive meaning...
leaf_t get_leaf(vcpu *vcpu)
{
    // ... while this function can use the less intuitive implementation details of a vCPU
    return vcpu->gr1();
}

}
```

Eventually, we should work to create SDK functions that cover all common operations that an extension writer needs to accomplish (MSRs, control registers, ept, etc). Also, I think that this should eventually be moved to the top level of the project to ```hypervisor/sdk``` to make it clear that it is a separate layer from ```hypervisor/bfvmm``` (can't move it now, because we already have something else called ```hypervisor/bfsdk''')