### PR TITLE
cmake: Fix bfsdk, LOG_BUILD bugs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,29 +105,13 @@ add_subproject(bfroot userspace SOURCE_DIR ${SOURCE_CMAKE_DIR})
 # VMM Components
 # ------------------------------------------------------------------------------
 
-add_subproject(bfsdk vmm DEPENDS bfroot)
 include_dependency(SOURCE_DEPENDS_DIR binutils)
-
-if(NOT WIN32)
-    if(NOT ENABLE_BUILD_BINUTILS)
-        add_subproject(
-            bfdso vmm
-            SOURCE_DIR ${SOURCE_BFRUNTIME_DIR}/src/dso
-            DEPENDS bfroot
-        )
-    else()
-        add_subproject(
-            bfdso vmm
-            SOURCE_DIR ${SOURCE_BFRUNTIME_DIR}/src/dso
-            DEPENDS binutils bfroot
-        )
-    endif()
-endif()
-
 include_dependency(SOURCE_DEPENDS_DIR newlib)
 include_dependency(SOURCE_DEPENDS_DIR llvm)
 include_dependency(SOURCE_DEPENDS_DIR libcxxabi)
 include_dependency(SOURCE_DEPENDS_DIR libcxx)
+
+add_subproject(bfsdk vmm DEPENDS bfroot)
 
 if(ENABLE_BUILD_VMM OR (ENABLE_BUILD_TEST AND NOT WIN32))
     add_subproject(bfruntime vmm DEPENDS gsl libcxx)
@@ -136,24 +120,7 @@ endif()
 
 if(ENABLE_BUILD_VMM)
     add_subproject(bfintrinsics vmm DEPENDS bfruntime)
-    add_subproject(bfvmm vmm DEPENDS bfunwind bfintrinsics)
-
-    add_subproject(cpuidcount vmm
-        DEPENDS bfvmm
-        SOURCE_DIR ${SOURCE_EXAMPLES_DIR}/cpuidcount
-    )
-    add_subproject(hook vmm
-        DEPENDS bfvmm
-        SOURCE_DIR ${SOURCE_EXAMPLES_DIR}/hook
-    )
-    add_subproject(rdtsc vmm
-        DEPENDS bfvmm
-        SOURCE_DIR ${SOURCE_EXAMPLES_DIR}/rdtsc
-    )
-    add_subproject(vpid vmm
-        DEPENDS bfvmm
-        SOURCE_DIR ${SOURCE_EXAMPLES_DIR}/vpid
-    )
+    add_subproject(bfvmm vmm DEPENDS bfunwind bfintrinsics bfsdk)
 endif()
 
 # ------------------------------------------------------------------------------
@@ -184,15 +151,16 @@ if(ENABLE_BUILD_USERSPACE)
     add_subproject(bfintrinsics userspace DEPENDS gsl json bfroot)
     add_subproject(bfm userspace DEPENDS gsl json cxxopts bfroot)
     add_subproject(bfack userspace DEPENDS bfintrinsics)
-    add_subproject(hook userspace
-        DEPENDS bfintrinsics
-        SOURCE_DIR ${SOURCE_EXAMPLES_DIR}/hook
-    )
 endif()
 
 # ------------------------------------------------------------------------------
 # External Components
 # ------------------------------------------------------------------------------
+
+list(APPEND EXTENSION ${SOURCE_EXAMPLES_DIR}/cpuidcount)
+list(APPEND EXTENSION ${SOURCE_EXAMPLES_DIR}/hook)
+list(APPEND EXTENSION ${SOURCE_EXAMPLES_DIR}/rdtsc)
+list(APPEND EXTENSION ${SOURCE_EXAMPLES_DIR}/vpid)
 
 include_external_extensions()
 

--- a/bfruntime/CMakeLists.txt
+++ b/bfruntime/CMakeLists.txt
@@ -64,6 +64,14 @@ if(PREFIX STREQUAL test)
 endif()
 
 # -----------------------------------------------------------------------------
+# dso
+# -----------------------------------------------------------------------------
+
+add_library(bfdso)
+target_link_libraries(bfdso PUBLIC bfruntime)
+target_sources(bfdso PRIVATE src/dso/dso.cpp)
+
+# -----------------------------------------------------------------------------
 # pthread
 # -----------------------------------------------------------------------------
 
