### PR TITLE
vcpu: Fix xsave init bugs

### DIFF
--- a/bfintrinsics/include/arch/intel_x64/crs.h
+++ b/bfintrinsics/include/arch/intel_x64/crs.h
@@ -44,6 +44,7 @@ extern "C" void _write_cr4(uint64_t val) noexcept;
 extern "C" uint64_t _read_cr8(void) noexcept;
 extern "C" void _write_cr8(uint64_t val) noexcept;
 
+extern "C" uint64_t _read_xcr0() noexcept;
 extern "C" void _write_xcr0(uint64_t val) noexcept;
 
 // *INDENT-OFF*
@@ -1190,6 +1191,9 @@ namespace xcr0
     constexpr const auto name = "xcr0";
 
     using value_type = uint64_t;
+
+    inline uint64_t get() noexcept
+    { return _read_xcr0(); }
 
     inline void set(value_type val) noexcept
     { _write_xcr0(val); }

--- a/bfintrinsics/src/arch/intel_x64/crs.asm
+++ b/bfintrinsics/src/arch/intel_x64/crs.asm
@@ -74,6 +74,15 @@ _write_cr8:
     mov cr8, rdi
     ret
 
+global _read_xcr0
+_read_xcr0:
+    mov rcx, 0
+    xgetbv
+    shl rdx, 32
+    or rax, rdx
+
+    ret
+
 global _write_xcr0
 _write_xcr0:
     mov rax, rdi

--- a/bfvmm/include/hve/arch/intel_x64/vcpu.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu.h
@@ -161,6 +161,7 @@ public:
 
 private:
 
+    void init_xsave();
     void write_host_state();
     void write_guest_state();
     void write_control_state();


### PR DESCRIPTION
Subleaf 0x1 of leaf 0xD reports the size of the xsave area needed
by the currently enabled features in (XCR0 | IA32_XSS). This patch
ensures that XCR0 and IA32_XSS contain the maximum number of bits set
as reported by CPUID before reading the size.

The old code was using the values without first setting them to their
maximum allowed value. However since the size returned is rounded up to
at least 4KB, it would never be a problem as long as the max xsave area
is less than 4KB as well.

This patch also fixes an issue where the xsave CPUID leaf was being read
before checking that the feature is implmented (as reported by leaf 1).