### PR TITLE
Cpuid interface

### DIFF
--- a/bfdriver/src/platform/linux/entry.c
+++ b/bfdriver/src/platform/linux/entry.c
@@ -311,7 +311,7 @@ ioctl_vmcall(struct ioctl_vmcall_args_t *user_args)
 
     mutex_lock(&g_status_mutex);
 
-    switch(g_status) {
+    switch (g_status) {
         case STATUS_RUNNING:
             args.reg1 = _vmcall(args.reg1, args.reg2, args.reg3, args.reg4);
             break;
@@ -464,7 +464,7 @@ int
 dev_pm(
     struct notifier_block *nb, unsigned long code, void *unused)
 {
-    switch(code) {
+    switch (code) {
         case PM_SUSPEND_PREPARE:
         case PM_HIBERNATION_PREPARE:
         case PM_RESTORE_PREPARE:

--- a/bfsdk/include/bftypes.h
+++ b/bfsdk/include/bftypes.h
@@ -84,8 +84,12 @@
 
 #ifdef ENABLE_BUILD_TEST
 #define VIRTUAL virtual
+#define PURE = 0
+#define OVERRIDE override
 #else
 #define VIRTUAL
+#define PURE
+#define OVERRIDE
 #endif
 
 /* -------------------------------------------------------------------------- */

--- a/bfvmm/CMakeLists.txt
+++ b/bfvmm/CMakeLists.txt
@@ -49,6 +49,7 @@ add_subdirectory(src/memory_manager)
 add_subdirectory(src/debug)
 
 install(FILES include/vmm.h DESTINATION include/bfvmm)
+install(DIRECTORY include/interface DESTINATION include/bfvmm)
 
 # ------------------------------------------------------------------------------
 # test

--- a/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
+++ b/bfvmm/include/hve/arch/intel_x64/vmexit/cpuid.h
@@ -28,6 +28,7 @@
 #include <bfdelegate.h>
 
 #include "../exit_handler.h"
+#include "../../../../interface/arch/intel_x64/cpuid.h"
 
 // -----------------------------------------------------------------------------
 // Definitions
@@ -40,17 +41,15 @@ class vcpu;
 
 /// CPUID
 ///
-/// Provides an interface for registering handlers for cpuid exits
-/// at a given (leaf, subleaf).
+/// Provides an implementation for registering handlers for cpuid exits
+/// at a given leaf
 ///
 class cpuid_handler
 {
-public:
 
-    /// Leaf type
-    ///
-    ///
-    using leaf_t = uint64_t;
+    using leaf_t = vcpu_cpuid_interface::leaf_t;
+
+public:
 
     /// Constructor
     ///
@@ -59,8 +58,7 @@ public:
     ///
     /// @param vcpu the vcpu object for this handler
     ///
-    cpuid_handler(
-        gsl::not_null<vcpu *> vcpu);
+    cpuid_handler(gsl::not_null<vcpu *> vcpu);
 
     /// Destructor
     ///

--- a/bfvmm/include/interface/arch/intel_x64/cpuid.h
+++ b/bfvmm/include/interface/arch/intel_x64/cpuid.h
@@ -1,0 +1,108 @@
+//
+// Copyright (C) 2019 Assured Information Security, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef BFVMM_INTERFACE_CPUID_INTEL_X64_H
+#define BFVMM_INTERFACE_CPUID_INTEL_X64_H
+
+namespace bfvmm::intel_x64
+{
+
+/// vCPU CPUID Interface
+///
+/// vCPUs that support CPUID virtualization must implement this interface
+///
+class vcpu_cpuid_interface
+{
+
+public:
+
+    /// CPUID leaf type
+    ///
+    ///
+    using leaf_t = uint64_t;
+
+    /// CPUID Add Handler
+    ///
+    /// Add a handler for a CPUID VM exit caused by the given CPUID leaf.
+    ///
+    /// @param leaf the CPUID leaf register handler @param h for
+    /// @param h the handler to call upon a VM exit
+    ///
+    VIRTUAL void cpuid_add_handler(leaf_t leaf, const handler_delegate_t &h) PURE;
+
+    /// CPUID Add Emulator
+    ///
+    /// Add an emulator for a CPUID VM exit caused by the given CPUID leaf.
+    ///
+    /// @param leaf the CPUID leaf register handler @param e for
+    /// @param e the emulator to call upon a VM exit
+    ///
+    VIRTUAL void cpuid_add_emulator(leaf_t leaf, const handler_delegate_t &e) PURE;
+
+    /// CPUID Execute
+    ///
+    /// Execute the CPUID instruction on a physical CPU using the register state
+    /// of a vCPU as inputs and outputs
+    ///
+    /// This function should be called in the context of a CPUID VM exit handler
+    ///
+    VIRTUAL void cpuid_execute() PURE;
+
+    /// CPUID Emulate
+    ///
+    /// Emulate the result of a CPUID instruction using the register state of a
+    /// vCPU as outputs.
+    ///
+    /// This function should be called in the context of a CPUID VM exit handler
+    ///
+    /// @param rax the emulated CPUID output for rax
+    /// @param rbx the emulated CPUID output for rbx
+    /// @param rcx the emulated CPUID output for rcx
+    /// @param rdx the emulated CPUID output for rdx
+    ///
+    VIRTUAL void cpuid_emulate(
+        uint64_t rax, uint64_t rbx, uint64_t rcx, uint64_t rdx) PURE;
+
+    /// CPUID VM Exit Leaf
+    ///
+    /// Get the CPUID leaf (rax) that caused the current VM exit handler to run.
+    ///
+    /// This function should be called in the context of a CPUID VM exit handler
+    ///
+    /// @return the leaf that caused a VM exit to occur
+    ///
+    VIRTUAL leaf_t cpuid_vmexit_leaf() const PURE;
+
+    /// CPUID VM Exit Subleaf
+    ///
+    /// Get the CPUID subleaf (rcx) that caused the current VM exit handler to
+    /// run.
+    ///
+    /// This function should be called in the context of a CPUID VM exit handler
+    ///
+    /// @return the subleaf that caused a VM exit to occur
+    ///
+    VIRTUAL leaf_t cpuid_vmexit_subleaf() const PURE;
+};
+
+}
+
+#endif

--- a/bfvmm/include/test/hve.h
+++ b/bfvmm/include/test/hve.h
@@ -172,10 +172,12 @@ setup_vcpu(MockRepository &mocks, ::intel_x64::vmcs::value_type reason = 0)
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::execute_rdcr3);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::execute_wrcr3);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::execute_wrcr4);
-    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_cpuid_handler);
-    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_cpuid_emulator);
-    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::execute_cpuid);
-    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::enable_cpuid_whitelisting);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_add_handler);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_add_emulator);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_execute);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_emulate);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_vmexit_leaf);
+    mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::cpuid_vmexit_subleaf);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_ept_misconfiguration_handler);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_ept_read_violation_handler);
     mocks.OnCall(vcpu, bfvmm::intel_x64::vcpu::add_ept_write_violation_handler);

