### PR TITLE
First VMExit Failure Logic

### DIFF
--- a/example/default/main.cpp
+++ b/example/default/main.cpp
@@ -86,6 +86,16 @@ namespace example
         ///   fault system works properly during testing.
         ///
 
+        /// NOTE:
+        /// - To report success, i.e., you can continue, nothing to see here,
+        ///   you need to execute a run API. If you are doing integration
+        ///   testing, this would be bf_vps_op_advance_ip_and_run_current.
+        ///   If you are cleaning up from a VM failure, you would typically
+        ///   run bf_vps_op_run as you should know exactly what parameters
+        ///   to give it. If you need to know what VM, VP and VPS are
+        ///   currently running, you can use the TLS functions.
+        ///
+
         bsl::print<bsl::V>() << bsl::here();
         syscall::bf_control_op_exit();
     }

--- a/kernel/src/fast_fail_trampoline.cpp
+++ b/kernel/src/fast_fail_trampoline.cpp
@@ -41,9 +41,9 @@ namespace mk
     /// <!-- inputs/outputs -->
     ///   @param tls the current TLS block
     ///
-    extern "C" void
-    fast_fail_trampoline(tls_t *const tls) noexcept
+    extern "C" [[nodiscard]] auto
+    fast_fail_trampoline(tls_t *const tls) noexcept -> bsl::exit_code
     {
-        fast_fail(*tls, static_cast<mk_ext_type *>(tls->ext_fail));
+        return fast_fail(*tls, static_cast<mk_ext_type *>(tls->ext_fail));
     }
 }

--- a/kernel/src/mk_main.hpp
+++ b/kernel/src/mk_main.hpp
@@ -414,12 +414,12 @@ namespace mk
             // [x] implement simplify the example as much as possible
             // [x] implement error on VMX instructions on Intel
             // [x] implement error on SVM instructions on AMD
-            // [ ] implement fix for vmexit first crash (vmxoff and check state)
+            // [x] implement fix for vmexit first crash (vmxoff and check state)
             // [x] implement fix for 128 cores on Windows
             // [x] implement alloc page
             // [ ] implement free page
+            // [ ] implement TLS functions for ext_id, vmid, vpid and vpsid
             // [x] implement virt_to_phys
-            // [ ] implement make ack
             // [ ] implement debugging mutex/transaction support
             // [x] implement Windows support
             // [x] implement UEFI support
@@ -430,7 +430,9 @@ namespace mk
             // [ ] implement per-VM direct maps
             // [x] implement reduce the size of the TLS block
             // [ ] implement optimizations for release builds
+            // [ ] implement dump function for AMD vps
             // [ ] implement dump functions for all types
+            // [ ] implement contants for all of the asm logic
             // [ ] implement all debug ops
             // [ ] implement some basic unit tests
             // [ ] implement some basic syscall tests

--- a/kernel/src/x64/fast_fail_entry.S
+++ b/kernel/src/x64/fast_fail_entry.S
@@ -34,5 +34,12 @@ fast_fail_entry:
     mov rdi, gs:[0x200]
     call fast_fail_trampoline
 
+    cmp rax, 0x0
+    je fast_fail_trampoline_success
     jmp intrinsic_halt
+
+fast_fail_trampoline_success:
+    ret
+    int 3
+
     .size fast_fail_entry, .-fast_fail_entry

--- a/kernel/src/x64/intel/intrinsic_t.S
+++ b/kernel/src/x64/intel/intrinsic_t.S
@@ -732,29 +732,6 @@ intrinsic_vmexit:
     mov [r15 + 0x0D8], rax
 
     /**************************************************************************/
-    /* Signal First Launch Success                                            */
-    /**************************************************************************/
-
-    mov rax, gs:[0x270]
-    cmp rax, 0x0
-    jne skip_first_launch_logic
-
-    mov rax, 0x1
-    mov gs:[0x270], rax
-
-    lea rax, [rip + fast_fail_entry]
-    mov gs:[0x180], rax
-    mov rax, 0x0
-    mov gs:[0x188], rax
-
-    lea rax, [rip + fast_fail_entry]
-    mov gs:[0x190], rax
-    mov rax, 0x0
-    mov gs:[0x198], rax
-
-skip_first_launch_logic:
-
-    /**************************************************************************/
     /* NMIs                                                                   */
     /**************************************************************************/
 

--- a/kernel/src/x64/vmexit_loop_entry.S
+++ b/kernel/src/x64/vmexit_loop_entry.S
@@ -31,24 +31,107 @@
     .type   vmexit_loop_entry, @function
 vmexit_loop_entry:
 
-    lea rax, [rip + loop]
-    mov gs:[0x1C0], rax
-    mov gs:[0x1C8], rsp
-
-loop:
+    /**************************************************************************/
+    /* Call VMExit Handler                                                      */
+    /**************************************************************************/
 
     mov rdi, gs:[0x200]
     call vmexit_loop_trampoline
 
-    cmp rax, 0x0
-    je loop
+    /**************************************************************************/
+    /* First Exit Logic                                                       */
+    /**************************************************************************/
+
+    /**
+     * NOTE:
+     * - If this is the first VMExit, we handle how we loop differently, as we
+     *   are still able to return back to the loader in this specific case.
+     * - The following checks to see if this is our first exit
+     */
+
+    push rax
 
     mov rax, gs:[0x270]
     cmp rax, 0x0
-    jne fast_fail_entry
+    jne skip_first_launch_logic
+
+    pop rax
+
+    cmp rax, 0x0
+    je install_fast_fail_and_continue_loop
+
+    /**
+     * NOTE:
+     * - If we get here, it is because our first exit failed, in which case
+     *   we can return from this function, and a proper exit will occur
+     */
 
     mov rax, 0x1
     ret
     int 3