@@ -87,6 +95,7 @@ target_sources(bfsyscall PRIVATE src/syscall/syscall.cpp)
 # -----------------------------------------------------------------------------
 
 install(TARGETS bfcrt DESTINATION lib EXPORT bfruntime-${PREFIX}-targets)
+install(TARGETS bfdso DESTINATION lib EXPORT bfruntime-${PREFIX}-targets)
 install(TARGETS bfpthread DESTINATION lib EXPORT bfruntime-${PREFIX}-targets)
 install(TARGETS bfsyscall DESTINATION lib EXPORT bfruntime-${PREFIX}-targets)
 

--- a/examples/cpuidcount/CMakeLists.txt
+++ b/examples/cpuidcount/CMakeLists.txt
@@ -19,12 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.13)
-project(cpuidcount C CXX)
-
-init_project(cpuidcount BINARY)
-
-target_sources(cpuidcount PRIVATE vmm/main.cpp)
-target_link_libraries(cpuidcount PRIVATE vmm::bfvmm)
-
-fini_project()
+if(ENABLE_BUILD_VMM)
+    add_subproject(cpuidcount vmm
+        DEPENDS bfvmm
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/vmm
+    )
+endif()

--- a/examples/cpuidcount/vmm/CMakeLists.txt
+++ b/examples/cpuidcount/vmm/CMakeLists.txt
@@ -19,39 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
-    message(STATUS "Including dependency: libcxxabi")
+cmake_minimum_required(VERSION 3.13)
+project(cpuidcount C CXX)
 
-    download_dependency(
-        libcxxabi
-        URL          ${LIBCXXABI_URL}
-        URL_MD5      ${LIBCXXABI_URL_MD5}
-    )
+init_project(cpuidcount BINARY)
 
-    generate_flags(
-        vmm
-        NOWARNINGS
-    )
+target_sources(cpuidcount PRIVATE main.cpp)
+target_link_libraries(cpuidcount PRIVATE vmm::bfvmm)
 
-    list(APPEND LIBCXXABI_CONFIGURE_FLAGS
-        -DLLVM_PATH=${CACHE_DIR}/llvm
-        -DLLVM_ENABLE_LIBCXX=ON
-        -DLIBCXXABI_LIBCXX_PATH=${CACHE_DIR}/libcxx
-        -DLIBCXXABI_SYSROOT=${VMM_PREFIX_PATH}
-        -DLIBCXXABI_HAS_PTHREAD_API=ON
-        -DLIBCXXABI_ENABLE_SHARED=OFF
-        -DLIBCXXABI_ENABLE_STATIC=ON
-        -DLIBCXXABI_INCLUDE_TESTS=OFF
-        -DCMAKE_TOOLCHAIN_FILE=${VMM_TOOLCHAIN_PATH}
-        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        -DCXX_SUPPORTS_CXX11=ON
-    )
-
-    add_dependency(
-        libcxxabi vmm
-        CMAKE_ARGS  ${LIBCXXABI_CONFIGURE_FLAGS}
-        DEPENDS     llvm_${VMM_PREFIX}
-        DEPENDS     newlib_${VMM_PREFIX}
-    )
-endif()
+fini_project()

--- a/examples/hook/CMakeLists.txt
+++ b/examples/hook/CMakeLists.txt
@@ -19,21 +19,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.13)
-project(hook C CXX)
-
-init_project(hook BINARY)
-
-if(PREFIX STREQUAL "vmm")
-    target_sources(hook PRIVATE vmm/main.cpp)
-    target_link_libraries(hook PRIVATE vmm::bfvmm)
-elseif(PREFIX STREQUAL "userspace")
-    target_sources(hook PRIVATE userspace/hook.cpp)
-    target_link_libraries(hook PRIVATE userspace::bfintrinsics)
-    target_include_directories(hook PRIVATE
-        ${CMAKE_CURRENT_LIST_DIR}/../../bfsdk/include
-        ${CMAKE_CURRENT_LIST_DIR}/../../bfintrinsics/include
+if(ENABLE_BUILD_VMM)
+    add_subproject(hook vmm
+        DEPENDS bfvmm
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/vmm
     )
 endif()
 
-fini_project()
+if(ENABLE_BUILD_USERSPACE)
+    add_subproject(hook userspace
+        DEPENDS bfintrinsics
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/userspace
+    )
+endif()

--- a/examples/hook/userspace/CMakeLists.txt
+++ b/examples/hook/userspace/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 #
 # Copyright (C) 2019 Assured Information Security, Inc.
 #
@@ -19,9 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.6)
-project(bfdso C CXX)
+cmake_minimum_required(VERSION 3.13)
+project(hook C CXX)
 