--- a/bfvmm/integration/arch/intel_x64/ept/remap_page.cpp
+++ b/bfvmm/integration/arch/intel_x64/ept/remap_page.cpp
@@ -65,7 +65,7 @@ public:
     explicit vcpu(vcpuid::type id) :
         bfvmm::intel_x64::vcpu{id}
     {
-        this->add_cpuid_emulator(
+        this->cpuid_add_emulator(
             42, handler_delegate_t::create<vcpu, &vcpu::test_cpuid_handler>(this)
         );
 

--- a/bfvmm/integration/arch/intel_x64/vmexit/cpuid/trap_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/cpuid/trap_cpuid.cpp
@@ -72,7 +72,7 @@ public:
             vcpu_delegate_t::create<test_hlt_delegate>()
         );
 
-        this->add_cpuid_emulator(
+        this->cpuid_add_emulator(
             42, handler_delegate_t::create<test_cpuid_handler>()
         );
     }

--- a/bfvmm/integration/arch/intel_x64/vmexit/monitor_trap/single_step_cpuid.cpp
+++ b/bfvmm/integration/arch/intel_x64/vmexit/monitor_trap/single_step_cpuid.cpp
@@ -43,7 +43,7 @@ public:
     explicit vcpu(vcpuid::type id) :
         bfvmm::intel_x64::vcpu{id}
     {
-        this->add_cpuid_emulator(
+        this->cpuid_add_emulator(
             42, handler_delegate_t::create<vcpu, &vcpu::cpuid_handler>(this)
         );
 

--- a/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vcpu.cpp
@@ -600,28 +600,6 @@ vcpu::execute_wrcr4()
 { m_control_register_handler.execute_wrcr4(this); }
 
 //--------------------------------------------------------------------------
-// CPUID
-//--------------------------------------------------------------------------
-
-void
-vcpu::add_cpuid_handler(
-    cpuid_handler::leaf_t leaf, const handler_delegate_t &d)
-{ m_cpuid_handler.add_handler(leaf, d); }
-
-void
-vcpu::add_cpuid_emulator(
-    cpuid_handler::leaf_t leaf, const handler_delegate_t &d)
-{ m_cpuid_handler.add_emulator(leaf, d); }
-
-void
-vcpu::execute_cpuid()
-{ m_cpuid_handler.execute(this); }
-
-void
-vcpu::enable_cpuid_whitelisting() noexcept
-{ m_cpuid_handler.enable_whitelisting(); }
-
-//--------------------------------------------------------------------------
 // EPT Misconfiguration
 //--------------------------------------------------------------------------
 

--- a/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
+++ b/bfvmm/src/hve/arch/intel_x64/vmexit/cpuid.cpp
@@ -179,9 +179,6 @@ cpuid_handler::add_emulator(
 void
 cpuid_handler::execute(gsl::not_null<vcpu *> vcpu)
 {
-    vcpu->set_gr1(vcpu->rax());
-    vcpu->set_gr2(vcpu->rcx());
-
     auto [rax, rbx, rcx, rdx] =
         ::x64::cpuid::get(
             gsl::narrow_cast<::x64::cpuid::field_type>(vcpu->rax()),
@@ -227,21 +224,20 @@ execute_emulators(vcpu *vcpu, const std::list<handler_delegate_t> &emulators)
 bool
 cpuid_handler::handle(vcpu *vcpu)
 {
-    const auto &emulators =
-        m_emulators.find(vcpu->rax());
+    vcpu->set_gr1(vcpu->rax());
+    vcpu->set_gr2(vcpu->rcx());
+
+    const auto &emulators = m_emulators.find(vcpu->rax());
 
     if (emulators != m_emulators.end()) {
         return execute_emulators(vcpu, emulators->second);
     }
 
     if (m_whitelist) {
-        vcpu->set_gr1(vcpu->rax());
-        vcpu->set_gr2(vcpu->rcx());
         return false;
     }
 
-    const auto &handlers =
-        m_handlers.find(vcpu->rax());
+    const auto &handlers = m_handlers.find(vcpu->rax());
 
     this->execute(vcpu);
 


### PR DESCRIPTION
This is a follow-up to PR #758, which (to reiterate here) had the following two goals:

1) Attempt to decouple an extension writer's needs from the historically turbulent vCPU class.
2) Translate operations that expose a vCPU's implementation details into more intuitive "english"

This PR proposes an alternative way to accomplish those two goals, without introducing the previous concept of "SDK functions". To summarize the new approach:

* Logical collections of features provided by a vCPU (using CPUID as the first guinea-pig) will be defined by an abstract [interface](https://github.com/JaredWright/hypervisor/blob/af2d5e7187bc68e2c1c989ba88dfd8c5b2372f19/bfvmm/include/interface/arch/intel_x64/cpuid.h) (a class with nothing besides pure virtual functions and type information)
* Each each function in the interface will represent a user need (i.e. use case) for the vCPU
* The interface will strive *not* to expose any implementation details of how each use case is accomplished. For example,  the ```leaf_t cpuid_vmexit_leaf()``` interface function describes a use case (get the CPUID leaf that caused a VM exit), and is implemented under the hood as a less intuitive implementation detail: ```vcpu->gr1()```
* A vCPU will implement each interface that it would like to provide (for example, the base intel_x64::vcpu will provide a specific implementation of the vcpu_cpuid_interface)

There's a couple specific review points that I have questions about, so I'll leave a self-review here shortly to start some conversation