+
+install_fast_fail_and_continue_loop:
+
+    /**
+     * NOTE:
+     * - If we get here, it is because the VMExit was successful, in which
+     *   case, we need to state that the next exit will not be our first,
+     *   and then insteall our fast fail entry point which is what will
+     *   execute in the event of an error instead of the current fast fail
+     *   entry point, which depends on what was executing at the time of the
+     *   error occuring.
+     */
+
+    mov rax, 0x1
+    mov gs:[0x270], rax
+
+    lea rax, [rip + fast_fail_entry]
+    mov gs:[0x180], rax
+    mov rax, 0x0
+    mov gs:[0x188], rax
+
+    lea rax, [rip + fast_fail_entry]
+    mov gs:[0x190], rax
+    mov rax, 0x0
+    mov gs:[0x198], rax
+
+    jmp vmexit_loop_entry
+
+skip_first_launch_logic:
+
+    pop rax
+
+    /**************************************************************************/
+    /* Remaining Exit Logic                                                   */
+    /**************************************************************************/
+
+    /**
+     * NOTE:
+     * - If got here, it means that this is the second (or more) VMExit.
+     *   This is the typical path that the code will take. In this path, we
+     *   need to determine if an error occured.
+     * - If the VMExit handler returned an error, we need to call the fast
+     *   fail path, which will allow the extension to decide what to do. If
+     *   the extension doesn't know what to do, we will have to halt. If it
+     *   handles the issue, we can continue the loop.
+     */
+
+
+    cmp rax, 0x0
+    je vmexit_loop_entry
+
+    mov rdi, gs:[0x200]
+    call fast_fail_entry
+
+    cmp rax, 0x0
+    je vmexit_loop_entry
+
+    /**
+     * Note:
+     * - The following should be unreachable, but is here just in case that
+     *   assumption becomes invalid.
+     */
+
+    jmp intrinsic_halt
 
     .size vmexit_loop_entry, .-vmexit_loop_entry

--- a/loader/efi/src/x64/demote.S
+++ b/loader/efi/src/x64/demote.S
@@ -301,6 +301,29 @@ gdt_and_cs_loaded:
 
 demotion_success:
 
+    /**
+     * NOTE:
+     * - If demotion is successful, before we return back to the loader, we
+     *   ensure that at least one exit occurs. This is done to properly handle
+     *   errors with the first VMExit. Specifically, if the first VMExit
+     *   generates a failure, it needs to return to loader. The state in
+     *   the root VP, which is what it will use to return is still the same
+     *   at this point, so a return is safe.
+     */
+
+    push rax
+    push rbx
+    push rcx
+    push rdx
+
+    mov rax, 0
+    cpuid
+
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
+
     call enable_interrupts
     ret
     int 3

--- a/loader/linux/src/x64/demote.S
+++ b/loader/linux/src/x64/demote.S
@@ -305,6 +305,29 @@ gdt_and_cs_loaded:
 
 demotion_success:
 
+    /**
+     * NOTE:
+     * - If demotion is successful, before we return back to the loader, we
+     *   ensure that at least one exit occurs. This is done to properly handle
+     *   errors with the first VMExit. Specifically, if the first VMExit
+     *   generates a failure, it needs to return to loader. The state in
+     *   the root VP, which is what it will use to return is still the same
+     *   at this point, so a return is safe.
+     */
+
+    push rax
+    push rbx
+    push rcx
+    push rdx
+
+    mov rax, 0
+    cpuid
+
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
+
     call enable_interrupts
     ret
     int 3

--- a/loader/windows/src/x64/demote.asm
+++ b/loader/windows/src/x64/demote.asm
@@ -297,6 +297,28 @@ gdt_and_cs_loaded:
 
 demotion_success:
 
+
+    ; NOTE:
+    ; - If demotion is successful, before we return back to the loader, we
+    ;   ensure that at least one exit occurs. This is done to properly handle
+    ;   errors with the first VMExit. Specifically, if the first VMExit
+    ;   generates a failure, it needs to return to loader. The state in
+    ;   the root VP, which is what it will use to return is still the same
+    ;   at this point, so a return is safe.
+
+    push rax
+    push rbx
+    push rcx
+    push rdx
+
+    mov rax, 0
+    cpuid
+
+    pop rdx
+    pop rcx
+    pop rbx
+    pop rax
+
     call enable_interrupts
     ret
     int 3

--- a/vmmctl/src/vmmctl_main.hpp
+++ b/vmmctl/src/vmmctl_main.hpp
@@ -105,7 +105,7 @@ namespace vmmctl
             -> bsl::exit_code
         {
             if (!ctl.write(request, ctl_args, bsl::size_of<A>())) {
-                bsl::error() << "command failed. check kernel logs details\n";
+                bsl::error() << "vmmctl failed. check kernel logs details\n";
                 return bsl::exit_failure;
             }
 
@@ -132,7 +132,7 @@ namespace vmmctl
             -> bsl::exit_code
         {
             if (!ctl.read_write(request, ctl_args, bsl::size_of<A>())) {
-                bsl::error() << "command failed. check kernel logs details\n";
+                bsl::error() << "vmmctl failed. check kernel logs details\n";
                 return bsl::exit_failure;
             }
 


### PR DESCRIPTION
This patch cleans up the first VMExit failure logic so that
it actually makes sense and works as intended. Now, if you
have an exception, or error on your first exit, the hypervior
will gracefully exit instead of halting, or pretending to
gracefully exit when in fact it was just getting luck.