### PR TITLE
Memory Types + Bump PAL Version

### DIFF
--- a/cmake/depend/pal.cmake
+++ b/cmake/depend/pal.cmake
@@ -3,7 +3,7 @@ message(STATUS "Adding dependency: pal")
 FetchContent_Declare(
     pal
     GIT_REPOSITORY  https://github.com/bareflank/pal.git
-    GIT_TAG         20.03.1
+    GIT_TAG         20.04.1
 )
 
 FetchContent_GetProperties(pal)

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -14,9 +14,7 @@ if(HYPERVISOR_TARGET_ARCH STREQUAL "x86_64")
         add_subdirectory(intel_x64/properties)
         add_subdirectory(intel_x64/vmcall)
         add_subdirectory(intel_x64/vmexit)
-
-        # PAL needs a few bug fixes before this example will compile:
-        # add_subdirectory(intel_x64/vmcs)
+        add_subdirectory(intel_x64/vmcs)
     endif()
 endif()
 

--- a/example/intel_x64/memory/src/memory.cpp
+++ b/example/intel_x64/memory/src/memory.cpp
@@ -4,6 +4,7 @@
 namespace vmm
 {
 
+constexpr const uint32_t SIZE_4KB = 0x1000;
 constexpr const uint32_t SIZE_16KB = 0x4000;
 constexpr const uint32_t SIZE_4MB = 0x400000;
 constexpr const uint32_t SIZE_1GB = 0x40000000;
@@ -19,7 +20,14 @@ bsl::errc_type vmm_init(x64_vm &root_vm, x64_platform &platform) noexcept
 
     // Allocate a virtual address space of 4 MB that is mapped to the physical
     // address 0xBEEF0000, using 2 MB page granularity.
-    uint32_t * bytes_3 = hva_map_alloc<uint32_t>(0xBEEF0000, SIZE_4MB, page_size::page_2m);
+    uint32_t * bytes_3 = hva_map_alloc<uint32_t>(0xBEEF0000, SIZE_4MB,
+                             page_size::page_2m);
+
+    // Allocate a virtual address space of 4 KB that is mapped to uncacheable
+    // (device) memory at the physical address 0xCAFE0000, using 4 KB page
+    // granularity.
+    uint32_t * bytes_4 = hva_map_alloc<uint32_t>(0xCAFE0000, SIZE_4KB,
+                             page_size::page_4k, memory_type::uncacheable);
 
     // Resolve the host physical address that "bytes_2" is mapped to, which
     // will give 0xF00D0000
@@ -29,6 +37,7 @@ bsl::errc_type vmm_init(x64_vm &root_vm, x64_platform &platform) noexcept
     hva_free(bytes_1);
     hva_free(bytes_2);
     hva_free(bytes_3);
+    hva_free(bytes_4);
 
     return 0;
 }

--- a/example/intel_x64/vmcs/src/vmcs.cpp
+++ b/example/intel_x64/vmcs/src/vmcs.cpp
@@ -21,7 +21,7 @@ void root_vcpu_init(x64_vcpu &vcpu) noexcept
     // Or you can read and write using intermediate integer values:
     auto reason = pal::exit_reason::get();
     auto basic_reason = pal::exit_reason::basic_exit_reason::get(reason);
-    auto vmentry_failure = pal::exit_reason::vm_entry_failure::get(reason);
+    auto vmentry_failure = pal::exit_reason::vm_entry_failure::is_enabled(reason);
 
     return;
 }

--- a/vmm/include/inttypes.h
+++ b/vmm/include/inttypes.h
@@ -1,1 +1,0 @@
-// TODO: Remove this dummy header once PAL supports printing via the bsl

--- a/vmm/include/stdio.h
+++ b/vmm/include/stdio.h
@@ -1,1 +1,0 @@
-// TODO: Remove this dummy header once PAL supports printing via the bsl

