### PR TITLE
Adds single core launch support for AMD

### DIFF
--- a/cmake/target/loader_build.cmake
+++ b/cmake/target/loader_build.cmake
@@ -23,10 +23,12 @@ if(HYPERVISOR_BUILD_LOADER)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_custom_target(loader_build
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux make
+            COMMAND sync
             VERBATIM
         )
         add_custom_target(driver_build
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux make
+            COMMAND sync
             VERBATIM
         )
     endif()

--- a/cmake/target/loader_clean.cmake
+++ b/cmake/target/loader_clean.cmake
@@ -24,11 +24,13 @@ if(HYPERVISOR_BUILD_LOADER)
         add_custom_target(loader_clean
             COMMAND ${CMAKE_COMMAND} --build . --target loader_unload
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux make clean
+            COMMAND sync
             VERBATIM
         )
         add_custom_target(driver_clean
             COMMAND ${CMAKE_COMMAND} --build . --target loader_unload
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux make clean
+            COMMAND sync
             VERBATIM
         )
     endif()

--- a/cmake/target/loader_unload.cmake
+++ b/cmake/target/loader_unload.cmake
@@ -22,10 +22,12 @@
 if(HYPERVISOR_BUILD_LOADER)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_custom_target(loader_unload
+            COMMAND sync
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux sudo make unload
             VERBATIM
         )
         add_custom_target(driver_unload
+            COMMAND sync
             COMMAND ${CMAKE_COMMAND} -E chdir ${CMAKE_CURRENT_LIST_DIR}/../../loader/linux sudo make unload
             VERBATIM
         )

--- a/cmake/target/start.cmake
+++ b/cmake/target/start.cmake
@@ -22,6 +22,7 @@
 if(HYPERVISOR_BUILD_VMMCTL)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_custom_target(start
+            COMMAND sync
             COMMAND sudo vmmctl/vmmctl start
             VERBATIM
         )

--- a/cmake/target/stop.cmake
+++ b/cmake/target/stop.cmake
@@ -22,6 +22,7 @@
 if(HYPERVISOR_BUILD_VMMCTL)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_custom_target(stop
+            COMMAND sync
             COMMAND sudo vmmctl/vmmctl stop
             VERBATIM
         )

--- a/loader/include/loader.h
+++ b/loader/include/loader.h
@@ -30,6 +30,13 @@
 #include <loader_types.h>
 
 /**
+ * @brief Returned by a loader function when an error occurs. Note that
+ *   functions that are responsible for stopping the hypervisor, in general,
+ *   should never return an error.
+ */
+#define LOADER_FAILURE (-1)
+
+/**
  * <!-- description -->
  *   @brief This function contains all of the code that is common between
  *     all archiectures and all platforms that is needed for initializing

--- a/loader/include/loader_platform.h
+++ b/loader/include/loader_platform.h
@@ -42,7 +42,7 @@
  *   @return Returns a pointer to the newly allocated memory on success.
  *     Returns a nullptr on failure.
  */
-void *platform_alloc(uint64_t size);
+void *platform_alloc(uintmax_t const size);
 
 /**
  * <!-- description -->
@@ -56,7 +56,7 @@ void *platform_alloc(uint64_t size);
  *   @param size the number of bytes that were allocated. Note that this
  *     may or may not be ignored depending on the platform.
  */
-void platform_free(void *ptr, uint64_t size);
+void platform_free(void *const ptr, uintmax_t const size);
 
 /**
  * <!-- description -->
@@ -68,7 +68,8 @@ void platform_free(void *ptr, uint64_t size);
  *   @return Given a virtual address, this function returns the virtual
  *     address's physical address. Returns NULL if the conversion failed.
  */
-uintptr_t platform_virt_to_phys(uintptr_t virt);
+uintptr_t platform_virt_to_phys(void const *const virt);
+
 /**
  * <!-- description -->
  *   @brief Sets "num" bytes in the memory pointed to by "ptr" to "val".
@@ -82,7 +83,7 @@ uintptr_t platform_virt_to_phys(uintptr_t virt);
  *   @return If the provided parameters are valid, returns 0, otherwise
  *     returns FAILURE.
  */
-int64_t platform_memset(void *ptr, char val, uint64_t num);
+int64_t platform_memset(void *const ptr, uint8_t const val, uintmax_t const num);
 
 /**
  * <!-- description -->
@@ -96,12 +97,12 @@ int64_t platform_memset(void *ptr, char val, uint64_t num);
  *   @return If "src" or "dst" are NULL, returns FAILURE, otherwise
  *     returns 0.
  */
-int64_t platform_memcpy(void *dst, const void *src, uint64_t num);
+int64_t platform_memcpy(void *const dst, void const *const src, uintmax_t const num);
 
 /**
  * @brief The callback signature for platform_on_each_cpu
  */
-typedef int64_t (*platform_per_cpu_func)(uint32_t);
+typedef int64_t (*platform_per_cpu_func)(uint32_t const);
 
 /**
  * <!-- description -->
@@ -118,6 +119,6 @@ typedef int64_t (*platform_per_cpu_func)(uint32_t);
  *   @return If each callback returns 0, this function returns 0, otherwise
  *     this function returns a non-0 value
  */
-int64_t platform_on_each_cpu(platform_per_cpu_func func, int reverse);
+int64_t platform_on_each_cpu(platform_per_cpu_func const func, uint32_t const reverse);
 
 #endif

--- a/loader/include/x64/amd/loader_arch.h
+++ b/loader/include/x64/amd/loader_arch.h
@@ -99,4 +99,19 @@ int64_t arch_stop_vmm_per_cpu(           // --
  */
 int64_t arch_check_hve_support(void);
 
+/**
+ * <!-- description -->
+ *   @brief Remove me
+ */
+void arch_init_serial(void);
+
+/**
+ * <!-- description -->
+ *   @brief Remove me
+ *
+ * <!-- inputs/outputs -->
+ *   @param str the msg to write to serial
+ */
+void arch_write_serial(char const *const str);
+
 #endif

--- a/loader/include/x64/amd/loader_arch_context.h
+++ b/loader/include/x64/amd/loader_arch_context.h
@@ -27,8 +27,11 @@
 #ifndef LOADER_ARCH_CONTEXT_H
 #define LOADER_ARCH_CONTEXT_H
 
+#include <vmcb_t.h>
+#include <state_save_t.h>
 #include <loader_types.h>
-#include <tmp_vmcb.h>
+
+#pragma pack(push, 1)
 
 /**
  * @class loader_arch_context_t
@@ -40,24 +43,51 @@
 struct loader_arch_context_t
 {
     /** @brief store the architecture's page size */
-    uint64_t page_size;
+    uintptr_t page_size;    // 0x00
     /** @brief stores number of physical address bits supported */
-    uint32_t physical_address_bits;
+    uintptr_t physical_address_bits;    // 0x08
+
+    /** @brief stores a pointer to the stack the host will use */
+    void *host_stack;    // 0x10
+    /** @brief stores the size of the host's stack */
+    uintptr_t host_stack_size;    // 0x18
 
     /** @brief stores the virtual address of the host vmcb */
-    struct vmcb_t *host_vmcb_virt;
+    struct vmcb_t *host_vmcb;    // 0x20
     /** @brief stores the physical address of the host vmcb */
-    uintptr_t host_vmcb_phys;
+    uintptr_t host_vmcb_phys;    // 0x28
 
     /** @brief stores the virtual address of the guest vmcb */
-    struct vmcb_t *guest_vmcb_virt;
+    struct vmcb_t *guest_vmcb;    // 0x30
     /** @brief stores the physical address of the guest vmcb */
-    uintptr_t guest_vmcb_phys;
+    uintptr_t guest_vmcb_phys;    // 0x38
 
     /** @brief stores the virtual address of the host state save */
-    void *host_state_save_virt;
+    struct state_save_t *host_save;    // 0x40
     /** @brief stores the physical address of the host state save */
-    uintptr_t host_state_save_phys;
+    uintptr_t host_save_phys;    // 0x48
+
+    /** @brief stores the virtual address of the guest state save */
+    struct state_save_t *guest_save;    // 0x50
+    /** @brief stores the physical address of the guest state save */
+    uintptr_t guest_save_phys;    // 0x58
+
+    /** @brief stores the virtual address of the host xsave area */
+    void *host_xsave;    // 0x60
+    /** @brief stores the physical address of the host xsave area */
+    uintptr_t host_xsave_phys;    // 0x68
+
+    /** @brief stores the virtual address of the guest xsave area */
+    void *guest_xsave;    // 0x70
+    /** @brief stores the physical address of the guest xsave area */
+    uintptr_t guest_xsave_phys;    // 0x78
+
+    /** @brief stores the address of the exit handler */
+    void *exit_handler;    // 0x80
 };
+
+_Static_assert(sizeof(struct loader_arch_context_t) == 0x88, "");
+
+#pragma pack(pop)
 
 #endif

--- a/loader/include/x64/amd/state_save_t.h
+++ b/loader/include/x64/amd/state_save_t.h
@@ -1,0 +1,95 @@
+/**
+ * @copyright
+ * Copyright (C) 2020 Assured Information Security, Inc.
+ *
+ * @copyright
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * @copyright
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * @copyright
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef STATE_SAVE_T
+#define STATE_SAVE_T
+
+#pragma pack(push, 1)
+
+#include <loader_types.h>
+
+/**
+ * @class state_save_t
+ *
+ * <!-- description -->
+ *   @brief The following defines the structure of the state save area for
+ *     the guest and the host. For the guest, we need to store state that
+ *     the VMRUN function does not save for us. For the host, we need to
+ *     provide a page of memory that the VMRUN function can save to as it
+ *     sees fit. Since we do not know what the format of the state save is
+ *     on AMD and you are not allowed to touch the host's state save area,
+ *     on the host, this structure only serves to reseve memory. The fields
+ *     only make sense for the guest.
+ */
+struct state_save_t
+{
+    // -------------------------------------------------------------------------
+    // General Purpose Registers
+    // -------------------------------------------------------------------------
+
+    uint64_t rcx;    ///< offset 0x000
+    uint64_t rdx;    ///< offset 0x008
+    uint64_t rbx;    ///< offset 0x010
+    uint64_t rbp;    ///< offset 0x018
+    uint64_t rdi;    ///< offset 0x020
+    uint64_t rsi;    ///< offset 0x028
+    uint64_t r8;     ///< offset 0x030
+    uint64_t r9;     ///< offset 0x038
+    uint64_t r10;    ///< offset 0x040
+    uint64_t r11;    ///< offset 0x048
+    uint64_t r12;    ///< offset 0x050
+    uint64_t r13;    ///< offset 0x058
+    uint64_t r14;    ///< offset 0x060
+    uint64_t r15;    ///< offset 0x068
+
+    // -------------------------------------------------------------------------
+    // Debug Registers
+    // -------------------------------------------------------------------------
+
+    uint64_t dr0;    ///< offset 0x070
+    uint64_t dr1;    ///< offset 0x078
+    uint64_t dr2;    ///< offset 0x080
+    uint64_t dr3;    ///< offset 0x088
+
+    // -------------------------------------------------------------------------
+    // Control Registers
+    // -------------------------------------------------------------------------
+
+    uint64_t cr8;    ///< offset 0x090
+
+    // -------------------------------------------------------------------------
+    // SSE / Floating Point
+    // -------------------------------------------------------------------------
+
+    uint64_t xcr0;                ///< offset 0x098
+    uint8_t reserved13[0xF60];    ///< offset 0x100
+};
+
+_Static_assert(sizeof(struct state_save_t) == 0x1000, "");
+
+#pragma pack(pop)
+
+#endif

