### PR TITLE
Add control register example

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -6,6 +6,7 @@ if(HYPERVISOR_TARGET_ARCH STREQUAL "x86_64")
         # TODO: Add other examples here
         add_subdirectory(intel_x64/bare_minimum)
         add_subdirectory(intel_x64/cpuid)
+        add_subdirectory(intel_x64/control_register)
         add_subdirectory(intel_x64/create_child_vm)
         add_subdirectory(intel_x64/io_port)
         add_subdirectory(intel_x64/memory)

--- a/example/intel_x64/control_register/CMakeLists.txt
+++ b/example/intel_x64/control_register/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+project(control_register_vmm_example CXX)
+
+add_executable(control_register)
+
+target_sources(control_register PRIVATE
+    src/control_register.cpp
+)
+
+target_link_libraries(control_register vmm)
+
+set_target_properties(control_register PROPERTIES
+    SUFFIX ".vmm"
+)
+
+install(TARGETS control_register DESTINATION bin)

--- a/example/intel_x64/control_register/src/control_register.cpp
+++ b/example/intel_x64/control_register/src/control_register.cpp
@@ -1,0 +1,86 @@
+#include <vmm/x64.hpp>
+#include <pal/control_register/cr0.h>
+#include <pal/control_register/cr3.h>
+#include <pal/control_register/cr4.h>
+
+// This example demonstrates how to virtualize control registers on an x64
+// platform using the Bareflank Hypervisor SDK. The example includes emulation
+// for the root virtual machine's cr0, cr3, and cr4.
+//
+// The following behaviors are emulated by this VMM:
+//
+//      - Attempts to disable protected mode (cr0.pe) and paging (cr0.pg) from
+//        within the root virtual machine are transparently blocked by the vmm.
+//
+//      - Reads to cr3 from within the root virtual machine are passed through
+//
+//      - If the root virtual machine writes the value "0x1337" to it's cr3,
+//        the vmm prints its own cr3 out to a serial port
+//
+//      - Attempts to enable virtual machine extensions (cr4.vmxe) from within
+//        root virtual machine are transparently blocked by the vmm.
+
+namespace vmm
+{
+
+void cr0_write_vmexit_handler(x64_vcpu &vcpu) noexcept
+{
+    uint64_t emulated_cr0 = vcpu.cr0_write_vmexit_value_get();
+    pal::cr0::pe::enable(emulated_cr0);
+    pal::cr0::pg::enable(emulated_cr0);
+    vcpu.cr0_write_emulate(emulated_cr0);
+
+    vcpu.instruction_pointer_advance();
+    vcpu.run();
+}
+
+void cr3_read_vmexit_handler(x64_vcpu &vcpu) noexcept
+{
+    vcpu.cr3_read_emulate(0xBADC0FFEE);
+
+    vcpu.instruction_pointer_advance();
+    vcpu.run();
+}
+
+void cr3_write_vmexit_handler(x64_vcpu &vcpu) noexcept
+{
+    uint64_t cr3_value = vcpu.cr3_write_vmexit_value_get();
+    if (cr3_value == 0x1337) {
+        pal::cr3::dump();
+    }
+
+    vcpu.instruction_pointer_advance();
+    vcpu.run();
+}
+
+void cr4_write_vmexit_handler(x64_vcpu &vcpu) noexcept
+{
+    uint64_t emulated_cr4 = vcpu.cr4_write_vmexit_value_get();
+    pal::cr4::vmxe::disable(emulated_cr4);
+    vcpu.cr4_write_emulate(emulated_cr4);
+
+    vcpu.instruction_pointer_advance();
+    vcpu.run();
+}
+
+void root_vcpu_init(x64_vcpu &vcpu) noexcept
+{
+    vcpu.cr0_write_vmexit_handler_set(cr0_write_vmexit_handler);
+    vcpu.cr0_write_vmexit_enable();
+
+    vcpu.cr3_read_vmexit_handler_set(cr0_write_vmexit_handler);
+    vcpu.cr3_read_vmexit_enable();
+    vcpu.cr3_write_vmexit_handler_set(cr0_write_vmexit_handler);
+    vcpu.cr3_write_vmexit_enable();
+
+    vcpu.cr4_write_vmexit_handler_set(cr0_write_vmexit_handler);
+    vcpu.cr4_write_vmexit_enable();
+}
+
+bsl::errc_type vmm_init(x64_vm &root_vm, x64_platform &platform) noexcept
+{
+    root_vm.vcpu_init_handler_set(root_vcpu_init);
+    return 0;
+}
+
+}