-init_project(bfdso)
-target_sources(bfdso PRIVATE dso.cpp)
+init_project(hook BINARY)
+
+target_sources(hook PRIVATE hook.cpp)
+target_link_libraries(hook PRIVATE userspace::bfintrinsics)
+target_include_directories(hook PRIVATE
+    ${CMAKE_CURRENT_LIST_DIR}/../../../bfsdk/include
+    ${CMAKE_CURRENT_LIST_DIR}/../../../bfintrinsics/include
+)
+
 fini_project()

--- a/examples/hook/vmm/CMakeLists.txt
+++ b/examples/hook/vmm/CMakeLists.txt
@@ -19,39 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
-    message(STATUS "Including dependency: libcxxabi")
+cmake_minimum_required(VERSION 3.13)
+project(hook C CXX)
 
-    download_dependency(
-        libcxxabi
-        URL          ${LIBCXXABI_URL}
-        URL_MD5      ${LIBCXXABI_URL_MD5}
-    )
+init_project(hook BINARY)
 
-    generate_flags(
-        vmm
-        NOWARNINGS
-    )
+target_sources(hook PRIVATE main.cpp)
+target_link_libraries(hook PRIVATE vmm::bfvmm)
 
-    list(APPEND LIBCXXABI_CONFIGURE_FLAGS
-        -DLLVM_PATH=${CACHE_DIR}/llvm
-        -DLLVM_ENABLE_LIBCXX=ON
-        -DLIBCXXABI_LIBCXX_PATH=${CACHE_DIR}/libcxx
-        -DLIBCXXABI_SYSROOT=${VMM_PREFIX_PATH}
-        -DLIBCXXABI_HAS_PTHREAD_API=ON
-        -DLIBCXXABI_ENABLE_SHARED=OFF
-        -DLIBCXXABI_ENABLE_STATIC=ON
-        -DLIBCXXABI_INCLUDE_TESTS=OFF
-        -DCMAKE_TOOLCHAIN_FILE=${VMM_TOOLCHAIN_PATH}
-        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        -DCXX_SUPPORTS_CXX11=ON
-    )
-
-    add_dependency(
-        libcxxabi vmm
-        CMAKE_ARGS  ${LIBCXXABI_CONFIGURE_FLAGS}
-        DEPENDS     llvm_${VMM_PREFIX}
-        DEPENDS     newlib_${VMM_PREFIX}
-    )
-endif()
+fini_project()

--- a/examples/rdtsc/CMakeLists.txt
+++ b/examples/rdtsc/CMakeLists.txt
@@ -19,12 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.13)
-project(rdtsc C CXX)
-
-init_project(rdtsc BINARY)
-
-target_sources(rdtsc PRIVATE vmm/main.cpp)
-target_link_libraries(rdtsc PRIVATE vmm::bfvmm)
-
-fini_project()
+if(ENABLE_BUILD_VMM)
+    add_subproject(rdtsc vmm
+        DEPENDS bfvmm
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/vmm
+    )
+endif()

--- a/examples/rdtsc/vmm/CMakeLists.txt
+++ b/examples/rdtsc/vmm/CMakeLists.txt
@@ -19,39 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
-    message(STATUS "Including dependency: libcxxabi")
+cmake_minimum_required(VERSION 3.13)
+project(rdtsc C CXX)
 
-    download_dependency(
-        libcxxabi
-        URL          ${LIBCXXABI_URL}
-        URL_MD5      ${LIBCXXABI_URL_MD5}
-    )
+init_project(rdtsc BINARY)
 
-    generate_flags(
-        vmm
-        NOWARNINGS
-    )
+target_sources(rdtsc PRIVATE main.cpp)
+target_link_libraries(rdtsc PRIVATE vmm::bfvmm)
 