--- a/loader/include/x64/amd/vmcb_t.h
+++ b/loader/include/x64/amd/vmcb_t.h
@@ -32,7 +32,7 @@
 #include <loader_types.h>
 
 /**
- * @class vmcb_t
+ * @struct vmcb_t
  *
  * <!-- description -->
  *   @brief The following defines the structure of the VMCB used by AMD's
@@ -77,7 +77,7 @@ struct vmcb_t
     uint8_t reserved2[0x3];                  ///< offset 0x005D
     uint64_t virtual_interrupt_a;            ///< offset 0x0060
     uint64_t virtual_interrupt_b;            ///< offset 0x0068
-    uint64_t exitcode;                       ///< offset 0x0070
+    int64_t exitcode;                        ///< offset 0x0070
     uint64_t exitinfo1;                      ///< offset 0x0078
     uint64_t exitinfo2;                      ///< offset 0x0080
     uint64_t exitininfo;                     ///< offset 0x0088
@@ -166,7 +166,7 @@ struct vmcb_t
     uint64_t sfmask;              ///< offset 0x0618
     uint64_t kernel_gs_base;      ///< offset 0x0620
     uint64_t sysenter_cs;         ///< offset 0x0628
-    uint64_t sysetner_esp;        ///< offset 0x0630
+    uint64_t sysenter_esp;        ///< offset 0x0630
     uint64_t sysenter_eip;        ///< offset 0x0638
     uint64_t cr2;                 ///< offset 0x0640
     uint8_t reserved12[0x20];     ///< offset 0x0648
@@ -179,10 +179,10 @@ struct vmcb_t
     uint8_t reserved13[0x968];    ///< offset 0x0698
 };
 
-_Static_assert(sizeof(struct vmcb_t) == 0x1000, "VMCB was not properly packed");
+_Static_assert(sizeof(struct vmcb_t) == 0x1000, "");
 
 // -----------------------------------------------------------------------------
-// Bit Masks
+// Intercept Bit Masks
 // -----------------------------------------------------------------------------
 
 #define VMCB_INTERCEPT_INSTRUCTION1_INTR ((uint64_t)1U << 0U)
@@ -249,6 +249,15 @@ _Static_assert(sizeof(struct vmcb_t) == 0x1000, "VMCB was not properly packed");
 #define VMCB_INTERCEPT_INSTRUCTION1_CR13_WRITE_COMPLETED ((uint64_t)1U << 61U)
 #define VMCB_INTERCEPT_INSTRUCTION1_CR14_WRITE_COMPLETED ((uint64_t)1U << 62U)
 #define VMCB_INTERCEPT_INSTRUCTION1_CR15_WRITE_COMPLETED ((uint64_t)1U << 63U)
+
+// -----------------------------------------------------------------------------
+// VMEXIT Code
+// -----------------------------------------------------------------------------
+
+#define VMEXIT_CPUID ((int64_t)0x072)
+#define VMEXIT_VMRUN ((int64_t)0x080)
+#define VMEXIT_VMMCALL ((int64_t)0x081)
+#define VMEXIT_INVALID ((int64_t)-1)
 
 #pragma pack(pop)
 

--- a/loader/include/x64/loader_check_canonical.h
+++ b/loader/include/x64/loader_check_canonical.h
@@ -30,6 +30,7 @@
 #include <loader_arch_context.h>
 #include <loader_debug.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -39,7 +40,7 @@
  * <!-- inputs/outputs -->
  *   @param virt the virtual address to check
  *   @param arch_context the architecture specific context for this cpu
- *   @return returns 0 if the address is canonical, FAILURE otherwise
+ *   @return returns 0 if the address is canonical, LOADER_FAILURE otherwise
  */
 static inline int
 check_canonical(uintptr_t virt, struct loader_arch_context_t *arch_context)