--- a/vmm/include/vmm/vcpu/x64/cr0.hpp
+++ b/vmm/include/vmm/vcpu/x64/cr0.hpp
@@ -13,35 +13,35 @@ class cr0
 public:
 
     /// @brief Enable vmexits for all writes to control register cr0
-    virtual void write_cr0_vmexit_enable() noexcept = 0;
+    virtual void cr0_write_vmexit_enable() noexcept = 0;
 
     /// @brief Disable vmexits for all writes to control register cr0
-    virtual void write_cr0_vmexit_disable() noexcept = 0;
+    virtual void cr0_write_vmexit_disable() noexcept = 0;
 
     /// @brief Set a vmexit handler that will be called for all vmexits caused
     ///     by a write to control register cr0 while a vcpu is executing.
     ///
     /// @param func The delegate function to be called
-    virtual void write_cr0_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
+    virtual void cr0_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
 
     /// @brief Returns the value being written to control register cr0 that
     ///     caused a vmexit to occur while a vcpu was executing
     ///
     /// @return The value written to cr0
-    virtual uint64_t write_cr0_vmexit_value_get() noexcept = 0;
+    virtual uint64_t cr0_write_vmexit_value_get() noexcept = 0;
 
     /// @brief Execute (on the vcpu) a write to cr0 that caused a vmexit
     ///     to occur, using the vcpu's registers as the source and destination
     ///     registers for the operation. This allows a user defined vm exit
     ///     handler to pass through a write to a vcpu's cr0.
-    virtual void write_cr0_execute() noexcept = 0;
+    virtual void cr0_write_execute() noexcept = 0;
 
     /// @brief Emulate a write to cr0 that caused a vmexit to occur while a
     ///     vcpu was executing. The given value is written into the vcpu's
     ///     cr0, instead of the value that caused the vm exit to occur. 
     ///
     /// @param cr0_value The value to be written to a vcpu's cr0
-    virtual void write_cr0_emulate(uint64_t cr0_value) noexcept = 0;
+    virtual void cr0_write_emulate(uint64_t cr0_value) noexcept = 0;
 
     virtual ~cr0() noexcept = default;
 protected:

--- a/vmm/include/vmm/vcpu/x64/cr3.hpp
+++ b/vmm/include/vmm/vcpu/x64/cr3.hpp
@@ -11,60 +11,60 @@ class cr3
 public:
 
     /// @brief Enable vmexits for all reads to control register cr3
-    virtual void read_cr3_vmexit_enable() noexcept = 0;
+    virtual void cr3_read_vmexit_enable() noexcept = 0;
 
     /// @brief Disable vmexits for all reads to control register cr3
-    virtual void read_cr3_vmexit_disable() noexcept = 0;
+    virtual void cr3_read_vmexit_disable() noexcept = 0;
 
     /// @brief Set a vmexit handler that will be called for all vmexits caused
     ///     by a read to control register cr3 while a vcpu is executing.
     ///
     /// @param func The delegate function to be called
-    virtual void read_cr3_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
+    virtual void cr3_read_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
 
     /// @brief Execute (on the vcpu) a read from cr3 that caused a vmexit
     ///     to occur, using the vcpu's registers as the source and destination
     ///     registers for the operation. This allows a user defined vm exit
     ///     handler to pass through a read from a vcpu's cr3.
-    virtual void read_cr3_execute() noexcept = 0;
+    virtual void cr3_read_execute() noexcept = 0;
 
     /// @brief Emulate a read from cr3 that caused a vmexit to occur while a
     ///     vcpu was executing. The given value is read into the vcpu's
     ///     destination register, instead of the vcpu's cr3. 
     ///
     /// @param cr3_value The value to be returned to a vcpu as a read from cr3
-    virtual void read_cr3_emulate(uint64_t cr3_value) noexcept = 0;
+    virtual void cr3_read_emulate(uint64_t cr3_value) noexcept = 0;
 
     /// @brief Enable vmexits for all writes to control register cr3