-    list(APPEND LIBCXXABI_CONFIGURE_FLAGS
-        -DLLVM_PATH=${CACHE_DIR}/llvm
-        -DLLVM_ENABLE_LIBCXX=ON
-        -DLIBCXXABI_LIBCXX_PATH=${CACHE_DIR}/libcxx
-        -DLIBCXXABI_SYSROOT=${VMM_PREFIX_PATH}
-        -DLIBCXXABI_HAS_PTHREAD_API=ON
-        -DLIBCXXABI_ENABLE_SHARED=OFF
-        -DLIBCXXABI_ENABLE_STATIC=ON
-        -DLIBCXXABI_INCLUDE_TESTS=OFF
-        -DCMAKE_TOOLCHAIN_FILE=${VMM_TOOLCHAIN_PATH}
-        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        -DCXX_SUPPORTS_CXX11=ON
-    )
-
-    add_dependency(
-        libcxxabi vmm
-        CMAKE_ARGS  ${LIBCXXABI_CONFIGURE_FLAGS}
-        DEPENDS     llvm_${VMM_PREFIX}
-        DEPENDS     newlib_${VMM_PREFIX}
-    )
-endif()
+fini_project()

--- a/examples/vpid/CMakeLists.txt
+++ b/examples/vpid/CMakeLists.txt
@@ -19,12 +19,9 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-cmake_minimum_required(VERSION 3.13)
-project(vpid C CXX)
-
-init_project(vpid BINARY)
-
-target_sources(vpid PRIVATE vmm/main.cpp)
-target_link_libraries(vpid PRIVATE vmm::bfvmm)
-
-fini_project()
+if(ENABLE_BUILD_VMM)
+    add_subproject(vpid vmm
+        DEPENDS bfvmm
+        SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/vmm
+    )
+endif()

--- a/examples/vpid/vmm/CMakeLists.txt
+++ b/examples/vpid/vmm/CMakeLists.txt
@@ -19,39 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-if((ENABLE_BUILD_VMM OR ENABLE_BUILD_TEST) AND NOT WIN32)
-    message(STATUS "Including dependency: libcxxabi")
+cmake_minimum_required(VERSION 3.13)
+project(vpid C CXX)
 
-    download_dependency(
-        libcxxabi
-        URL          ${LIBCXXABI_URL}
-        URL_MD5      ${LIBCXXABI_URL_MD5}
-    )
+init_project(vpid BINARY)
 
-    generate_flags(
-        vmm
-        NOWARNINGS
-    )
+target_sources(vpid PRIVATE main.cpp)
+target_link_libraries(vpid PRIVATE vmm::bfvmm)
 
-    list(APPEND LIBCXXABI_CONFIGURE_FLAGS
-        -DLLVM_PATH=${CACHE_DIR}/llvm
-        -DLLVM_ENABLE_LIBCXX=ON
-        -DLIBCXXABI_LIBCXX_PATH=${CACHE_DIR}/libcxx
-        -DLIBCXXABI_SYSROOT=${VMM_PREFIX_PATH}
-        -DLIBCXXABI_HAS_PTHREAD_API=ON
-        -DLIBCXXABI_ENABLE_SHARED=OFF
-        -DLIBCXXABI_ENABLE_STATIC=ON
-        -DLIBCXXABI_INCLUDE_TESTS=OFF
-        -DCMAKE_TOOLCHAIN_FILE=${VMM_TOOLCHAIN_PATH}
-        -DCMAKE_C_FLAGS=${CMAKE_C_FLAGS}
-        -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
-        -DCXX_SUPPORTS_CXX11=ON
-    )
-
-    add_dependency(
-        libcxxabi vmm
-        CMAKE_ARGS  ${LIBCXXABI_CONFIGURE_FLAGS}
-        DEPENDS     llvm_${VMM_PREFIX}
-        DEPENDS     newlib_${VMM_PREFIX}
-    )
-endif()
+fini_project()

--- a/scripts/cmake/macros.cmake
+++ b/scripts/cmake/macros.cmake
@@ -376,6 +376,7 @@ function(add_dependency NAME PREFIX)
             list(APPEND ARGN
                 CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
             )
+            list(APPEND ARGN LOG_DIR ${DEPENDS_DIR}/${NAME}/${PREFIX}/stamp)
         endif()
     else()
         list(APPEND ARGN


### PR DESCRIPTION
Remove the bfdso dependency from libcxx. The dso object is built as a
runtime component to which libcxxabi links in the VMM's final link
step. Removing the subproject dependency ensures that libcxxabi and
libcxx are not checked for changes on every make

Add top-level CMakeLists.txt for each example extension. Now each
example should be able to be built as an external extension, even though
they reside in-tree.

Pass explicit 'LOG_BUILD' to ExternalProject_Add (EPA) so that log files
are written to the stamp directory. Omitting this can cause EPA to
put log files in a non-existent directory in parallel builds.

Signed-off-by: Connor Davis <davisc@ainfosec.com>