@@ -49,12 +50,12 @@ check_canonical(uintptr_t virt, struct loader_arch_context_t *arch_context)
 
     if (NULL == arch_context) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (0U == arch_context->physical_address_bits) {
         BFERROR("invalid physical address bits\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     upper = (upper << (arch_context->physical_address_bits - 1U));
@@ -62,7 +63,7 @@ check_canonical(uintptr_t virt, struct loader_arch_context_t *arch_context)
 
     if (((virt < upper) && (virt > lower))) {
         BFERROR("virt address not canonical: 0x%" PRIxPTR "\n", virt);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/include/x64/loader_check_page_aligned.h
+++ b/loader/include/x64/loader_check_page_aligned.h
@@ -30,6 +30,7 @@
 #include <loader_arch_context.h>
 #include <loader_debug.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -39,24 +40,24 @@
  * <!-- inputs/outputs -->
  *   @param virt the address to check
  *   @param arch_context the architecture specific context for this cpu
- *   @return returns 0 if the address is page aligned, FAILURE otherwise
+ *   @return returns 0 if the address is page aligned, LOADER_FAILURE otherwise
  */
 static inline int
 check_page_aligned(uintptr_t addr, struct loader_arch_context_t *context)
 {
     if (NULL == context) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (0U == context->page_size) {
         BFERROR("invalid page size\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if ((addr & (context->page_size - 1)) != 0) {
         BFERROR("address not page aligned: 0x%" PRIxPTR "\n", addr);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/include/x64/loader_check_valid_physical.h
+++ b/loader/include/x64/loader_check_valid_physical.h
@@ -30,6 +30,7 @@
 #include <loader_arch_context.h>
 #include <loader_debug.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -39,7 +40,7 @@
  * <!-- inputs/outputs -->
  *   @param virt the physical address to check
  *   @param arch_context the architecture specific context for this cpu
- *   @return returns 0 if the address is valid, FAILURE otherwise
+ *   @return returns 0 if the address is valid, LOADER_FAILURE otherwise
  */
 static inline int
 check_valid_physical(uintptr_t phys, struct loader_arch_context_t *context)
@@ -48,18 +49,18 @@ check_valid_physical(uintptr_t phys, struct loader_arch_context_t *context)
 
     if (NULL == context) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (0U == context->physical_address_bits) {
         BFERROR("invalid physical address bits\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     max <<= context->physical_address_bits;
     if (phys >= max) {
         BFERROR("phys address not valid: 0x%" PRIxPTR "\n", phys);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/include/x64/loader_gdt.h
+++ b/loader/include/x64/loader_gdt.h
@@ -94,7 +94,7 @@ get_segment_descriptor_attrib(
         return 0xFFFFFFFFU;
     }
 
-    if (0 == index) {
+    if (0U == index) {
         return 0U;
     }
 
@@ -129,7 +129,7 @@ get_segment_descriptor_attrib(
  *   @param index the index of the segment descriptor in the provided gdtr
  *     to get the limit from.
  *   @return Returns the requested limit on success, otherwise returns
- *     0, indicating an invalid limit.
+ *     1, indicating an invalid limit.
  */
 static inline uint32_t
 get_segment_descriptor_limit(
@@ -137,16 +137,16 @@ get_segment_descriptor_limit(
 {
     if (NULL == gdtr) {
         BFERROR("invalid argument: gdtr == NULL\n");
-        return 0;
+        return 1U;
     }
 
-    if (0 == index) {
+    if (0U == index) {
         return 0U;
     }
 
     if (index >= ((gdtr->limit + 1) / sizeof(struct segment_descriptor))) {
         BFERROR("invalid argument: index into GDT is out of range\n");
-        return 0;
+        return 1U;
     }
 
     /**
@@ -194,7 +194,7 @@ get_segment_descriptor_base(
         return 0xFFFFFFFFU;
     }
 
-    if (0 == index) {
+    if (0U == index) {
         return 0U;
     }
 

--- a/loader/linux/Makefile
+++ b/loader/linux/Makefile
@@ -42,8 +42,10 @@ ifneq ($(KERNELRELEASE),)
 
 	ifneq (,$(findstring AuthenticAMD,$(VENDOR_ID)))
 		$(TARGET_MODULE)-objs += src/x64/arch_cpuid.o
+		$(TARGET_MODULE)-objs += src/x64/arch_inb.o
 		$(TARGET_MODULE)-objs += src/x64/arch_lgdt.o
 		$(TARGET_MODULE)-objs += src/x64/arch_lidt.o
+		$(TARGET_MODULE)-objs += src/x64/arch_outb.o
 		$(TARGET_MODULE)-objs += src/x64/arch_rdmsr.o
 		$(TARGET_MODULE)-objs += src/x64/arch_readcr0.o
 		$(TARGET_MODULE)-objs += src/x64/arch_readcr2.o
@@ -68,6 +70,7 @@ ifneq ($(KERNELRELEASE),)
 		$(TARGET_MODULE)-objs += src/x64/amd/arch_vmload.o
 		$(TARGET_MODULE)-objs += src/x64/amd/arch_vmrun.o
 		$(TARGET_MODULE)-objs += src/x64/amd/arch_vmsave.o
+		$(TARGET_MODULE)-objs += ../src/x64/arch_serial.o
 		$(TARGET_MODULE)-objs += ../src/x64/amd/arch_check_hve_support.o
 		$(TARGET_MODULE)-objs += ../src/x64/amd/arch_loader_fini.o
 		$(TARGET_MODULE)-objs += ../src/x64/amd/arch_loader_init.o
@@ -82,8 +85,10 @@ ifneq ($(KERNELRELEASE),)
 
 	ifneq (,$(findstring GenuineIntel,$(VENDOR_ID)))
 		$(TARGET_MODULE)-objs += src/x64/arch_cpuid.o
+		$(TARGET_MODULE)-objs += src/x64/arch_inb.o
 		$(TARGET_MODULE)-objs += src/x64/arch_lgdt.o
 		$(TARGET_MODULE)-objs += src/x64/arch_lidt.o
+		$(TARGET_MODULE)-objs += src/x64/arch_outb.o
 		$(TARGET_MODULE)-objs += src/x64/arch_rdmsr.o
 		$(TARGET_MODULE)-objs += src/x64/arch_readcr0.o
 		$(TARGET_MODULE)-objs += src/x64/arch_readcr2.o
@@ -127,6 +132,8 @@ clean:
 	$(MAKE) -C $(BUILDSYSTEM_DIR) M=$(PWD) clean
 	rm -f ../src/*.o*
 	rm -f ../src/.*.o*
+	rm -f ../src/x64/*.o*
+	rm -f ../src/x64/.*.o*
 	rm -f ../src/x64/amd/*.o*
 	rm -f ../src/x64/amd/.*.o*
 	rm -f ../src/x64/intel/*.o*

--- a/loader/linux/include/inttypes.h
+++ b/loader/linux/include/inttypes.h
@@ -26,13 +26,16 @@
  * SOFTWARE.
  */
 
-    .code64
-    .intel_syntax noprefix
+#ifndef INTTYPES_H
+#define INTTYPES_H
 
-    .globl  arch_sgdt
-    .type   arch_sgdt, @function
-arch_sgdt:
+#include "stdint.h"
 
-    sgdt [rdi]
-    ret
-    .size arch_sgdt, .-arch_sgdt
+#define PRId64 "lld"
+#define PRIu64 "llu"
+#define PRIx64 "llx"
+#define PRIdPTR "ld"
+#define PRIuPTR "lu"
+#define PRIxPTR "lx"
+
+#endif

--- a/loader/linux/include/loader_types.h
+++ b/loader/linux/include/loader_types.h
@@ -29,13 +29,7 @@
 #ifndef LOADER_TYPES_H
 #define LOADER_TYPES_H
 
-#include <linux/types.h>
-#define PRId64 "lld"
-#define PRIu64 "llu"
-#define PRIx64 "llx"
-#define PRIdPTR "ld"
-#define PRIuPTR "lu"
-#define PRIxPTR "lx"
-#define FAILURE ((int64_t)-1)
+#include "stdint.h"
+#include "inttypes.h"
 
 #endif

--- a/loader/linux/include/stdint.h
+++ b/loader/linux/include/stdint.h
@@ -26,13 +26,11 @@
  * SOFTWARE.
  */
 
-    .code64
-    .intel_syntax noprefix
+#ifndef STDINT_H
+#define STDINT_H
 
-    .globl  arch_sgdt
-    .type   arch_sgdt, @function
-arch_sgdt:
+#include <linux/types.h>
+#define intmax_t intptr_t
+#define uintmax_t uintptr_t
 
-    sgdt [rdi]
-    ret
-    .size arch_sgdt, .-arch_sgdt
+#endif

--- a/loader/linux/include/x64/amd/loader_intrinsics.h
+++ b/loader/linux/include/x64/amd/loader_intrinsics.h
@@ -49,13 +49,13 @@
  *     and returns the results
  *
  * <!-- inputs/outputs -->
- *   @param eax the index used by CPUID, returns resulting eax
- *   @param ebx returns resulting ebx
- *   @param ecx the subindex used by CPUID, returns the resulting ecx
- *   @param edx returns resulting edx
+ *   @param rax the index used by CPUID, returns resulting rax
+ *   @param rbx returns resulting rbx
+ *   @param rcx the subindex used by CPUID, returns the resulting rcx
+ *   @param rdx returns resulting rdx
  *     to.
  */
-void arch_cpuid(uint32_t *const eax, uint32_t *const ebx, uint32_t *const ecx, uint32_t *const edx);
+void arch_cpuid(uint64_t *const rax, uint64_t *const rbx, uint64_t *const rcx, uint64_t *const rdx);
 
 /* -------------------------------------------------------------------------- */
 /* - MSRS                                                                   - */
@@ -324,20 +324,55 @@ uint64_t arch_readdr7(void);
 
 /**
  * <!-- description -->
- *   @brief Executes the VMLOAD instruction given a pointer to a VMCB.
+ *   @brief Executes the VMLOAD instruction given a physical address to a VMCB.
  *
  * <!-- inputs/outputs -->
- *   @param vmcb a pointer to a VMCB
+ *   @param vmcbpa a physical address to a VMCB
  */
-void arch_vmload(uintptr_t vmcb);
+void arch_vmload(uintptr_t vmcbpa);
 
 /**
  * <!-- description -->
- *   @brief Executes the VMSAVE instruction given a pointer to a VMCB.
+ *   @brief Executes the VMSAVE instruction given a physical address to a VMCB.
  *
  * <!-- inputs/outputs -->
- *   @param vmcb a pointer to a VMCB
+ *   @param vmcbpa a physical address to a VMCB
  */
-void arch_vmsave(uintptr_t vmcb);
+void arch_vmsave(uintptr_t vmcbpa);
+
+/**
+ * <!-- description -->
+ *   @brief Executes the VMRUN instruction.
+ *
+ * <!-- inputs/outputs -->
+ *   @param ac the architecture specific context for this cpu
+ */
+int64_t arch_vmrun(void *ac);
+
+/* -------------------------------------------------------------------------- */
+/* - Port IO                                                                - */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * <!-- description -->
+ *   @brief Executes the INB instruction given the provided Port
+ *     and returns the results
+ *
+ * <!-- inputs/outputs -->
+ *   @param port the port to read
+ *   @return Returns the resulting port IO value
+ */
+uint8_t arch_inb(uint16_t const port);
+
+/**
+ * <!-- description -->
+ *   @brief Executes the OUTB instruction given the provided Port
+ *     and value
+ *
+ * <!-- inputs/outputs -->
+ *   @param port the port to write to
+ *   @param val the value to write to the given Port
+ */
+void arch_outb(uint16_t const port, uint8_t val);
 
 #endif

--- a/loader/linux/src/x64/amd/arch_vmload.S
+++ b/loader/linux/src/x64/amd/arch_vmload.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_vmload

--- a/loader/linux/src/x64/amd/arch_vmrun.S
+++ b/loader/linux/src/x64/amd/arch_vmrun.S
@@ -26,12 +26,256 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_vmrun
     .type   arch_vmrun, @function
 arch_vmrun:
 
+    call arch_vmrun_success
     ret
+
+arch_vmrun_success:
+
+    /*************************************************************************/
+    /* Guest VMCB Setup                                                      */
+    /*************************************************************************/
+
+    mov rsi, [rdi + 0x30]
+
+    /**
+     * Store the guest's rip. Note that the vmrun instruction is what will
+     * branch the guest and host, so the RIP value is the return address of
+     * the next instruction after the call above.
+     */
+    pop rax
+    mov [rsi + 0x0578], rax
+
+    /**
+     * Store the guest's rflags. Since a call instruction does not modify the
+     * flags, the rflags are whatever we were given when arch_vmrun was
+     * called.
+     */
+    pushfq
+    pop rax
+    mov [rsi + 0x0570], rax
+
+    /**
+     * Store the rsp. Since we popped return return address to get the RIP,
+     * the stack pointer is now pointing to the stack that is used by the
+     * arch_vmrun function. Since RIP is set to the instruction after the
+     * call, the stack is in the right place for returning from this function.
+     */
+    mov [rsi + 0x05D8], rsp
+
+    /*************************************************************************/
+    /* Guest VMCB Physical Address                                           */
+    /*************************************************************************/
+
+    /**
+     * We need to store the Guest's VMCB physical address in rax so that the
+     * VMRUN instruction can execute. From this point on, rax cannot be
+     * touched.
+     */
+
+    mov rax, [rdi + 0x38]
+
+    /*************************************************************************/
+    /* Host Stack Setup                                                      */
+    /*************************************************************************/
+
+    mov rsi, [rdi + 0x020]
+
+    /**
+     * Store the host's stack. The host and the guest cannot share the same
+     * stack. Since the guest state is set up properly, once the vmrun
+     * executes, this function will return from the guest as if setting the
+     * host stack never happened. The host will have it's own stack to
+     * execute from. Note that this host can never go back, meaning, it must
+     * enter a while(1) and attempt to return without the stack being put
+     * back, otherwise the host will crash (as it no longer has the stack
+     * information to leave it's current position in the stack). To ensure
+     * this function can at least return, we grab the return address and use
+     * it to initialize our new stack.
+     */
+    mov rsp, [rsi + 0x05D8]
+
+    /**
+     * Store the guest state save and the arch context to the stack. The
+     * VMRUN loop will use both of these to save the state of the guest
+     * and then bring up the host state, reversing this on before returning
+     * to the guest.
+     */
+    mov rsi, [rdi + 0x50]
+
+    push rsi      /** contains the guest save */
+    push rdi      /** contains the arch context */
+
+    /*************************************************************************/
+    /* VMRUN loop                                                            */
+    /*************************************************************************/
+
+arch_vmrun_loop:
+
+    vmload rax
+    vmrun rax
+    vmsave rax
+
+    /**
+     * After the vmrun instruction returns, we need to handle the VMEXIT.
+     * The state associated with the guest is sitting in the general purpose
+     * registers, except for RIP, RSP and RAX. The stack has the arch context
+     * and the state save in it, which we will need to safely store the
+     * guest state the the VMEXIT didn't save for us. So to handle this, we
+     * save off RDI and RSI so that we can save them to the guest state save.
+     */
+
+    push rsi
+    push rdi
+
+    mov rdi, [rsp + 0x10]
+    mov rsi, [rsp + 0x18]
+
+    pop rax
+    mov [rsi + 0x020], rax
+    pop rax
+    mov [rsi + 0x028], rax
+
+    /**
+     * At this point, we have loaded RSI and RDI with the guest state save
+     * and the arch context, and we have also saved off the guest's values
+     * for RSI and RDI, so we can safely save the rest of the general
+     * purpose registers and the debug registers.
+     */
+
+    mov [rsi + 0x000], rcx
+    mov [rsi + 0x008], rdx
+    mov [rsi + 0x010], rbx
+    mov [rsi + 0x018], rbp
+    mov [rsi + 0x030], r8
+    mov [rsi + 0x038], r9
+    mov [rsi + 0x040], r10
+    mov [rsi + 0x048], r11
+    mov [rsi + 0x050], r12
+    mov [rsi + 0x058], r13
+    mov [rsi + 0x060], r14
+    mov [rsi + 0x068], r15
+
+    mov rax, dr0
+    mov [rsi + 0x070], rax
+    mov rax, dr1
+    mov [rsi + 0x078], rax
+    mov rax, dr2
+    mov [rsi + 0x080], rax
+    mov rax, dr3
+    mov [rsi + 0x088], rax
+    mov rax, cr8
+    mov [rsi + 0x090], rax
+
+    xor ecx, ecx
+    xgetbv
+    mov [rsi + 0x098], eax
+
+    xor edx, edx
+    mov eax, 0xFFFFFFFF
+    mov rcx, [rdi + 0x70]
+    xsaves64 [rcx]
+
+    /**
+     * The next step is set up the host state to a set of initial values.
+     * This will ensure the host's registers make sense when having to debug
+     * issues, and it also ensures nothing in the guest can touch the host.
+     */
+    mov rax, [rdi + 0x28]
+    vmload rax
+
+    mov rax, 0
+    mov dr0, rax
+    mov rax, 0
+    mov dr1, rax
+    mov rax, 0
+    mov dr2, rax
+    mov rax, 0
+    mov dr3, rax
+    mov rax, 0xFFFF0FF0
+    mov dr6, rax
+    mov rax, 0x00000400
+    mov dr7, rax
+    mov rax, 0
+    mov cr2, rax
+    mov rax, 0xF
+    mov cr8, rax
+
+    mov rcx, [rdi + 0x60]
+    mov al, 0x80
+    mov [rcx + 0x20F], al
+    xor edx, edx
+    mov eax, 0xFFFFFFFF
+    xrstors64 [rcx]
+
+    /**
+     * Finally, call the exit handler so that it can deal with the VMEXIT.
+     */
+
+    mov rax, [rdi + 0x80]
+    call rax
+
+    mov rdi, [rsp + 0x0]
+    mov rsi, [rsp + 0x8]
+
+    /**
+     * At this point, we are done handling the VMEXIT and we must return to
+     * the guest. To do this, we simply reverse everything we did above.
+     * The only difference is, we do not attempt to hold save the host state
+     * as we assume a fresh start on every VMEXIT, so it is fine to trash the
+     * host state on the way out.
+     */
+
+    xor edx, edx
+    mov eax, 0xFFFFFFFF
+    mov rcx, [rdi + 0x70]
+    xrstors64 [rcx]
+
+    xor edx, edx
+    mov eax, [rsi + 0x098]
+    xor ecx, ecx
+    xsetbv
+
+    mov rax, [rsi + 0x090]
+    mov cr8, rax
+    mov rax, [rsi + 0x088]
+    mov dr3, rax
+    mov rax, [rsi + 0x080]
+    mov dr2, rax
+    mov rax, [rsi + 0x078]
+    mov dr1, rax
+    mov rax, [rsi + 0x070]
+    mov dr0, rax
+
+    mov r15, [rsi + 0x068]
+    mov r14, [rsi + 0x060]
+    mov r13, [rsi + 0x058]
+    mov r12, [rsi + 0x050]
+    mov r11, [rsi + 0x048]
+    mov r10, [rsi + 0x040]
+    mov r9,  [rsi + 0x038]
+    mov r8,  [rsi + 0x030]
+    mov rbp, [rsi + 0x018]
+    mov rbx, [rsi + 0x010]
+    mov rdx, [rsi + 0x008]
+    mov rcx, [rsi + 0x000]
+
+    mov rax, [rsi + 0x028]
+    push rax
+    mov rax, [rsi + 0x020]
+    push rax
+
+    mov rax, [rdi + 0x38]
+
+    pop rdi
+    pop rsi
+
+    jmp arch_vmrun_loop
+
     .size arch_vmrun, .-arch_vmrun

--- a/loader/linux/src/x64/amd/arch_vmrun.o.ur-detected
+++ b/loader/linux/src/x64/amd/arch_vmrun.o.ur-detected
@@ -1,0 +1,1 @@
+/home/user/working/hypervisor/loader/linux/src/x64/amd/arch_vmrun.o-.text-145 /home/user/working/hypervisor/loader/linux/src/x64/amd/arch_vmrun.S .text arch_vmrun_loop callq *%rax

--- a/loader/linux/src/x64/amd/arch_vmsave.S
+++ b/loader/linux/src/x64/amd/arch_vmsave.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_vmsave

--- a/loader/linux/src/x64/arch_cpuid.S
+++ b/loader/linux/src/x64/arch_cpuid.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_cpuid
@@ -37,13 +37,15 @@ arch_cpuid:
     mov r10, rdx
     mov r11, rcx
 
-    mov eax, [rdi]
-    mov ecx, [rdx]
+    mov rax, [rdi]
+    mov rbx, [rsi]
+    mov rcx, [r10]
+    mov rdx, [r11]
     cpuid
-    mov [rdi], eax
-    mov [rsi], ebx
-    mov [r10], ecx
-    mov [r11], edx
+    mov [rdi], rax
+    mov [rsi], rbx
+    mov [r10], rcx
+    mov [r11], rdx
 
     pop rbx
     ret

--- a/loader/linux/src/x64/arch_inb.S
+++ b/loader/linux/src/x64/arch_inb.S
@@ -29,10 +29,11 @@
     .code64
     .intel_syntax noprefix
 
-    .globl  arch_sgdt
-    .type   arch_sgdt, @function
-arch_sgdt:
+    .globl  arch_inb
+    .type   arch_inb, @function
+arch_inb:
 
-    sgdt [rdi]
+    xor rax, rax
+    mov rdx, rdi
+    in al, dx
     ret
-    .size arch_sgdt, .-arch_sgdt

--- a/loader/linux/src/x64/arch_lgdt.S
+++ b/loader/linux/src/x64/arch_lgdt.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_lgdt

--- a/loader/linux/src/x64/arch_lidt.S
+++ b/loader/linux/src/x64/arch_lidt.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_lidt

--- a/loader/linux/src/x64/arch_outb.S
+++ b/loader/linux/src/x64/arch_outb.S
@@ -29,10 +29,12 @@
     .code64
     .intel_syntax noprefix
 
-    .globl  arch_sgdt
-    .type   arch_sgdt, @function
-arch_sgdt:
+    .globl  arch_outb
+    .type   arch_outb, @function
+arch_outb:
 
-    sgdt [rdi]
+    mov rdx, rdi
+    mov rax, rsi
+    out dx, al
+    xor rax, rax
     ret
-    .size arch_sgdt, .-arch_sgdt

--- a/loader/linux/src/x64/arch_rdmsr.S
+++ b/loader/linux/src/x64/arch_rdmsr.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_rdmsr

--- a/loader/linux/src/x64/arch_readcr0.S
+++ b/loader/linux/src/x64/arch_readcr0.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcr0

--- a/loader/linux/src/x64/arch_readcr2.S
+++ b/loader/linux/src/x64/arch_readcr2.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcr2

--- a/loader/linux/src/x64/arch_readcr3.S
+++ b/loader/linux/src/x64/arch_readcr3.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcr3

--- a/loader/linux/src/x64/arch_readcr4.S
+++ b/loader/linux/src/x64/arch_readcr4.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcr4

--- a/loader/linux/src/x64/arch_readcr8.S
+++ b/loader/linux/src/x64/arch_readcr8.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcr8

--- a/loader/linux/src/x64/arch_readcs.S
+++ b/loader/linux/src/x64/arch_readcs.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readcs

--- a/loader/linux/src/x64/arch_readdr0.S
+++ b/loader/linux/src/x64/arch_readdr0.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr0

--- a/loader/linux/src/x64/arch_readdr1.S
+++ b/loader/linux/src/x64/arch_readdr1.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr1

--- a/loader/linux/src/x64/arch_readdr2.S
+++ b/loader/linux/src/x64/arch_readdr2.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr2

--- a/loader/linux/src/x64/arch_readdr3.S
+++ b/loader/linux/src/x64/arch_readdr3.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr3

--- a/loader/linux/src/x64/arch_readdr6.S
+++ b/loader/linux/src/x64/arch_readdr6.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr6

--- a/loader/linux/src/x64/arch_readdr7.S
+++ b/loader/linux/src/x64/arch_readdr7.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readdr7

--- a/loader/linux/src/x64/arch_readds.S
+++ b/loader/linux/src/x64/arch_readds.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readds

--- a/loader/linux/src/x64/arch_reades.S
+++ b/loader/linux/src/x64/arch_reades.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_reades

--- a/loader/linux/src/x64/arch_readfs.S
+++ b/loader/linux/src/x64/arch_readfs.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readfs

--- a/loader/linux/src/x64/arch_readgs.S
+++ b/loader/linux/src/x64/arch_readgs.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readgs

--- a/loader/linux/src/x64/arch_readss.S
+++ b/loader/linux/src/x64/arch_readss.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_readss

--- a/loader/linux/src/x64/arch_sidt.S
+++ b/loader/linux/src/x64/arch_sidt.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_sidt

--- a/loader/linux/src/x64/arch_wrmsr.S
+++ b/loader/linux/src/x64/arch_wrmsr.S
@@ -26,7 +26,7 @@
  * SOFTWARE.
  */
 
-     .code64
+    .code64
     .intel_syntax noprefix
 
     .globl  arch_wrmsr

--- a/loader/src/dump_vmm.c
+++ b/loader/src/dump_vmm.c
@@ -24,8 +24,8 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/loader_fini.c
+++ b/loader/src/loader_fini.c
@@ -24,10 +24,10 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_arch.h>
 #include <loader_debug.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/loader_init.c
+++ b/loader/src/loader_init.c
@@ -24,12 +24,12 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_arch.h>
 #include <loader_debug.h>
 #include <loader_global_resources.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -46,17 +46,17 @@ loader_init(void)
 {
     if (platform_memset(&g_contexts, 0, sizeof(g_contexts))) {
         BFERROR("platform_memset failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (platform_memset(&g_arch_contexts, 0, sizeof(g_arch_contexts))) {
         BFERROR("platform_memset failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (arch_loader_init()) {
         BFERROR("arch_loader_init failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/src/start_vmm.c
+++ b/loader/src/start_vmm.c
@@ -24,10 +24,10 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_debug.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -57,7 +57,7 @@ start_vmm(void)
 
     if (platform_on_each_cpu(start_vmm_per_cpu, 0)) {
         BFERROR("platform_on_each_cpu failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/src/start_vmm_per_cpu.c
+++ b/loader/src/start_vmm_per_cpu.c
@@ -24,12 +24,12 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_arch.h>
 #include <loader_debug.h>
 #include <loader_global_resources.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -47,31 +47,21 @@ start_vmm_per_cpu(uint32_t const cpu)
 {
     if (cpu >= MAX_NUMBER_OF_ROOT_VCPUS) {
         BFERROR("cpu index %u is out of range\n", cpu);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (VMM_STARTED == g_contexts[cpu].started) {
         BFALERT("cpu %u was never stopped. stopping now\n", cpu);
         if (stop_vmm_per_cpu(cpu) != 0) {
             BFERROR("stop_vmm_per_cpu failed\n");
-            return FAILURE;
+            return LOADER_FAILURE;
         }
-    }
-
-    if (platform_memset(&g_contexts[cpu], 0, sizeof(g_contexts[cpu]))) {
-        BFERROR("platform_memset failed\n");
-        return FAILURE;
-    }
-
-    if (platform_memset(&g_arch_contexts[cpu], 0, sizeof(g_arch_contexts[cpu]))) {
-        BFERROR("platform_memset failed\n");
-        return FAILURE;
     }
 
     if (arch_start_vmm_per_cpu(cpu, &g_contexts[cpu], &g_arch_contexts[cpu])) {
         BFERROR("arch_start_vmm_per_cpu failed\n");
         arch_stop_vmm_per_cpu(cpu, &g_contexts[cpu], &g_arch_contexts[cpu]);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     g_contexts[cpu].started = VMM_STARTED;

--- a/loader/src/stop_vmm.c
+++ b/loader/src/stop_vmm.c
@@ -24,10 +24,10 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_debug.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/stop_vmm_per_cpu.c
+++ b/loader/src/stop_vmm_per_cpu.c
@@ -24,12 +24,12 @@
  * SOFTWARE.
  */
 
-#include <loader.h>
 #include <loader_arch.h>
 #include <loader_debug.h>
 #include <loader_global_resources.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -47,7 +47,7 @@ stop_vmm_per_cpu(uint32_t const cpu)
 {
     if (cpu >= MAX_NUMBER_OF_ROOT_VCPUS) {
         BFERROR("cpu index %u is out of range\n", cpu);
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     if (VMM_STARTED != g_contexts[cpu].started) {

--- a/loader/src/x64/amd/arch_check_hve_support.c
+++ b/loader/src/x64/amd/arch_check_hve_support.c
@@ -27,6 +27,7 @@
 #include <loader_debug.h>
 #include <loader_intrinsics.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -39,34 +40,38 @@
 int64_t
 arch_check_hve_support(void)
 {
-    uint32_t eax;
-    uint32_t ebx;
-    uint32_t ecx;
-    uint32_t edx;
+    uint64_t rax;
+    uint64_t rbx;
+    uint64_t rcx;
+    uint64_t rdx;
     uint64_t msr;
 
-    eax = CPUID_FN0000_0000;
-    ecx = 0U;
-    arch_cpuid(&eax, &ebx, &ecx, &edx);
-    if ((ebx != CPUID_FN0000_0000_EBX_VENDOR_ID) ||    // --
-        (ecx != CPUID_FN0000_0000_ECX_VENDOR_ID) ||    // --
-        (edx != CPUID_FN0000_0000_EDX_VENDOR_ID)) {
+    rax = CPUID_FN0000_0000;
+    rbx = 0U;
+    rcx = 0U;
+    rdx = 0U;
+    arch_cpuid(&rax, &rbx, &rcx, &rdx);
+    if ((rbx != CPUID_FN0000_0000_EBX_VENDOR_ID) ||    // --
+        (rcx != CPUID_FN0000_0000_ECX_VENDOR_ID) ||    // --
+        (rdx != CPUID_FN0000_0000_EDX_VENDOR_ID)) {
         BFERROR("CPUID vendor not supported\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    eax = CPUID_FN8000_0001;
-    ecx = 0U;
-    arch_cpuid(&eax, &ebx, &ecx, &edx);
-    if ((ecx & CPUID_FN8000_0001_ECX_SVM) == 0) {
+    rax = CPUID_FN8000_0001;
+    rbx = 0U;
+    rcx = 0U;
+    rdx = 0U;
+    arch_cpuid(&rax, &rbx, &rcx, &rdx);
+    if ((rcx & CPUID_FN8000_0001_ECX_SVM) == 0) {
         BFERROR("This CPU does not support SVM\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     msr = arch_rdmsr(MSR_VM_CR);
     if ((msr & MSR_VM_CR_SVMDIS) != 0) {
         BFERROR("SVM has been disabled in BIOS. SVM not supported\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     return 0;

--- a/loader/src/x64/amd/arch_loader_fini.c
+++ b/loader/src/x64/amd/arch_loader_fini.c
@@ -26,6 +26,7 @@
 
 #include <loader_arch.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/x64/amd/arch_loader_init.c
+++ b/loader/src/x64/amd/arch_loader_init.c
@@ -26,6 +26,7 @@
 
 #include <loader_arch.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
@@ -39,5 +40,7 @@
 int64_t
 arch_loader_init(void)
 {
+    arch_init_serial();
+
     return 0;
 }

--- a/loader/src/x64/amd/arch_start_vmm_per_cpu.c
+++ b/loader/src/x64/amd/arch_start_vmm_per_cpu.c
@@ -35,27 +35,25 @@
 #include <loader_intrinsics.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->
  *   @brief Enable Secure Virtual Machine support. This turns on the
  *     ability to use the VMRUN, VMLOAD and VMSAVE instructions, as well
  *     as some other support instructions like stgi and clgi.
+ *
+ * <!-- inputs/outputs -->
+ *   @return Returns 0 on success
  */
 int64_t
 enable_svm(void)
 {
-    /**
-     * TODO:
-     * - We should not be reading EFER more than once, so we really should
-     *   read this into the context before we start and then use it as needed.
-     */
-
     uint64_t efer = arch_rdmsr(MSR_EFER);
 
     if ((efer & MSR_EFER_SVME) != 0) {
         BFERROR("SVM is already running. Is another hypervisor running?\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
     arch_wrmsr(MSR_EFER, efer | MSR_EFER_SVME);
@@ -64,259 +62,186 @@ enable_svm(void)
 
 /**
  * <!-- description -->
- *   @brief Prepare the host VMCB. Once a VMRUN is performed, the host
- *     and the guest will diverge into two different states. The VMRUN
- *     instruction does not save all of the state that the host requires
- *     similar to how it does not save/load all of the guest state.
- *     This function allocates space for the missing host state.
+ *   @brief Allocate, validate and clear a block of memory.
  *
  * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
+ *   @param virt the location to store the newly allocated memory
+ *   @param size the size of the memory to allocate
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
-prepare_host_vmcb(struct loader_arch_context_t *arch_context)
+setup_virt(void **virt, uintptr_t const size, struct loader_arch_context_t *ac)
 {
-    uintptr_t virt;
-    uintptr_t phys;
-
-    if (NULL == arch_context) {
+    if (NULL == virt) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    virt = (uintptr_t)platform_alloc(sizeof(struct vmcb_t));
-    if (0U == virt) {
-        BFERROR("failed to allocate host vmcb\n");
-        return FAILURE;
+    if (NULL != *virt) {
+        BFERROR("virtual address was never freed\n");
+        return LOADER_FAILURE;
     }
 
-    phys = platform_virt_to_phys(virt);
-    if (0U == phys) {
-        BFERROR("failed to get the host vmcb's physical address\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+    *virt = platform_alloc(size);
+    if (NULL == *virt) {
+        BFERROR("failed to allocate memory\n");
+        return LOADER_FAILURE;
     }
 
-    if (check_page_aligned(virt, arch_context)) {
+    if (check_page_aligned((uintptr_t)*virt, ac)) {
         BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (check_page_aligned(phys, arch_context)) {
-        BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
-    }
-
-    if (check_canonical(virt, arch_context)) {
+    if (check_canonical((uintptr_t)*virt, ac)) {
         BFERROR("check_canonical failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (check_valid_physical(phys, arch_context)) {
-        BFERROR("check_valid_physical failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+    if (platform_memset(*virt, 0, size)) {
+        BFERROR("platform_memset failed\n");
+        return LOADER_FAILURE;
     }
-
-    arch_context->host_vmcb_virt = (struct vmcb_t *)virt;
-    arch_context->host_vmcb_phys = phys;
 
     return 0;
 }
 
 /**
  * <!-- description -->
- *   @brief Prepare the guest VMCB. The guest VMCB is used to store all
- *     of the state associated with the guest VM. This function allocates
- *     space for this state.
+ *   @brief Get and validate the physical address of an existing virtual
+ *     address
  *
  * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
+ *   @param phys the location to store the physical address
+ *   @param virt the virtual address to get the physical address of
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
-prepare_guest_vmcb(struct loader_arch_context_t *arch_context)
+setup_phys(uintptr_t *phys, void *virt, struct loader_arch_context_t *ac)
 {
-    uintptr_t virt;
-    uintptr_t phys;
-
-    if (NULL == arch_context) {
+    if (NULL == phys) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    virt = (uintptr_t)platform_alloc(sizeof(struct vmcb_t));
-    if (0U == virt) {
-        BFERROR("failed to allocate guest vmcb\n");
-        return FAILURE;
+    if (NULL == virt) {
+        BFERROR("invalid argument\n");
+        return LOADER_FAILURE;
     }
 
-    phys = platform_virt_to_phys(virt);
-    if (0U == phys) {
-        BFERROR("failed to get the guest vmcb's physical address\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+    if (0U != *phys) {
+        BFERROR("physical address was never reset\n");
+        return LOADER_FAILURE;
     }
 
-    if (check_page_aligned(virt, arch_context)) {
+    *phys = platform_virt_to_phys(virt);
+    if (0U == *phys) {
+        BFERROR("platform_virt_to_phys failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (check_page_aligned(*phys, ac)) {
         BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (check_page_aligned(phys, arch_context)) {
-        BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
-    }
-
-    if (check_canonical(virt, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
-    }
-
-    if (check_valid_physical(phys, arch_context)) {
+    if (check_valid_physical(*phys, ac)) {
         BFERROR("check_valid_physical failed\n");
-        platform_free((void *)virt, sizeof(struct vmcb_t));
-        return FAILURE;
+        return LOADER_FAILURE;
     }
-
-    arch_context->guest_vmcb_virt = (struct vmcb_t *)virt;
-    arch_context->guest_vmcb_phys = phys;
 
     return 0;
 }
 
 /**
  * <!-- description -->
- *   @brief Prepare the host state save. The host state save is used
- *     by the VMRUN instruction to store state associated with the
- *     host. This state does not include the state that is saved using
- *     the vmsave instruction, which is why we also have a host VMCB.
- *     This function allocates the space for the host state save.
+ *   @brief Prepare the host VMCB. The host VMCB is used to store state
+ *     that the VMRUN function does not save for us. This does not
+ *     include the state save or the xsave state. Note that we must also
+ *     store the host stack so that the VMLAUNCH code can use it as needed.
  *
  * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
-prepare_host_state_save(struct loader_arch_context_t *arch_context)
+prepare_host_vmcb(struct loader_arch_context_t *ac)
 {
-    uintptr_t virt;
-    uintptr_t phys;
-
-    if (NULL == arch_context) {
+    if (NULL == ac) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    virt = (uintptr_t)platform_alloc(arch_context->page_size);
-    if (0U == virt) {
-        BFERROR("failed to allocate host state save\n");
-        return FAILURE;
-    }
-
-    phys = platform_virt_to_phys(virt);
-    if (0U == phys) {
-        BFERROR("failed to get the host state save's physical address\n");
-        platform_free((void *)virt, arch_context->page_size);
-        return FAILURE;
-    }
-
-    if (check_page_aligned(virt, arch_context)) {
-        BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, arch_context->page_size);
-        return FAILURE;
-    }
-
-    if (check_page_aligned(phys, arch_context)) {
-        BFERROR("check_page_aligned failed\n");
-        platform_free((void *)virt, arch_context->page_size);
-        return FAILURE;
-    }
-
-    if (check_canonical(virt, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        platform_free((void *)virt, arch_context->page_size);
-        return FAILURE;
-    }
-
-    if (check_valid_physical(phys, arch_context)) {
-        BFERROR("check_valid_physical failed\n");
-        platform_free((void *)virt, arch_context->page_size);
-        return FAILURE;
-    }
-
-    arch_context->host_state_save_virt = (void *)virt;
-    arch_context->host_state_save_phys = phys;
-
-    return 0;
-}
-
-/**
- * <!-- description -->
- *   @brief Configure the host VMCB. Once a VMRUN is performed, the host
- *     and the guest will diverge into two different states. The VMRUN
- *     instruction does not save all of the state that the host requires
- *     similar to how it does not save/load all of the guest state.
- *     This function uses the vmsave instruction to store the missing
- *     host state.
- *
- * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
- *   @return Returns 0 on success
- */
-int64_t
-configure_host_vmcb(struct loader_arch_context_t *arch_context)
-{
-    if (NULL == arch_context) {
-        BFERROR("invalid argument\n");
-        return FAILURE;
-    }
-
-    if (NULL == arch_context->host_vmcb_virt) {
-        BFERROR("invalid host vmcb virtual address\n");
-        return FAILURE;
-    }
-
-    if (0U == arch_context->host_vmcb_phys) {
-        BFERROR("invalid host vmcb physical address\n");
-        return FAILURE;
+    if (0U == ac->host_stack_size) {
+        BFERROR("invalid host stack size\n");
+        return LOADER_FAILURE;
     }
 
     /**
-     * Note:
+     * Notes:
+     * - Allocate, validate and clear the host's VMCB
+     * - Get and validate the host VMCB's physical address
+     * - Allocate, validate and clear the host's stack
+     */
+
+    if (setup_virt((void **)&ac->host_vmcb, sizeof(struct vmcb_t), ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_phys(&ac->host_vmcb_phys, ac->host_vmcb, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_virt(&ac->host_stack, ac->host_stack_size, ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Store the host RSP. Note that RSP must be at the top of the stack
+     *   so that it can be used once VMRUN is used.
+     */
+
+    ac->host_vmcb->rsp = (uintptr_t)ac->host_stack + ac->host_stack_size;
+
+    /**
+     * Notes:
      * - Get and store the FS, GS, TR and LDTR
      * - Get and store the KernelGsBase
      * - Get and store the STAR, LSTAR, CSTAR, SFMASK
      * - Get and store the SYSENTER_CS, SYSENTER_ESP, SYSENTER_EIP
      */
 
-    arch_vmsave(arch_context->host_vmcb_phys);
+    arch_vmsave(ac->host_vmcb_phys);
+
+    /**
+     * Notes:
+     * - Done.
+     */
 
     return 0;
 }
 
 /**
  * <!-- description -->
- *   @brief Configure the guest VMCB. The guest VMCB is used to store all
- *     of the state associated with the guest VM. This function configures
- *     this state.
+ *   @brief Prepare the guest VMCB. The guest VMCB is used to store state
+ *     that the VMRUN function saves for us. This does not include the
+ *     state save or the xsave state. Note that since the VMRUN will use
+ *     the guest VMCB to save and load the guest state for us, we must
+ *     populate it with the initial state of the guest.
  *
  * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
-configure_guest_vmcb(struct loader_arch_context_t *arch_context)
+prepare_guest_vmcb(struct loader_arch_context_t *ac)
 {
-    struct vmcb_t *vmcb = NULL;
-
     uint16_t es_index = 0;
     uint16_t cs_index = 0;
     uint16_t ss_index = 0;
@@ -325,47 +250,46 @@ configure_guest_vmcb(struct loader_arch_context_t *arch_context)
     struct global_descriptor_table_register gdtr = {0};
     struct interrupt_descriptor_table_register idtr = {0};
 
-    if (NULL == arch_context) {
+    if (NULL == ac) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
-
-    if (NULL == arch_context->guest_vmcb_virt) {
-        BFERROR("invalid guest vmcb virtual address\n");
-        return FAILURE;
-    }
-
-    if (0U == arch_context->guest_vmcb_phys) {
-        BFERROR("invalid guest vmcb physical address\n");
-        return FAILURE;
-    }
-
-    vmcb = arch_context->guest_vmcb_virt;
 
     /**
-     * TODO: We will need to turn on more than just this inside the default
-     *       extension including the SVM control bit, EFER MSR, remaining
-     *       VM instructions, etc... In general, this code belongs in the
-     *       extension and not in the kernel.
+     * Notes:
+     * - Allocate, validate and clear the guest's VMCB
+     * - Get and validate the guest VMCB's physical address
      */
 
-    vmcb->intercept_instruction1 |= VMCB_INTERCEPT_INSTRUCTION1_CPUID;
-    vmcb->intercept_instruction1 |= VMCB_INTERCEPT_INSTRUCTION1_VMRUN;
+    if (setup_virt((void **)&ac->guest_vmcb, sizeof(struct vmcb_t), ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_phys(&ac->guest_vmcb_phys, ac->guest_vmcb, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
+    }
 
     /**
-     * TODO: We need to determine what the supported values for ASID are
-     *       from CPUID, and we will need a "vm" structure in the kernel
-     *       that we can use to give out these values based on the max
-     *       total number of supported VMs. For now, we just set this to
-     *       1. Also note that this is the same as VPID, so Intel will
-     *       need the same thing. The current code gives each vCPU its own
-     *       VPID which is not right. Instead, each VM should have its
-     *       own VPID/ASID so that you can flush the TLB using remote
-     *       instructions like the new INVLPGB that AMD is adding. Also
-     *       note that this code belongs in the extension and not in the
-     *       kernel as the kernel will have concept of a VM.
+     * Notes:
+     * - Turn on the minimum number of controls. AMD requires that the VMRUN
+     *   control is turned on, meaning all attempts to call the VMRUN
+     *   instruction will fail.
      */
-    vmcb->tlb_control = 1;
+    ac->guest_vmcb->intercept_instruction1 |= VMCB_INTERCEPT_INSTRUCTION1_CPUID;
+    ac->guest_vmcb->intercept_instruction1 |= VMCB_INTERCEPT_INSTRUCTION1_VMRUN;
+    ac->guest_vmcb->intercept_instruction1 |= VMCB_INTERCEPT_INSTRUCTION1_VMMCALL;
+
+    /**
+     * Notes:
+     * - Set the ASID which is a TLB tag for removing the need for flushing
+     *   the TLB on world switches. The root OS always has an ASID of 1 while
+     *   the host always has an ASID of 0. All guest VMs have an ASID of
+     *   something greater than 1.
+     */
+
+    ac->guest_vmcb->guest_asid = 1;
 
     /**
      * Note:
@@ -376,40 +300,31 @@ configure_guest_vmcb(struct loader_arch_context_t *arch_context)
     arch_sgdt(&gdtr);
     arch_sidt(&idtr);
 
-    vmcb->gdtr_limit = gdtr.limit;
-    vmcb->gdtr_base = (uintptr_t)gdtr.base;
-    vmcb->idtr_limit = idtr.limit;
-    vmcb->idtr_base = (uintptr_t)idtr.base;
+    ac->guest_vmcb->gdtr_limit = gdtr.limit;
+    ac->guest_vmcb->gdtr_base = (uintptr_t)gdtr.base;
+    ac->guest_vmcb->idtr_limit = idtr.limit;
+    ac->guest_vmcb->idtr_base = (uintptr_t)idtr.base;
 
-    if (check_canonical(vmcb->gdtr_base, arch_context)) {
-        BFERROR("gdtr base not canonical: 0x%" PRIx64 "\n", vmcb->gdtr_base);
-        return FAILURE;
-    }
-
-    if (check_canonical(vmcb->idtr_base, arch_context)) {
-        BFERROR("idtr base not canonical: 0x%" PRIx64 "\n", vmcb->idtr_base);
-        return FAILURE;
-    }
-
-    BFDEBUG("gdtr_limit: 0x%x\n", vmcb->gdtr_limit);
-    BFDEBUG("gdtr_base: 0x%" PRIx64 "\n", vmcb->gdtr_base);
-    BFDEBUG("idtr_limit: 0x%x\n", vmcb->idtr_limit);
-    BFDEBUG("idtr_base: 0x%" PRIx64 "\n", vmcb->idtr_base);
+    BFDEBUG("gdtr_limit: 0x%x\n", ac->guest_vmcb->gdtr_limit);
+    BFDEBUG("gdtr_base: 0x%" PRIx64 "\n", ac->guest_vmcb->gdtr_base);
+    BFDEBUG("idtr_limit: 0x%x\n", ac->guest_vmcb->idtr_limit);
+    BFDEBUG("idtr_base: 0x%" PRIx64 "\n", ac->guest_vmcb->idtr_base);
 
     /**
      * Note:
-     * - Get segment selectors.
+     * - Get segment selectors. Note that we only get ES, CS, SS and DS as
+     *   the vmload/vmsave instructions will get the others for us.
      */
 
-    vmcb->es_selector = arch_reades();
-    vmcb->cs_selector = arch_readcs();
-    vmcb->ss_selector = arch_readss();
-    vmcb->ds_selector = arch_readds();
+    ac->guest_vmcb->es_selector = arch_reades();
+    ac->guest_vmcb->cs_selector = arch_readcs();
+    ac->guest_vmcb->ss_selector = arch_readss();
+    ac->guest_vmcb->ds_selector = arch_readds();
 
-    BFDEBUG("es_selector: 0x%x\n", vmcb->es_selector);
-    BFDEBUG("cs_selector: 0x%x\n", vmcb->cs_selector);
-    BFDEBUG("ss_selector: 0x%x\n", vmcb->ss_selector);
-    BFDEBUG("ds_selector: 0x%x\n", vmcb->ds_selector);
+    BFDEBUG("es_selector: 0x%x\n", ac->guest_vmcb->es_selector);
+    BFDEBUG("cs_selector: 0x%x\n", ac->guest_vmcb->cs_selector);
+    BFDEBUG("ss_selector: 0x%x\n", ac->guest_vmcb->ss_selector);
+    BFDEBUG("ds_selector: 0x%x\n", ac->guest_vmcb->ds_selector);
 
     /**
      * Note:
@@ -419,10 +334,10 @@ configure_guest_vmcb(struct loader_arch_context_t *arch_context)
      *   global descriptor table.
      */
 
-    es_index = vmcb->es_selector >> 3U;
-    cs_index = vmcb->cs_selector >> 3U;
-    ss_index = vmcb->ss_selector >> 3U;
-    ds_index = vmcb->ds_selector >> 3U;
+    es_index = ac->guest_vmcb->es_selector >> 3U;
+    cs_index = ac->guest_vmcb->cs_selector >> 3U;
+    ss_index = ac->guest_vmcb->ss_selector >> 3U;
+    ds_index = ac->guest_vmcb->ds_selector >> 3U;
 
     BFDEBUG("es_index: 0x%x\n", es_index);
     BFDEBUG("cs_index: 0x%x\n", cs_index);
@@ -441,165 +356,130 @@ configure_guest_vmcb(struct loader_arch_context_t *arch_context)
      *   does not work this way.
      */
 
-    vmcb->es_attrib = get_segment_descriptor_attrib(&gdtr, es_index);
-    vmcb->es_limit = get_segment_descriptor_limit(&gdtr, es_index);
-    vmcb->es_base = get_segment_descriptor_base(&gdtr, es_index);
-    vmcb->cs_attrib = get_segment_descriptor_attrib(&gdtr, cs_index);
-    vmcb->cs_limit = get_segment_descriptor_limit(&gdtr, cs_index);
-    vmcb->cs_base = get_segment_descriptor_base(&gdtr, cs_index);
-    vmcb->ss_attrib = get_segment_descriptor_attrib(&gdtr, ss_index);
-    vmcb->ss_limit = get_segment_descriptor_limit(&gdtr, ss_index);
-    vmcb->ss_base = get_segment_descriptor_base(&gdtr, ss_index);
-    vmcb->ds_attrib = get_segment_descriptor_attrib(&gdtr, ds_index);
-    vmcb->ds_limit = get_segment_descriptor_limit(&gdtr, ds_index);
-    vmcb->ds_base = get_segment_descriptor_base(&gdtr, ds_index);
+    ac->guest_vmcb->es_attrib = get_segment_descriptor_attrib(&gdtr, es_index);
+    ac->guest_vmcb->es_limit = get_segment_descriptor_limit(&gdtr, es_index);
+    ac->guest_vmcb->es_base = get_segment_descriptor_base(&gdtr, es_index);
+    ac->guest_vmcb->cs_attrib = get_segment_descriptor_attrib(&gdtr, cs_index);
+    ac->guest_vmcb->cs_limit = get_segment_descriptor_limit(&gdtr, cs_index);
+    ac->guest_vmcb->cs_base = get_segment_descriptor_base(&gdtr, cs_index);
+    ac->guest_vmcb->ss_attrib = get_segment_descriptor_attrib(&gdtr, ss_index);
+    ac->guest_vmcb->ss_limit = get_segment_descriptor_limit(&gdtr, ss_index);
+    ac->guest_vmcb->ss_base = get_segment_descriptor_base(&gdtr, ss_index);
+    ac->guest_vmcb->ds_attrib = get_segment_descriptor_attrib(&gdtr, ds_index);
+    ac->guest_vmcb->ds_limit = get_segment_descriptor_limit(&gdtr, ds_index);
+    ac->guest_vmcb->ds_base = get_segment_descriptor_base(&gdtr, ds_index);
 
-    if (0xFFFFFFFFU == vmcb->es_attrib) {
+    BFDEBUG("es_attrib: 0x%x\n", ac->guest_vmcb->es_attrib);
+    BFDEBUG("es_limit: 0x%x\n", ac->guest_vmcb->es_limit);
+    BFDEBUG("es_base: 0x%" PRIx64 "\n", ac->guest_vmcb->es_base);
+    BFDEBUG("cs_attrib: 0x%x\n", ac->guest_vmcb->cs_attrib);
+    BFDEBUG("cs_limit: 0x%x\n", ac->guest_vmcb->cs_limit);
+    BFDEBUG("cs_base: 0x%" PRIx64 "\n", ac->guest_vmcb->cs_base);
+    BFDEBUG("ss_attrib: 0x%x\n", ac->guest_vmcb->ss_attrib);
+    BFDEBUG("ss_limit: 0x%x\n", ac->guest_vmcb->ss_limit);
+    BFDEBUG("ss_base: 0x%" PRIx64 "\n", ac->guest_vmcb->ss_base);
+    BFDEBUG("ds_attrib: 0x%x\n", ac->guest_vmcb->ds_attrib);
+    BFDEBUG("ds_limit: 0x%x\n", ac->guest_vmcb->ds_limit);
+    BFDEBUG("ds_base: 0x%" PRIx64 "\n", ac->guest_vmcb->ds_base);
+
+    if (0xFFFFFFFFU == ac->guest_vmcb->es_attrib) {
         BFERROR("failed to get the es segment's attributes\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->cs_attrib) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->cs_attrib) {
         BFERROR("failed to get the cs segment's attributes\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->ss_attrib) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->ss_attrib) {
         BFERROR("failed to get the ss segment's attributes\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->ds_attrib) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->ds_attrib) {
         BFERROR("failed to get the ds segment's attributes\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0U == vmcb->es_limit) {
+    if (1U == ac->guest_vmcb->es_limit) {
         BFERROR("failed to get the es segment's limit\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0U == vmcb->cs_limit) {
+    if (1U == ac->guest_vmcb->cs_limit) {
         BFERROR("failed to get the cs segment's limit\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0U == vmcb->ss_limit) {
+    if (1U == ac->guest_vmcb->ss_limit) {
         BFERROR("failed to get the ss segment's limit\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0U == vmcb->ds_limit) {
+    if (1U == ac->guest_vmcb->ds_limit) {
         BFERROR("failed to get the ds segment's limit\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->es_base) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->es_base) {
         BFERROR("failed to get the es segment's base address\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->cs_base) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->cs_base) {
         BFERROR("failed to get the cs segment's base address\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->ss_base) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->ss_base) {
         BFERROR("failed to get the ss segment's base address\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (0xFFFFFFFFU == vmcb->ds_base) {
+    if (0xFFFFFFFFU == ac->guest_vmcb->ds_base) {
         BFERROR("failed to get the ds segment's base address\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
-
-    if (check_canonical(vmcb->es_base, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        return FAILURE;
-    }
-
-    if (check_canonical(vmcb->cs_base, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        return FAILURE;
-    }
-
-    if (check_canonical(vmcb->ss_base, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        return FAILURE;
-    }
-
-    if (check_canonical(vmcb->ds_base, arch_context)) {
-        BFERROR("check_canonical failed\n");
-        return FAILURE;
-    }
-
-    BFDEBUG("es_attrib: 0x%x\n", vmcb->es_attrib);
-    BFDEBUG("es_limit: 0x%x\n", vmcb->es_limit);
-    BFDEBUG("es_base: 0x%" PRIx64 "\n", vmcb->es_base);
-    BFDEBUG("cs_attrib: 0x%x\n", vmcb->cs_attrib);
-    BFDEBUG("cs_limit: 0x%x\n", vmcb->cs_limit);
-    BFDEBUG("cs_base: 0x%" PRIx64 "\n", vmcb->cs_base);
-    BFDEBUG("ss_attrib: 0x%x\n", vmcb->ss_attrib);
-    BFDEBUG("ss_limit: 0x%x\n", vmcb->ss_limit);
-    BFDEBUG("ss_base: 0x%" PRIx64 "\n", vmcb->ss_base);
-    BFDEBUG("ds_attrib: 0x%x\n", vmcb->ds_attrib);
-    BFDEBUG("ds_limit: 0x%x\n", vmcb->ds_limit);
-    BFDEBUG("ds_base: 0x%" PRIx64 "\n", vmcb->ds_base);
 
     /**
      * Note:
      * - Get the VMCB's model specific registers.
      */
 
-    vmcb->efer = arch_rdmsr(MSR_EFER);
-    vmcb->g_pat = arch_rdmsr(MSR_PAT);
-    vmcb->dbgctl = arch_rdmsr(MSR_DEBUGCTL);
+    ac->guest_vmcb->efer = arch_rdmsr(MSR_EFER);
+    ac->guest_vmcb->g_pat = arch_rdmsr(MSR_PAT);
+    ac->guest_vmcb->dbgctl = arch_rdmsr(MSR_DEBUGCTL);
 
-    if ((vmcb->efer & MSR_EFER_SVME) == 0) {
-        BFERROR("svme has not been enabled: 0x%" PRIx64 "\n", vmcb->efer);
-        return FAILURE;
-    }
-
-    if (0U == vmcb->g_pat) {
-        BFERROR("invalid PAT: 0x%" PRIx64 "\n", vmcb->g_pat);
-        return FAILURE;
-    }
-
-    BFDEBUG("efer: 0x%" PRIx64 "\n", vmcb->efer);
-    BFDEBUG("g_pat: 0x%" PRIx64 "\n", vmcb->g_pat);
-    BFDEBUG("dbgctl: 0x%" PRIx64 "\n", vmcb->dbgctl);
+    BFDEBUG("efer: 0x%" PRIx64 "\n", ac->guest_vmcb->efer);
+    BFDEBUG("g_pat: 0x%" PRIx64 "\n", ac->guest_vmcb->g_pat);
+    BFDEBUG("dbgctl: 0x%" PRIx64 "\n", ac->guest_vmcb->dbgctl);
 
     /**
      * Note:
      * - Get the VMCB's control registers.
      */
 
-    vmcb->cr0 = arch_readcr0();
-    vmcb->cr2 = arch_readcr2();
-    vmcb->cr3 = arch_readcr3();
-    vmcb->cr4 = arch_readcr4();
+    ac->guest_vmcb->cr0 = arch_readcr0();
+    ac->guest_vmcb->cr2 = arch_readcr2();
+    ac->guest_vmcb->cr3 = arch_readcr3();
+    ac->guest_vmcb->cr4 = arch_readcr4();
 
-    if (check_valid_physical(vmcb->cr3, arch_context)) {
-        BFERROR("check_valid_physical failed\n");
-        return FAILURE;
-    }
-
-    BFDEBUG("cr0: 0x%" PRIx64 "\n", vmcb->cr0);
-    BFDEBUG("cr2: 0x%" PRIx64 "\n", vmcb->cr2);
-    BFDEBUG("cr3: 0x%" PRIx64 "\n", vmcb->cr3);
-    BFDEBUG("cr4: 0x%" PRIx64 "\n", vmcb->cr4);
+    BFDEBUG("cr0: 0x%" PRIx64 "\n", ac->guest_vmcb->cr0);
+    BFDEBUG("cr2: 0x%" PRIx64 "\n", ac->guest_vmcb->cr2);
+    BFDEBUG("cr3: 0x%" PRIx64 "\n", ac->guest_vmcb->cr3);
+    BFDEBUG("cr4: 0x%" PRIx64 "\n", ac->guest_vmcb->cr4);
 
     /**
      * Note:
      * - Get the VMCB's debug registers.
      */
 
-    vmcb->dr6 = arch_readdr6();
-    vmcb->dr7 = arch_readdr7();
+    ac->guest_vmcb->dr6 = arch_readdr6();
+    ac->guest_vmcb->dr7 = arch_readdr7();
 
-    BFDEBUG("dr6: 0x%" PRIx64 "\n", vmcb->dr6);
-    BFDEBUG("dr7: 0x%" PRIx64 "\n", vmcb->dr7);
+    BFDEBUG("dr6: 0x%" PRIx64 "\n", ac->guest_vmcb->dr6);
+    BFDEBUG("dr7: 0x%" PRIx64 "\n", ac->guest_vmcb->dr7);
 
     /**
      * Note:
@@ -609,39 +489,73 @@ configure_guest_vmcb(struct loader_arch_context_t *arch_context)
      * - Get and store the SYSENTER_CS, SYSENTER_ESP, SYSENTER_EIP
      */
 
-    arch_vmsave(arch_context->guest_vmcb_phys);
+    arch_vmsave(ac->guest_vmcb_phys);
+
+    BFDEBUG("fs_selector: 0x%x\n", ac->guest_vmcb->fs_selector);
+    BFDEBUG("fs_attrib: 0x%x\n", ac->guest_vmcb->fs_attrib);
+    BFDEBUG("fs_limit: 0x%x\n", ac->guest_vmcb->fs_limit);
+    BFDEBUG("fs_base: 0x%" PRIx64 "\n", ac->guest_vmcb->fs_base);
+    BFDEBUG("gs_selector: 0x%x\n", ac->guest_vmcb->gs_selector);
+    BFDEBUG("gs_attrib: 0x%x\n", ac->guest_vmcb->gs_attrib);
+    BFDEBUG("gs_limit: 0x%x\n", ac->guest_vmcb->gs_limit);
+    BFDEBUG("gs_base: 0x%" PRIx64 "\n", ac->guest_vmcb->gs_base);
+    BFDEBUG("tr_selector: 0x%x\n", ac->guest_vmcb->tr_selector);
+    BFDEBUG("tr_attrib: 0x%x\n", ac->guest_vmcb->tr_attrib);
+    BFDEBUG("tr_limit: 0x%x\n", ac->guest_vmcb->tr_limit);
+    BFDEBUG("tr_base: 0x%" PRIx64 "\n", ac->guest_vmcb->tr_base);
+    BFDEBUG("ldtr_selector: 0x%x\n", ac->guest_vmcb->ldtr_selector);
+    BFDEBUG("ldtr_attrib: 0x%x\n", ac->guest_vmcb->ldtr_attrib);
+    BFDEBUG("ldtr_limit: 0x%x\n", ac->guest_vmcb->ldtr_limit);
+    BFDEBUG("ldtr_base: 0x%" PRIx64 "\n", ac->guest_vmcb->ldtr_base);
+    BFDEBUG("kernel_gs_base: 0x%" PRIx64 "\n", ac->guest_vmcb->kernel_gs_base);
+    BFDEBUG("star: 0x%" PRIx64 "\n", ac->guest_vmcb->star);
+    BFDEBUG("lstar: 0x%" PRIx64 "\n", ac->guest_vmcb->lstar);
+    BFDEBUG("cstar: 0x%" PRIx64 "\n", ac->guest_vmcb->cstar);
+    BFDEBUG("sfmask: 0x%" PRIx64 "\n", ac->guest_vmcb->sfmask);
+    BFDEBUG("sysenter_cs: 0x%" PRIx64 "\n", ac->guest_vmcb->sysenter_cs);
+    BFDEBUG("sysenter_esp: 0x%" PRIx64 "\n", ac->guest_vmcb->sysenter_esp);
+    BFDEBUG("sysenter_eip: 0x%" PRIx64 "\n", ac->guest_vmcb->sysenter_eip);
+
+    /**
+     * Notes:
+     * - Done.
+     */
 
     return 0;
 }
 
 /**
  * <!-- description -->
- *   @brief Configure the host state save. The host state save is used
- *     by the VMRUN instruction to store state associated with the
- *     host. This state does not include the state that is saved using
- *     the vmsave instruction, which is why we also have a host VMCB.
- *     This function tells the hardware where to find this state save.
+ *   @brief Prepare the host state save. The host state save is used by the
+ *     VMRUN instruction to save/load some of the host's state. This does
+ *     not include the host VMCB state or the xsave state.
  *
  * <!-- inputs/outputs -->
- *   @param arch_context the architecture specific context for this cpu
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
-configure_host_state_save(struct loader_arch_context_t *arch_context)
+prepare_host_state_save(struct loader_arch_context_t *ac)
 {
-    if (NULL == arch_context) {
+    if (NULL == ac) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (NULL == arch_context->host_state_save_virt) {
-        BFERROR("invalid host state save virtual address\n");
-        return FAILURE;
+    /**
+     * Notes:
+     * - Allocate, validate and clear the host's state save
+     * - Get and validate the host state save's physical address
+     */
+
+    if (setup_virt((void **)&ac->host_save, sizeof(struct state_save_t), ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
     }
 
-    if (0U == arch_context->host_state_save_phys) {
-        BFERROR("invalid host state save physical address\n");
-        return FAILURE;
+    if (setup_phys(&ac->host_save_phys, ac->host_save, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
     }
 
     /**
@@ -649,9 +563,182 @@ configure_host_state_save(struct loader_arch_context_t *arch_context)
      * - Set the host state save area for this CPU.
      */
 
-    arch_wrmsr(MSR_VM_HSAVE_PA, arch_context->host_state_save_phys);
+    arch_wrmsr(MSR_VM_HSAVE_PA, ac->host_save_phys);
+
+    /**
+     * Notes:
+     * - Done.
+     */
 
     return 0;
+}
+
+/**
+ * <!-- description -->
+ *   @brief Prepare the guest state save. The guest state save is used to
+ *     store the state that the VMRUN does not store for the guest. This does
+ *     not include the guest VMCB state or the xsave state.
+ *
+ * <!-- inputs/outputs -->
+ *   @param ac the architecture specific context for this cpu
+ *   @return Returns 0 on success
+ */
+int64_t
+prepare_guest_state_save(struct loader_arch_context_t *ac)
+{
+    if (NULL == ac) {
+        BFERROR("invalid argument\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Allocate, validate and clear the guest's state save
+     * - Get and validate the guest state save's physical address
+     */
+
+    if (setup_virt((void **)&ac->guest_save, sizeof(struct state_save_t), ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_phys(&ac->guest_save_phys, ac->guest_save, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Done.
+     */
+
+    return 0;
+}
+
+/**
+ * <!-- description -->
+ *   @brief Prepare the host xsave area. The host xsave area is used to
+ *     save/load state the the VMRUN does not save/load for us that is
+ *     specifically handled by the xsave instruction. This does not include
+ *     the host VMCB state or the state save.
+ *
+ * <!-- inputs/outputs -->
+ *   @param ac the architecture specific context for this cpu
+ *   @return Returns 0 on success
+ */
+int64_t
+prepare_host_xsave_area(struct loader_arch_context_t *ac)
+{
+    if (NULL == ac) {
+        BFERROR("invalid argument\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Allocate, validate and clear the host's xsave area
+     * - Get and validate the host xsave area's physical address
+     */
+
+    if (setup_virt(&ac->host_xsave, ac->page_size, ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_phys(&ac->host_xsave_phys, ac->host_xsave, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Done.
+     */
+
+    return 0;
+}
+
+/**
+ * <!-- description -->
+ *   @brief Prepare the guest xsave area. The guest xsave area is used to
+ *     save/load state the the VMRUN does not save/load for us that is
+ *     specifically handled by the xsave instruction. This does not include
+ *     the guest VMCB state or the state save.
+ *
+ * <!-- inputs/outputs -->
+ *   @param ac the architecture specific context for this cpu
+ *   @return Returns 0 on success
+ */
+int64_t
+prepare_guest_xsave_area(struct loader_arch_context_t *ac)
+{
+    if (NULL == ac) {
+        BFERROR("invalid argument\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Allocate, validate and clear the guest's xsave area
+     * - Get and validate the guest xsave area's physical address
+     */
+
+    if (setup_virt(&ac->guest_xsave, ac->page_size, ac)) {
+        BFERROR("setup_virt failed\n");
+        return LOADER_FAILURE;
+    }
+
+    if (setup_phys(&ac->guest_xsave_phys, ac->guest_xsave, ac)) {
+        BFERROR("setup_phys failed\n");
+        return LOADER_FAILURE;
+    }
+
+    /**
+     * Notes:
+     * - Done.
+     */
+
+    return 0;
+}
+
+/**
+ * <!-- description -->
+ *   @brief Handles VMEXIT events. This occurs when the vmrun instruction
+ *     returns and an intercept must be handled.
+ *
+ * <!-- inputs/outputs -->
+ *   @param ac the architecture specific context for this cpu
+ */
+void
+arch_exit_handler(struct loader_arch_context_t *ac)
+{
+    switch (ac->guest_vmcb->exitcode) {
+        case VMEXIT_INVALID:
+            arch_write_serial("invalid guest state\n");
+            break;
+
+        case VMEXIT_CPUID:
+            arch_cpuid(
+                &ac->guest_vmcb->rax,
+                &ac->guest_save->rbx,
+                &ac->guest_save->rcx,
+                &ac->guest_save->rdx);
+
+            ac->guest_vmcb->rip = ac->guest_vmcb->nrip;
+            return;
+
+        case VMEXIT_VMMCALL:
+            arch_write_serial("intercepted vmmcall\n");
+            ac->guest_vmcb->rip = ac->guest_vmcb->nrip;
+            return;
+
+        default:
+            arch_write_serial("unhandled intercept\n");
+            break;
+    };
+
+    while (1) {
+    }
 }
 
 /**
@@ -664,23 +751,29 @@ configure_host_state_save(struct loader_arch_context_t *arch_context)
  * <!-- inputs/outputs -->
  *   @param cpu the id of the cpu to start
  *   @param context the common context for this cpu
- *   @param arch_context the architecture specific context for this cpu
+ *   @param ac the architecture specific context for this cpu
  *   @return Returns 0 on success
  */
 int64_t
 arch_start_vmm_per_cpu(                  // --
     uint32_t const cpu,                  // --
     struct loader_context_t *context,    // --
-    struct loader_arch_context_t *arch_context)
+    struct loader_arch_context_t *ac)
 {
-    if (NULL == context) {
-        BFERROR("invalid argument\n");
-        return FAILURE;
+    if (0 != cpu) {
+        return 0;
     }
 
-    if (NULL == arch_context) {
+    arch_write_serial("arch_start_vmm_per_cpu\n");
+
+    if (NULL == context) {
         BFERROR("invalid argument\n");
-        return FAILURE;
+        return LOADER_FAILURE;
+    }
+
+    if (NULL == ac) {
+        BFERROR("invalid argument\n");
+        return LOADER_FAILURE;
     }
 
     /**
@@ -688,55 +781,167 @@ arch_start_vmm_per_cpu(                  // --
      * - We need to get the physical address bit limit value from CPUID
      *   instead of hardcoding it.
      */
-    arch_context->page_size = 0x1000U;
-    arch_context->physical_address_bits = 48U;
+    ac->page_size = 0x1000U;
+    ac->physical_address_bits = 48U;
+    ac->host_stack_size = 0x10000;
+    ac->exit_handler = &arch_exit_handler;
 
     if (arch_check_hve_support()) {
-        BFERROR("arch_check_hve_support failed\n");
-        return FAILURE;
+        BFERROR("arch_check_hvm_support failed\n");
+        return LOADER_FAILURE;
     }
 
     if (enable_svm()) {
         BFERROR("enable_svm failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (prepare_host_vmcb(arch_context)) {
+    if (prepare_host_vmcb(ac)) {
         BFERROR("prepare_host_vmcb failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (prepare_guest_vmcb(arch_context)) {
+    if (prepare_guest_vmcb(ac)) {
         BFERROR("prepare_guest_vmcb failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (prepare_host_state_save(arch_context)) {
+    if (prepare_host_state_save(ac)) {
         BFERROR("prepare_host_state_save failed\n");
-        return FAILURE;
+        return LOADER_FAILURE;
     }
 
-    if (configure_host_vmcb(arch_context)) {
-        BFERROR("configure_host_vmcb failed\n");
-        return FAILURE;
+    if (prepare_guest_state_save(ac)) {
+        BFERROR("prepare_guest_state_save failed\n");
+        return LOADER_FAILURE;
     }
 
-    if (configure_guest_vmcb(arch_context)) {
-        BFERROR("configure_guest_vmcb failed\n");
-        return FAILURE;
+    if (prepare_host_xsave_area(ac)) {
+        BFERROR("prepare_host_xsave_area failed\n");
+        return LOADER_FAILURE;
     }
 
-    if (configure_host_state_save(arch_context)) {
-        BFERROR("configure_host_state_save failed\n");
-        return FAILURE;
+    if (prepare_guest_xsave_area(ac)) {
+        BFERROR("prepare_guest_xsave_area failed\n");
+        return LOADER_FAILURE;
     }
 
-    // uint64_t rflags;              ///< offset 0x0570
-    // uint64_t rip;                 ///< offset 0x0578
-    // uint64_t rsp;                 ///< offset 0x05D8
-    // uint64_t rax;                 ///< offset 0x05F8
-
-    BFDEBUG("starting hypervisor on cpu: %u\n", cpu);
+    arch_vmrun(ac);
+    arch_write_serial("root OS cpu now in a VM\n");
 
     return 0;
 }
+
+// // clang-format off
+
+// uint8_t *vmcb;
+
+// vmcb = ((uint8_t *)ac->guest_vmcb);
+
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x000,  *(uint32_t *)(vmcb + 0x000), "- intercept crs");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x004,  *(uint32_t *)(vmcb + 0x004), "- intercept drs");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x008,  *(uint32_t *)(vmcb + 0x008), "- intercept exceptions");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x00C,  *(uint32_t *)(vmcb + 0x00C), "- intercept misc1");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x010,  *(uint32_t *)(vmcb + 0x010), "- intercept misc2");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x014,  *(uint32_t *)(vmcb + 0x014), "- intercept misc3");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x058,  *(uint32_t *)(vmcb + 0x058), "- asid");
+
+// vmcb += 0x400;
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x000,  *(uint16_t *)(vmcb + 0x000), "- es selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x002,  *(uint16_t *)(vmcb + 0x002), "- es attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x004,  *(uint32_t *)(vmcb + 0x004), "- es limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x008,  *(uint64_t *)(vmcb + 0x008), "- es base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x010,  *(uint16_t *)(vmcb + 0x010), "- cs selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x012,  *(uint16_t *)(vmcb + 0x012), "- cs attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x014,  *(uint32_t *)(vmcb + 0x014), "- cs limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x018,  *(uint64_t *)(vmcb + 0x018), "- cs base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x020,  *(uint16_t *)(vmcb + 0x020), "- ss selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x022,  *(uint16_t *)(vmcb + 0x022), "- ss attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x024,  *(uint32_t *)(vmcb + 0x024), "- ss limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x028,  *(uint64_t *)(vmcb + 0x028), "- ss base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x030,  *(uint16_t *)(vmcb + 0x030), "- ds selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x032,  *(uint16_t *)(vmcb + 0x032), "- ds attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x034,  *(uint32_t *)(vmcb + 0x034), "- ds limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x038,  *(uint64_t *)(vmcb + 0x038), "- ds base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x040,  *(uint16_t *)(vmcb + 0x040), "- fs selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x042,  *(uint16_t *)(vmcb + 0x042), "- fs attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x044,  *(uint32_t *)(vmcb + 0x044), "- fs limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x048,  *(uint64_t *)(vmcb + 0x048), "- fs base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x050,  *(uint16_t *)(vmcb + 0x050), "- gs selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x052,  *(uint16_t *)(vmcb + 0x052), "- gs attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x054,  *(uint32_t *)(vmcb + 0x054), "- gs limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x058,  *(uint64_t *)(vmcb + 0x058), "- gs base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x060,  *(uint16_t *)(vmcb + 0x060), "- gdtr selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x062,  *(uint16_t *)(vmcb + 0x062), "- gdtr attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x064,  *(uint32_t *)(vmcb + 0x064), "- gdtr limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x068,  *(uint64_t *)(vmcb + 0x068), "- gdtr base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x070,  *(uint16_t *)(vmcb + 0x070), "- ldtr selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x072,  *(uint16_t *)(vmcb + 0x072), "- ldtr attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x074,  *(uint32_t *)(vmcb + 0x074), "- ldtr limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x078,  *(uint64_t *)(vmcb + 0x078), "- ldtr base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x080,  *(uint16_t *)(vmcb + 0x080), "- idtr selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x082,  *(uint16_t *)(vmcb + 0x082), "- idtr attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x084,  *(uint32_t *)(vmcb + 0x084), "- idtr limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x088,  *(uint64_t *)(vmcb + 0x088), "- idtr base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x090,  *(uint16_t *)(vmcb + 0x090), "- tr selector");
+// BFDEBUG("[0x%03x]: 0x%04x              %s\n",    0x092,  *(uint16_t *)(vmcb + 0x092), "- tr attributes");
+// BFDEBUG("[0x%03x]: 0x%08x          %s\n",        0x094,  *(uint32_t *)(vmcb + 0x094), "- tr limit");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x098,  *(uint64_t *)(vmcb + 0x098), "- tr base");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%02x                %s\n",  0x0CB,  *(uint8_t *)(vmcb + 0x0CB), "- cpl");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x0D0,  *(uint64_t *)(vmcb + 0x0D0), "- efer");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x148,  *(uint64_t *)(vmcb + 0x148), "- cr4");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x150,  *(uint64_t *)(vmcb + 0x150), "- cr3");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x158,  *(uint64_t *)(vmcb + 0x158), "- cr0");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x160,  *(uint64_t *)(vmcb + 0x160), "- dr7");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x168,  *(uint64_t *)(vmcb + 0x168), "- dr6");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x170,  *(uint64_t *)(vmcb + 0x170), "- rflags");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x178,  *(uint64_t *)(vmcb + 0x178), "- rip");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x1D8,  *(uint64_t *)(vmcb + 0x1D8), "- rsp");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x1F8,  *(uint64_t *)(vmcb + 0x1F8), "- rax");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x200,  *(uint64_t *)(vmcb + 0x200), "- star");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x208,  *(uint64_t *)(vmcb + 0x208), "- lstar");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x210,  *(uint64_t *)(vmcb + 0x210), "- cstar");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x218,  *(uint64_t *)(vmcb + 0x218), "- sfmask");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x220,  *(uint64_t *)(vmcb + 0x220), "- kernel gs base");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x228,  *(uint64_t *)(vmcb + 0x228), "- sysenter_cs");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x230,  *(uint64_t *)(vmcb + 0x230), "- sysenter_esp");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x238,  *(uint64_t *)(vmcb + 0x238), "- sysenter_eip");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x240,  *(uint64_t *)(vmcb + 0x240), "- cr2");
+// BFDEBUG("\n");
+
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x268,  *(uint64_t *)(vmcb + 0x268), "- pat");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x270,  *(uint64_t *)(vmcb + 0x270), "- dbgctl");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x278,  *(uint64_t *)(vmcb + 0x278), "- br from");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x280,  *(uint64_t *)(vmcb + 0x280), "- br to");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x288,  *(uint64_t *)(vmcb + 0x288), "- last exception from");
+// BFDEBUG("[0x%03x]: 0x%016llx  %s\n",             0x290,  *(uint64_t *)(vmcb + 0x290), "- last except to");
+// BFDEBUG("\n");

--- a/loader/src/x64/arch_serial.c
+++ b/loader/src/x64/arch_serial.c
@@ -1,0 +1,88 @@
+/**
+ * @copyright
+ * Copyright (C) 2020 Assured Information Security, Inc.
+ *
+ * @copyright
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * @copyright
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * @copyright
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <loader_intrinsics.h>
+#include <loader_types.h>
+#include <loader.h>
+
+#define baud_rate_lo_reg ((uint16_t)0U)
+#define baud_rate_hi_reg ((uint16_t)1U)
+#define interrupt_en_reg ((uint16_t)1U)
+#define fifo_control_reg ((uint16_t)2U)
+#define line_control_reg ((uint16_t)3U)
+#define line__status_reg ((uint16_t)5U)
+
+#define fifo_control_enable_fifos ((uint8_t)1U << 0U)
+#define fifo_control_clear_recieve_fifo ((uint8_t)1U << 1U)
+#define fifo_control_clear_transmit_fifo ((uint8_t)1U << 2U)
+
+static uint8_t
+serial_inb(uint16_t addr)
+{
+    addr += 0x03F8U;
+    return arch_inb(addr);
+}
+
+static void
+serial_outb(uint16_t addr, uint8_t const data)
+{
+    addr += 0x03F8U;
+    arch_outb(addr, data);
+}
+
+static uint8_t
+serial_is_transmit_empty(void)
+{
+    return serial_inb(line__status_reg) & (1U << 5U);
+}
+
+void
+arch_init_serial(void)
+{
+    uint8_t bits = 0U;
+    bits |= fifo_control_enable_fifos;
+    bits |= fifo_control_clear_recieve_fifo;
+    bits |= fifo_control_clear_transmit_fifo;
+
+    serial_outb(line_control_reg, 0x80);
+    serial_outb(baud_rate_lo_reg, 0x01);
+    serial_outb(baud_rate_hi_reg, 0x00);
+    serial_outb(line_control_reg, 0x03);
+    serial_outb(interrupt_en_reg, 0x00);
+    serial_outb(fifo_control_reg, bits);
+}
+
+void
+arch_write_serial(char const *const str)
+{
+    int i;
+    while (serial_is_transmit_empty() == 0)
+        ;
+
+    for (i = 0; str[i] != '\0'; ++i) {
+        serial_outb(0, str[i]);
+    }
+}

--- a/loader/src/x64/intel/arch_check_hvm_support.c
+++ b/loader/src/x64/intel/arch_check_hvm_support.c
@@ -1,5 +1,3 @@
-/* SPDX-License-Identifier: SPDX-License-Identifier: GPL-2.0 OR MIT */
-
 /**
  * @copyright
  * Copyright (C) 2020 Assured Information Security, Inc.
@@ -26,13 +24,26 @@
  * SOFTWARE.
  */
 
-    .code64
-    .intel_syntax noprefix
+#include <loader_debug.h>
+#include <loader_intrinsics.h>
+#include <loader_types.h>
+#include <loader.h>
 
-    .globl  arch_sgdt
-    .type   arch_sgdt, @function
-arch_sgdt:
+/**
+ * <!-- description -->
+ *   @brief This function checks to see if Intel VT-x support is available on
+ *     the currently running CPU
+ *
+ * <!-- inputs/outputs -->
+ *   @return Returns 0 on success
+ */
+int64_t
+arch_check_hvm_support(void)
+{
+    /**
+     * See AMD arch_check_svm_support() for details on how to implement
+     * this function
+     */
 
-    sgdt [rdi]
-    ret
-    .size arch_sgdt, .-arch_sgdt
+    return 0;
+}

--- a/loader/src/x64/intel/arch_loader_fini.c
+++ b/loader/src/x64/intel/arch_loader_fini.c
@@ -26,6 +26,7 @@
 
 #include <loader_arch.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/x64/intel/arch_loader_init.c
+++ b/loader/src/x64/intel/arch_loader_init.c
@@ -26,6 +26,7 @@
 
 #include <loader_arch.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/x64/intel/arch_start_vmm_per_cpu.c
+++ b/loader/src/x64/intel/arch_start_vmm_per_cpu.c
@@ -30,6 +30,7 @@
 #include <loader_debug.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->

--- a/loader/src/x64/intel/arch_stop_vmm_per_cpu.c
+++ b/loader/src/x64/intel/arch_stop_vmm_per_cpu.c
@@ -30,6 +30,7 @@
 #include <loader_debug.h>
 #include <loader_platform.h>
 #include <loader_types.h>
+#include <loader.h>
 
 /**
  * <!-- description -->


### PR DESCRIPTION
This patch enables the ability to launch the VMM on AMD on a
single core. It uses an old hack to deal with a lack of our
own CR3, which will be removed once we have the CR3 part
added, and as a result, it only works on single core. It also
cannot be stopped, as that logic is really specific to the
way that the VMM was launched which will change once all of
this code is moved to C++, so that functionality will come
later as well.