-    virtual void write_cr3_vmexit_enable() noexcept = 0;
+    virtual void cr3_write_vmexit_enable() noexcept = 0;
 
     /// @brief Disable vmexits for all writes to control register cr3
-    virtual void write_cr3_vmexit_disable() noexcept = 0;
+    virtual void cr3_write_vmexit_disable() noexcept = 0;
 
     /// @brief Set a vmexit handler that will be called for all vmexits caused
     ///     by a write to control register cr3 while a vcpu is executing.
     ///
     /// @param func The delegate function to be called
-    virtual void write_cr3_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
+    virtual void cr3_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
 
     /// @brief Returns the value being written to control register cr3 that
     ///     caused a vmexit to occur while a vcpu was executing
     ///
     /// @return The value written to cr3 that caused a vmexit
-    virtual uint64_t write_cr3_vmexit_value_get() noexcept = 0;
+    virtual uint64_t cr3_write_vmexit_value_get() noexcept = 0;
 
     /// @brief Execute (on the vcpu) a write to cr3 that caused a vmexit
     ///     to occur, using the vcpu's registers as the source and destination
     ///     registers for the operation. This allows a user defined vm exit
     ///     handler to pass through a write to a vcpu's cr3.
-    virtual void write_cr3_execute() noexcept = 0;
+    virtual void cr3_write_execute() noexcept = 0;
 
     /// @brief Emulate a write to cr3 that caused a vmexit to occur while a
     ///     vcpu was executing. The given value is written into the vcpu's
     ///     cr3, instead of the value that caused the vm exit to occur. 
     ///
     /// @param cr3_value The value to be written to a vcpu's cr3
-    virtual void write_cr3_emulate(uint64_t cr3_value) noexcept = 0;
+    virtual void cr3_write_emulate(uint64_t cr3_value) noexcept = 0;
 
     virtual ~cr3() noexcept = default;
 protected:

--- a/vmm/include/vmm/vcpu/x64/cr4.hpp
+++ b/vmm/include/vmm/vcpu/x64/cr4.hpp
@@ -11,35 +11,35 @@ class cr4
 public:
 
     /// @brief Enable vmexits for all writes to control register cr4
-    virtual void write_cr4_vmexit_enable() noexcept = 0;
+    virtual void cr4_write_vmexit_enable() noexcept = 0;
 
     /// @brief Disable vmexits for all writes to control register cr4
-    virtual void write_cr4_vmexit_disable() noexcept = 0;
+    virtual void cr4_write_vmexit_disable() noexcept = 0;
 
     /// @brief Set a vmexit handler that will be called for all vmexits caused
     ///     by a write to control register cr4 while a vcpu is executing.
     ///
     /// @param func The delegate function to be called
-    virtual void write_cr4_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
+    virtual void cr4_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
 
     /// @brief Returns the value being written to control register cr4 that
     ///     caused a vmexit to occur while a vcpu was executing
     ///
     /// @return The value written to cr4
-    virtual uint64_t write_cr4_vmexit_value_get() noexcept = 0;
+    virtual uint64_t cr4_write_vmexit_value_get() noexcept = 0;
 
     /// @brief Execute (on the vcpu) a write to cr4 that caused a vmexit
     ///     to occur, using the vcpu's registers as the source and destination
     ///     registers for the operation. This allows a user defined vm exit
     ///     handler to pass through a write to a vcpu's cr4.
-    virtual void write_cr4_execute() noexcept = 0;
+    virtual void cr4_write_execute() noexcept = 0;
 
     /// @brief Emulate a write to cr4 that caused a vmexit to occur while a
     ///     vcpu was executing. The given value is written into the vcpu's
     ///     cr4, instead of the value that caused the vm exit to occur. 
     ///
     /// @param cr4_value The value to be written to a vcpu's cr4
-    virtual void write_cr4_emulate(uint64_t cr4_value) noexcept = 0;
+    virtual void cr4_write_emulate(uint64_t cr4_value) noexcept = 0;
 
     virtual ~cr4() noexcept = default;
 protected:

