### PR TITLE
Fix Windows IOCTL Interface

### DIFF
--- a/loader/efi/CMakeLists.txt
+++ b/loader/efi/CMakeLists.txt
@@ -65,7 +65,7 @@ list(APPEND HEADERS
 	${CMAKE_CURRENT_LIST_DIR}/include/efi/efi_types.h
 	${CMAKE_CURRENT_LIST_DIR}/include/efi/extened_processor_information.h
 	${CMAKE_CURRENT_LIST_DIR}/include/types.h
-	${CMAKE_CURRENT_LIST_DIR}/src/platform_on_each_cpu_callback_args.h
+	${CMAKE_CURRENT_LIST_DIR}/include/work_on_cpu_callback_args.h
 	${CMAKE_CURRENT_LIST_DIR}/../include/interface/c/bfelf/bfelf_elf64_ehdr_t.h
 	${CMAKE_CURRENT_LIST_DIR}/../include/interface/c/bfelf/bfelf_elf64_phdr_t.h
 	${CMAKE_CURRENT_LIST_DIR}/../include/interface/c/bfelf/bfelf_types.h

--- a/loader/efi/include/work_on_cpu_callback_args.h
+++ b/loader/efi/include/work_on_cpu_callback_args.h
@@ -1,0 +1,63 @@
+/**
+ * @copyright
+ * Copyright (C) 2020 Assured Information Security, Inc.
+ *
+ * @copyright
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * @copyright
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * @copyright
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PLATFORM_ON_EACH_CPU_CALLBACK_ARGS_H
+#define PLATFORM_ON_EACH_CPU_CALLBACK_ARGS_H
+
+#include <platform.h>
+#include <types.h>
+
+/**
+ * @struct work_on_cpu_callback_args
+ *
+ * <!-- description -->
+ *   @brief Defines the args passed to the platform_on_each_cpu_callback
+ *     function.
+ */
+struct work_on_cpu_callback_args
+{
+    /**
+     * @brief The fucntion to call from platform_on_each_cpu_callback
+     */
+    platform_per_cpu_func func;
+
+    /**
+     * @brief The CPU platform_on_each_cpu_callback is called on
+     */
+    uint32_t cpu;
+
+    /**
+     * @brief reserved
+     */
+    uint32_t reserved;
+
+    /**
+     * @brief The return value of 'func'
+     */
+    int64_t ret;
+};
+
+#endif

--- a/loader/linux/include/work_on_cpu_callback_args.h
+++ b/loader/linux/include/work_on_cpu_callback_args.h
@@ -1,0 +1,63 @@
+/**
+ * @copyright
+ * Copyright (C) 2020 Assured Information Security, Inc.
+ *
+ * @copyright
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * @copyright
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * @copyright
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef PLATFORM_ON_EACH_CPU_CALLBACK_ARGS_H
+#define PLATFORM_ON_EACH_CPU_CALLBACK_ARGS_H
+
+#include <platform.h>
+#include <types.h>
+
+/**
+ * @struct work_on_cpu_callback_args
+ *
+ * <!-- description -->
+ *   @brief Defines the args passed to the platform_on_each_cpu_callback
+ *     function.
+ */
+struct work_on_cpu_callback_args
+{
+    /**
+     * @brief The fucntion to call from platform_on_each_cpu_callback
+     */
+    platform_per_cpu_func func;
+
+    /**
+     * @brief The CPU platform_on_each_cpu_callback is called on
+     */
+    uint32_t cpu;
+
+    /**
+     * @brief reserved
+     */
+    uint32_t reserved;
+
+    /**
+     * @brief The return value of 'func'
+     */
+    int64_t ret;
+};
+
+#endif

--- a/loader/src/start_vmm.c
+++ b/loader/src/start_vmm.c
@@ -262,32 +262,23 @@ verify_start_vmm_args(struct start_vmm_args_t const *const args)
  *     will call platform and architecture specific functions as needed.
  *
  * <!-- inputs/outputs -->
- *   @param ioctl_args arguments from the ioctl
+ *   @param args arguments from the ioctl
  *   @return 0 on success, LOADER_FAILURE on failure.
  */
 int64_t
-start_vmm(struct start_vmm_args_t const *const ioctl_args)
+start_vmm(struct start_vmm_args_t const *const args)
 {
-    int64_t ret;
-    struct start_vmm_args_t args;
-
-    if (((void *)0) == ioctl_args) {
-        bferror("ioctl_args was NULL");
+    if (((void *)0) == args) {
+        bferror("args was NULL");
         return LOADER_FAILURE;
     }
 
-    ret = platform_copy_from_user(&args, ioctl_args, sizeof(struct start_vmm_args_t));
-    if (ret) {
-        bferror("platform_copy_from_user failed");
-        return LOADER_FAILURE;
-    }
-
-    if (verify_start_vmm_args(&args)) {
+    if (verify_start_vmm_args(args)) {
         bferror("verify_start_vmm_args failed");
         return LOADER_FAILURE;
     }
 
-    if (alloc_and_start_the_vmm(&args)) {
+    if (alloc_and_start_the_vmm(args)) {
         bferror("alloc_and_start_the_vmm failed");
         return LOADER_FAILURE;
     }

--- a/loader/src/stop_vmm.c
+++ b/loader/src/stop_vmm.c
@@ -57,27 +57,18 @@ verify_stop_vmm_args(struct stop_vmm_args_t const *const args)
  *     will call platform and architecture specific functions as needed.
  *
  * <!-- inputs/outputs -->
- *   @param ioctl_args arguments from the ioctl
+ *   @param args arguments from the ioctl
  *   @return 0 on success, LOADER_FAILURE on failure.
  */
 int64_t
-stop_vmm(struct stop_vmm_args_t const *const ioctl_args)
+stop_vmm(struct stop_vmm_args_t const *const args)
 {
-    int64_t ret;
-    struct stop_vmm_args_t args;
-
-    if (((void *)0) == ioctl_args) {
-        bferror("ioctl_args was NULL");
+    if (((void *)0) == args) {
+        bferror("args was NULL");
         return LOADER_FAILURE;
     }
 
-    ret = platform_copy_from_user(&args, ioctl_args, sizeof(struct stop_vmm_args_t));
-    if (ret) {
-        bferror("platform_copy_from_user failed");
-        return LOADER_FAILURE;
-    }
-
-    if (verify_stop_vmm_args(&args)) {
+    if (verify_stop_vmm_args(args)) {
         bferror("verify_stop_vmm_args failed");
         return LOADER_FAILURE;
     }

--- a/loader/windows/include/work_on_cpu_callback_args.h
+++ b/loader/windows/include/work_on_cpu_callback_args.h
@@ -31,13 +31,13 @@
 #include <types.h>
 
 /**
- * @struct platform_on_each_cpu_callback_args
+ * @struct work_on_cpu_callback_args
  *
  * <!-- description -->
  *   @brief Defines the args passed to the platform_on_each_cpu_callback
  *     function.
  */
-struct platform_on_each_cpu_callback_args
+struct work_on_cpu_callback_args
 {
     /**
      * @brief The fucntion to call from platform_on_each_cpu_callback
@@ -48,6 +48,11 @@ struct platform_on_each_cpu_callback_args
      * @brief The CPU platform_on_each_cpu_callback is called on
      */
     uint32_t cpu;
+
+    /**
+     * @brief Singals when the DPC is done.
+     */
+    uint32_t done;
 
     /**
      * @brief The return value of 'func'

--- a/utils/loop.sh
+++ b/utils/loop.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# Copyright (C) 2020 Assured Information Security, Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+if [ $# -ne 0 ]; then
+    ITERATIONS=$1
+else
+    ITERATIONS=100
+fi
+
+for ((i = 0 ; i <= $ITERATIONS ; i++));
+do
+    cmake --build . --target start
+    cmake --build . --target stop
+done


### PR DESCRIPTION
This patch converts the core scheduling logic to the DPC interface
which prevents random crashes if the core is changed after affinity
is set. It also adds MDL page locks to the copy to/from user logic.