### PR TITLE
Improve NMI handling

### DIFF
--- a/bfvmm/include/hve/arch/intel_x64/vcpu_state.h
+++ b/bfvmm/include/hve/arch/intel_x64/vcpu_state.h
@@ -68,6 +68,9 @@ struct vcpu_state_t {
     uint64_t dr2;                   // 0x0F8
     uint64_t dr3;                   // 0x100
     uint64_t dr6;                   // 0x108
+
+    uint64_t nmi_flag;              // 0x110
+    uint64_t nmi_count;             // 0x118
 };
 
 }

--- a/bfvmm/src/hve/arch/intel_x64/vmcs_resume.asm
+++ b/bfvmm/src/hve/arch/intel_x64/vmcs_resume.asm
@@ -25,6 +25,8 @@ default rel
 %define IA32_XSS_MSR   0xDA0
 %define VMCS_GUEST_RSP 0x0000681C
 %define VMCS_GUEST_RIP 0x0000681E
+%define VMCS_PROC_CTRL 0x00004002
+%define NMI_WINDOW_EXITING 0x400000
 
 global vmcs_resume:function
 
@@ -92,6 +94,41 @@ vmcs_resume:
     mov rsi, VMCS_GUEST_RIP
     vmwrite rsi, [rdi + 0x078]
 
+    ; Set nmi_flag. This tells the NMI handler that it is safe to
+    ; enable the NMI-window exit.
+    ;
+    ; Note that all references to nmi_flag (0x110) and nmi_count (0x118)
+    ; must be done via gs and not rdi because rdi != gs on
+    ; world-switches, and, for any given exit, gs is constant.
+    ;
+    ; Note that an lfence is required to ensure that the store to
+    ; nmi_flag completes *locally* prior to the load from nmi_count below.
+    ; The store may not be globally visible prior to the load, but that
+    ; is fine since the data isn't being shared with other CPUs.
+
+    mov qword [gs:0x110], 1
+    lfence
+
+    ; Load nmi_count then reset it to 0. If it was zero, then
+    ; no NMI occured prior to setting nmi_flag to 1, so restore
+    ; the guest GPRs like normal.
+
+    mov rax, [gs:0x118]
+    mov qword [gs:0x118], 0
+    cmp rax, 0
+    je .restore_gprs
+
+    ; Since nmi_count != 0, we know an NMI fired during this exit but
+    ; before setting nmi_flag above. So enable NMI-window exiting on
+    ; the current vmcs, i.e., the one being resumed:
+
+    mov rsi, VMCS_PROC_CTRL
+    vmread rax, rsi
+    or rax, NMI_WINDOW_EXITING
+    vmwrite rsi, rax
+
+.restore_gprs:
+
     mov r15, [rdi + 0x070]
     mov r14, [rdi + 0x068]
     mov r13, [rdi + 0x060]
@@ -109,6 +146,28 @@ vmcs_resume:
 
     mov rdi, [rdi + 0x030]
 
+    ; Clear nmi_flag and do the resume
+    ;
+    ; In general, this is done so that if an NMI occurs while the
+    ; next exit is being handled (but before nmi_flag is set to 1 on
+    ; the next resume), the NMI handler will increment nmi_count, which
+    ; will then be read by the above code as non-zero and cause the
+    ; vmwrite with NMI_WINDOW_EXITING enabled.
+    ;
+    ; However, the mov must immediately precede vmresume to handle
+    ; the case where an NMI occurs after nmi_flag is cleared
+    ; but before vmresume: If the NMI handler sees nmi_flag == 0,
+    ; it decodes the instruction referenced by RIP that was pushed
+    ; onto the stack by the CPU when the NMI fired. If it isn't
+    ; the vmresume opcode, it increments nmi_count, otherwise it
+    ; enables NMI-window exiting.
+    ;
+    ; The lfence is used to ensure the mov instruction is not reordered
+    ; in front of instructions prior to the fence. It is assumed that
+    ; the vmresume will not be reordered in front of the mov.
+
+    lfence
+    mov qword [gs:0x110], 0
     vmresume
 
 ; We should never get this far. If we do, it's because the resume failed. If


### PR DESCRIPTION
This patch modifies the way NMIs are handled when running in the
VMM. The old approach unconditionally enables NMI-window exiting
and injects the NMI when the window exit occurs. This works fine
as long the vcpu that caused the exit is the same one that is
subsequently entered.

However if a different one is entered, since NMIs can fire on any
instruction in the VMM, it is possible for the NMI-window exit to be
enabled on the vcpu that is *not* being entered. In this case the NMI
sits in the non-current VMCS for an indeterminate amount of time.

These changes ensure that no matter when the NMI is taken, the NMI-window
exit is always enabled on the VMCS that is being entered (i.e. with
vmlaunch or vmresume). It also eliminates races with accesses to the
VMCS field from C++ that control the window exit, by ensuring that
the field is only read and written in the vmcs_resume or
vmcs_launch code.