--- a/vmm/include/vmm/memory/memory_type.hpp
+++ b/vmm/include/vmm/memory/memory_type.hpp
@@ -1,0 +1,16 @@
+#ifndef VMM_MEMORY_MEMORY_TYPE_HPP
+#define VMM_MEMORY_MEMORY_TYPE_HPP
+
+namespace vmm
+{
+
+/// @brief Defines the memory types (i.e. caching methods) supported by the
+///     vmm's memory interfaces
+enum class memory_type {
+    uncacheable,
+    write_back
+};
+
+}
+
+#endif

--- a/vmm/include/vmm/memory/page_size.hpp
+++ b/vmm/include/vmm/memory/page_size.hpp
@@ -4,6 +4,8 @@
 namespace vmm
 {
 
+/// @brief Defines the page sizes (mapping granularities) supported by the
+///     vmm's memory interfaces
 enum class page_size {
     page_4k=0x1000,
     page_2m=0x200000,

--- a/vmm/include/vmm/memory/vmm_memory.hpp
+++ b/vmm/include/vmm/memory/vmm_memory.hpp
@@ -2,6 +2,7 @@
 #define VMM_MEMORY_VMM_MEMORY_HPP
 
 #include <vmm/memory/page_size.hpp>
+#include <vmm/memory/memory_type.hpp>
 #include <bsl/cstdint.hpp>
 #include <bsl/errc_type.hpp>
 
@@ -26,15 +27,19 @@ T * hva_alloc(uintmax_t size)
 
 /// @brief Allocate a host virtual address mapping of @param size bytes to the
 ///     given host physical address, using the optional page size as a
-///     granularity for the mapping (defaults to 4 KB)
+///     granularity for the mapping (defaults to 4 KB), and optional memory
+///     type (defaults to write-back)
 ///
 /// @param hpa The host physical address to a create a mapping to
 /// @param size The size of the mapping, in bytes
 /// @param ps The page size (granularity) to be used for the mapping.
+/// @param mt The memory type (caching method) to be used for the mapping.
 ///
 /// @return A host virtual address that may be used to access the mapped host
 ///     physical address range
-void * hva_map_alloc(uintptr_t hpa, uintmax_t size, page_size ps=page_size::page_4k);
+void * hva_map_alloc(uintptr_t hpa, uintmax_t size,
+                        page_size ps=page_size::page_4k,
+                        memory_type mt=memory_type::write_back);
 
 /// @brief Allocate a host virtual address mapping of @param size bytes to the
 ///     given host physical address, using the optional page size as a
@@ -47,8 +52,10 @@ void * hva_map_alloc(uintptr_t hpa, uintmax_t size, page_size ps=page_size::page
 /// @return A host virtual address that may be used to access the mapped host
 ///     physical address range
 template<typename T>
-T * hva_map_alloc(uintptr_t hpa, uintmax_t size, page_size ps=page_size::page_4k)
-{ return static_cast<T*>(hva_map_alloc(hpa, size, ps)); }
+T * hva_map_alloc(uintptr_t hpa, uintmax_t size,
+                    page_size ps=page_size::page_4k,
+                    memory_type mt=memory_type::write_back)
+{ return static_cast<T*>(hva_map_alloc(hpa, size, ps, mt)); }
   
 /// @brief Free the given host virtual address
 ///

--- a/vmm/src/memory/x64/x64_vmm_memory.cpp
+++ b/vmm/src/memory/x64/x64_vmm_memory.cpp
@@ -9,7 +9,7 @@ void * hva_alloc(uintmax_t size)
     return static_cast<void *>(nullptr);
 }
 
-void * hva_map_alloc(uintptr_t hpa, uintmax_t size, page_size ps)
+void * hva_map_alloc(uintptr_t hpa, uintmax_t size, page_size ps, memory_type mt)
 {
     // TODO: Implement Me!
     return static_cast<void *>(nullptr);


### PR DESCRIPTION
1) Add memory types to vmm memory interfaces for mapping host-virtual to host-physical addresses
2) Bump PAL to version 20.04.1 to fix VMCS accessor issues