--- a/vmm/include/vmm/vcpu/x64/xcr0.hpp
+++ b/vmm/include/vmm/vcpu/x64/xcr0.hpp
@@ -13,7 +13,7 @@ public:
     ///     instruction while a vcpu is executing.
     ///
     /// @param func The delegate function to be called
-    virtual void write_xcr0_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
+    virtual void xcr0_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept = 0;
 
     virtual ~xcr0() noexcept = default;
 protected:

--- a/vmm/src/vcpu/x64/intel/intel_cr0.hpp
+++ b/vmm/src/vcpu/x64/intel/intel_cr0.hpp
@@ -11,37 +11,37 @@ class intel_cr0 :
 {
 public:
 
-    void write_cr0_vmexit_enable() noexcept
+    void cr0_write_vmexit_enable() noexcept
     {
         // TODO: Implement Me!
         return;
     }
 
-    void write_cr0_vmexit_disable() noexcept
+    void cr0_write_vmexit_disable() noexcept
     {
         // TODO: Implement Me!
         return;
     }
 
-    void write_cr0_vmexit_handler_set(x64_vcpu_delegate func)
+    void cr0_write_vmexit_handler_set(x64_vcpu_delegate func)
     {
         // TODO: Implement Me!
         return;
     }
 
-    uint64_t write_cr0_vmexit_value_get() noexcept
+    uint64_t cr0_write_vmexit_value_get() noexcept
     {
         // TODO: Implement Me!
         return 0;
     }
 
-    void write_cr0_execute() noexcept
+    void cr0_write_execute() noexcept
     {
         // TODO: Implement Me!
         return;
     }
 
-    void write_cr0_emulate(uint64_t cr0_value) noexcept
+    void cr0_write_emulate(uint64_t cr0_value) noexcept
     {
         // TODO: Implement Me!
         return;

--- a/vmm/src/vcpu/x64/intel/intel_cr3.hpp
+++ b/vmm/src/vcpu/x64/intel/intel_cr3.hpp
@@ -11,57 +11,57 @@ class intel_cr3 :
 {
 public:
 
-    void read_cr3_vmexit_enable() noexcept
+    void cr3_read_vmexit_enable() noexcept
     {
         return;
     }
 
-    void read_cr3_vmexit_disable() noexcept
+    void cr3_read_vmexit_disable() noexcept
     {
         return;
     }
 
-    void read_cr3_vmexit_handler_set(x64_vcpu_delegate func)
+    void cr3_read_vmexit_handler_set(x64_vcpu_delegate func)
     {
         return;
     }
 
-    void read_cr3_execute() noexcept
+    void cr3_read_execute() noexcept
     {
         return;
     }
 
-    void read_cr3_emulate(uint64_t cr3_value) noexcept
+    void cr3_read_emulate(uint64_t cr3_value) noexcept
     {
         return;
     }
 
-    void write_cr3_vmexit_enable() noexcept
+    void cr3_write_vmexit_enable() noexcept
     {
         return;
     }
 
-    void write_cr3_vmexit_disable() noexcept
+    void cr3_write_vmexit_disable() noexcept
     {
         return;
     }
 
-    void write_cr3_vmexit_handler_set(x64_vcpu_delegate func)
+    void cr3_write_vmexit_handler_set(x64_vcpu_delegate func)
     {
         return;
     }
 
-    uint64_t write_cr3_vmexit_value_get() noexcept
+    uint64_t cr3_write_vmexit_value_get() noexcept
     {
         return 0;
     }
 
-    void write_cr3_execute() noexcept
+    void cr3_write_execute() noexcept
     {
         return;
     }
 
-    void write_cr3_emulate(uint64_t cr3_value) noexcept
+    void cr3_write_emulate(uint64_t cr3_value) noexcept
     {
         return;
     }

--- a/vmm/src/vcpu/x64/intel/intel_cr4.hpp
+++ b/vmm/src/vcpu/x64/intel/intel_cr4.hpp
@@ -11,32 +11,32 @@ class intel_cr4 :
 {
 public:
 
-    void write_cr4_vmexit_enable() noexcept
+    void cr4_write_vmexit_enable() noexcept
     {
         return;
     }
 
-    void write_cr4_vmexit_disable() noexcept
+    void cr4_write_vmexit_disable() noexcept
     {
         return;
     }
 
-    void write_cr4_vmexit_handler_set(x64_vcpu_delegate func)
+    void cr4_write_vmexit_handler_set(x64_vcpu_delegate func)
     {
         return;
     }
 
-    uint64_t write_cr4_vmexit_value_get() noexcept
+    uint64_t cr4_write_vmexit_value_get() noexcept
     {
         return 0;
     }
 
-    void write_cr4_execute() noexcept
+    void cr4_write_execute() noexcept
     {
         return;
     }
 
-    void write_cr4_emulate(uint64_t cr4_value) noexcept
+    void cr4_write_emulate(uint64_t cr4_value) noexcept
     {
         return;
     }

--- a/vmm/src/vcpu/x64/intel/intel_xcr0.hpp
+++ b/vmm/src/vcpu/x64/intel/intel_xcr0.hpp
@@ -11,7 +11,7 @@ class intel_xcr0 :
 {
 public:
 
-    void write_xcr0_vmexit_handler_set(x64_vcpu_delegate func)
+    void xcr0_write_vmexit_handler_set(x64_vcpu_delegate func)
     {
         // TODO: Implement Me!
         return;

--- a/vmm/src/vcpu/x64/x64_vcpu_seam.hpp
+++ b/vmm/src/vcpu/x64/x64_vcpu_seam.hpp
@@ -82,76 +82,76 @@ public:
     { return m_cpuid.cpuid_emulate(eax, ebx, ecx, edx); }
 
     // ------------------------------ cr0 seam ---------------------------------
-    void write_cr0_vmexit_enable() noexcept final
-    { return m_cr0.write_cr0_vmexit_enable(); }
+    void cr0_write_vmexit_enable() noexcept final
+    { return m_cr0.cr0_write_vmexit_enable(); }
 
-    void write_cr0_vmexit_disable() noexcept final
-    { return m_cr0.write_cr0_vmexit_disable(); }
+    void cr0_write_vmexit_disable() noexcept final
+    { return m_cr0.cr0_write_vmexit_disable(); }
 
-    void write_cr0_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
-    { return m_cr0.write_cr0_vmexit_handler_set(func); }
+    void cr0_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
+    { return m_cr0.cr0_write_vmexit_handler_set(func); }
 
-    uint64_t write_cr0_vmexit_value_get() noexcept final
-    { return m_cr0.write_cr0_vmexit_value_get(); }
+    uint64_t cr0_write_vmexit_value_get() noexcept final
+    { return m_cr0.cr0_write_vmexit_value_get(); }
 
-    void write_cr0_execute() noexcept final
-    { return m_cr0.write_cr0_execute(); }
+    void cr0_write_execute() noexcept final
+    { return m_cr0.cr0_write_execute(); }
 
-    void write_cr0_emulate(uint64_t cr0_value) noexcept final
-    { return m_cr0.write_cr0_emulate(cr0_value); }
+    void cr0_write_emulate(uint64_t cr0_value) noexcept final
+    { return m_cr0.cr0_write_emulate(cr0_value); }
 
     // ------------------------------ cr3 seam ---------------------------------
-    void read_cr3_vmexit_enable() noexcept final
-    { return m_cr3.read_cr3_vmexit_enable(); }
+    void cr3_read_vmexit_enable() noexcept final
+    { return m_cr3.cr3_read_vmexit_enable(); }
 
-    void read_cr3_vmexit_disable() noexcept final
-    { return m_cr3.read_cr3_vmexit_disable(); }
+    void cr3_read_vmexit_disable() noexcept final
+    { return m_cr3.cr3_read_vmexit_disable(); }
 
-    void read_cr3_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
-    { return m_cr3.read_cr3_vmexit_handler_set(func); }
+    void cr3_read_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
+    { return m_cr3.cr3_read_vmexit_handler_set(func); }
 
-    void read_cr3_execute() noexcept final
-    { return m_cr3.read_cr3_execute(); }
+    void cr3_read_execute() noexcept final
+    { return m_cr3.cr3_read_execute(); }
 
-    void read_cr3_emulate(uint64_t cr3_value) noexcept final
-    { return m_cr3.read_cr3_emulate(cr3_value); }
+    void cr3_read_emulate(uint64_t cr3_value) noexcept final
+    { return m_cr3.cr3_read_emulate(cr3_value); }
 
-    void write_cr3_vmexit_enable() noexcept final
-    { return m_cr3.write_cr3_vmexit_enable(); }
+    void cr3_write_vmexit_enable() noexcept final
+    { return m_cr3.cr3_write_vmexit_enable(); }
 
-    void write_cr3_vmexit_disable() noexcept final
-    { return m_cr3.write_cr3_vmexit_disable(); }
+    void cr3_write_vmexit_disable() noexcept final
+    { return m_cr3.cr3_write_vmexit_disable(); }
 
-    void write_cr3_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
-    { return m_cr3.write_cr3_vmexit_handler_set(func); }
+    void cr3_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
+    { return m_cr3.cr3_write_vmexit_handler_set(func); }
 
-    uint64_t write_cr3_vmexit_value_get() noexcept final
-    { return m_cr3.write_cr3_vmexit_value_get(); }
+    uint64_t cr3_write_vmexit_value_get() noexcept final
+    { return m_cr3.cr3_write_vmexit_value_get(); }
 
-    void write_cr3_execute() noexcept final
-    { return m_cr3.write_cr3_execute(); }
+    void cr3_write_execute() noexcept final
+    { return m_cr3.cr3_write_execute(); }
 
-    void write_cr3_emulate(uint64_t cr3_value) noexcept final
-    { return m_cr3.write_cr3_emulate(cr3_value); }
+    void cr3_write_emulate(uint64_t cr3_value) noexcept final
+    { return m_cr3.cr3_write_emulate(cr3_value); }
 
     // ------------------------------ cr4 seam ---------------------------------
-    void write_cr4_vmexit_enable() noexcept final
-    { return m_cr4.write_cr4_vmexit_enable(); }
+    void cr4_write_vmexit_enable() noexcept final
+    { return m_cr4.cr4_write_vmexit_enable(); }
 
-    void write_cr4_vmexit_disable() noexcept final
-    { return m_cr4.write_cr4_vmexit_disable(); }
+    void cr4_write_vmexit_disable() noexcept final
+    { return m_cr4.cr4_write_vmexit_disable(); }
 
-    void write_cr4_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
-    { return m_cr4.write_cr4_vmexit_handler_set(func); }
+    void cr4_write_vmexit_handler_set(x64_vcpu_delegate func) noexcept final
+    { return m_cr4.cr4_write_vmexit_handler_set(func); }
 
-    uint64_t write_cr4_vmexit_value_get() noexcept final
-    { return m_cr4.write_cr4_vmexit_value_get(); }
+    uint64_t cr4_write_vmexit_value_get() noexcept final
+    { return m_cr4.cr4_write_vmexit_value_get(); }
 
-    void write_cr4_execute() noexcept final
-    { return m_cr4.write_cr4_execute(); }
+    void cr4_write_execute() noexcept final
+    { return m_cr4.cr4_write_execute(); }
 
-    void write_cr4_emulate(uint64_t cr4_value) noexcept final
-    { return m_cr4.write_cr4_emulate(cr4_value); }
+    void cr4_write_emulate(uint64_t cr4_value) noexcept final
+    { return m_cr4.cr4_write_emulate(cr4_value); }
 
     // ----------------------- general register seam ---------------------------
     uint64_t rax_get() noexcept
@@ -482,8 +482,8 @@ public:
     { return m_wrmsr.wrmsr_emulate(value); }
 
     // ------------------------------ xcr0 seam --------------------------------
-    void write_xcr0_vmexit_handler_set(x64_vcpu_delegate func)
-    { return m_xcr0.write_xcr0_vmexit_handler_set(func); }
+    void xcr0_write_vmexit_handler_set(x64_vcpu_delegate func)
+    { return m_xcr0.xcr0_write_vmexit_handler_set(func); }
 
 private:
     execute_type m_execute{};


### PR DESCRIPTION
1) Add an example that virtualizes cr0, cr3, and cr4 of a root vm

2) Update the vcpu's control register interfaces to support readablility
   of the example, and naming convention consistency with the other vcpu
   interfaces

Signed-off-by: JaredWright <jared.wright12@gmail.com>