### PR TITLE
Fix Windows + Cmake

### DIFF
--- a/PreLoad.cmake
+++ b/PreLoad.cmake
@@ -1,4 +1,5 @@
-# Ninja is the only supported CMake generator on Windows
+# Ninja is the hypervisor's only supported CMake generator on Windows
+# Override the user's command line settings if any other generator is specified
 if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Windows)
     message(STATUS "Using CMake Generator: Ninja")
     set(CMAKE_GENERATOR "Ninja" CACHE INTERNAL "")
@@ -9,42 +10,48 @@ if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL Darwin)
     set(HAVE_FLAG_SEARCH_PATHS_FIRST 0 CACHE INTERNAL "")
 endif()
 
-# Default to the project's built in clang toolchain
+# Default to the project's built in clang toolchain if not specified
 if(NOT CMAKE_TOOLCHAIN_FILE)
-    # Default the C compiler to Clang
+
+    # Default the C compiler to Clang if not specified
     if(NOT CMAKE_C_COMPILER)
 
         if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-            find_program(CLANG_BIN llvm-clang)
+            set(CMAKE_C_COMPILER llvm-clang)
         else()
-            find_program(CLANG_BIN clang)
-        endif()
-
-        if(CLANG_BIN)
-            set(CMAKE_C_COMPILER ${CLANG_BIN} CACHE INTERNAL "")
-            set(CMAKE_ASM-ATT_COMPILER ${CLANG_BIN} CACHE INTERNAL "")
-        else()
-            message(FATAL_ERROR "Unable to find default C compiler: clang")
+            set(CMAKE_C_COMPILER clang)
         endif()
 
     endif()
 
-    # Default the C++ compiler and linker to Clang++
+    find_program(CLANG_BIN ${CMAKE_C_COMPILER})
+
+    if(CLANG_BIN)
+        set(CMAKE_C_COMPILER ${CLANG_BIN} CACHE INTERNAL "")
+        set(CMAKE_ASM-ATT_COMPILER ${CLANG_BIN} CACHE INTERNAL "")
+    else()
+        message(FATAL_ERROR "Unable to find C compiler: ${CMAKE_C_COMPILER}")
+    endif()
+
+    # Default the C++ compiler and linker to Clang++ if not specified
     if(NOT CMAKE_CXX_COMPILER)
 
         if(CMAKE_HOST_SYSTEM_NAME STREQUAL Darwin)
-            find_program(CLANG++_BIN llvm-clang++)
+            set(CMAKE_CXX_COMPILER llvm-clang++)
         else()
-            find_program(CLANG++_BIN clang++)
-        endif()
-
-        if(CLANG++_BIN)
-            set(CMAKE_CXX_COMPILER ${CLANG++_BIN} CACHE INTERNAL "")
-        else()
-            message(FATAL_ERROR "Unable to find default C++ compiler: clang++")
+            set(CMAKE_CXX_COMPILER clang++)
         endif()
 
     endif()
 
+    find_program(CLANG++_BIN ${CMAKE_CXX_COMPILER})
+
+    if(CLANG++_BIN)
+        set(CMAKE_CXX_COMPILER ${CLANG++_BIN} CACHE INTERNAL "")
+    else()
+        message(FATAL_ERROR "Unable to find C++ compiler: ${CMAKE_CXX_COMPILER}")
+    endif()
+
     set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_LIST_DIR}/cmake/toolchain/clang.cmake CACHE INTERNAL "")
+
 endif()

--- a/kernel/CMakeLists.txt
+++ b/kernel/CMakeLists.txt
@@ -15,6 +15,7 @@ target_compile_options(kernel PRIVATE
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fno-rtti>"
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-nostdlib>"
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-nostdlibinc>"
+    "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-mno-red-zone>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:--target=x86_64-unknown-linux-gnu>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:-march=core2>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},AMD64>:--target=x86_64-unknown-linux-gnu>"
@@ -32,6 +33,8 @@ target_link_options(kernel PRIVATE
     "-Wl,-zmax-page-size=0x1000"
     "-Wl,-znoexecstack"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:--target=x86_64-unknown-linux-gnu>"
+    "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},AMD64>:--target=x86_64-unknown-linux-gnu>"
+    "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},armv8a>:--target=aarch64-unknown-linux-gnu>"
 )
 
 target_include_directories(kernel PRIVATE
@@ -39,10 +42,6 @@ target_include_directories(kernel PRIVATE
 )
 
 target_link_libraries(kernel bsl pal)
-
-set_target_properties(kernel PROPERTIES
-    SUFFIX ".vmm"
-)
 
 if(NOT HYPERVISOR_BUILD_KERNEL)
     set_target_properties(kernel PROPERTIES

--- a/microv/CMakeLists.txt
+++ b/microv/CMakeLists.txt
@@ -37,6 +37,7 @@ target_compile_options(microv PUBLIC
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-fno-rtti>"
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-nostdlib>"
     "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-nostdlibinc>"
+    "$<$<OR:$<COMPILE_LANGUAGE:C>,$<COMPILE_LANGUAGE:CXX>>:-mno-red-zone>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:--target=x86_64-unknown-linux-gnu>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:-march=core2>"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},AMD64>:--target=x86_64-unknown-linux-gnu>"
@@ -54,6 +55,8 @@ target_link_options(microv PUBLIC
     "-Wl,-zmax-page-size=0x1000"
     "-Wl,-znoexecstack"
     "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},x86_64>:--target=x86_64-unknown-linux-gnu>"
+    "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},AMD64>:--target=x86_64-unknown-linux-gnu>"
+    "$<$<STREQUAL:${HYPERVISOR_TARGET_ARCH},armv8a>:--target=aarch64-unknown-linux-gnu>"
 )
 
 target_include_directories(microv PUBLIC


### PR DESCRIPTION
1) Update PreLoad.cmake to correctly use user-defined compilers
2) Update linker flags in kernel and microv components for AMD64
3) Add -mno-red-zone to compiler flags in kernel and microv components

Signed-off-by: JaredWright <jared.wright12@gmail.com>