### PR TITLE
 Changed Makefile for linux loader to support different locales

### DIFF
--- a/loader/linux/Makefile
+++ b/loader/linux/Makefile
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 TARGET_MODULE := bareflank_loader
-VENDOR_ID := $(shell lscpu | grep 'Vendor ID')
+VENDOR_ID := $(shell lscpu)
 
 ifneq ($(KERNELRELEASE),)
 	obj-m := $(TARGET_MODULE).o


### PR DESCRIPTION
When building on Linux with a non-english locale setting, the output of `lscpu` might be non-english and therefore not contain the string "Vendor ID", resulting in failing build process.

I think this fix won't hurt, but if you decide to only support english language settings, that's also fine. 

Quick example of my output:

``` 
Architektur:                     x86_64
CPU Operationsmodus:             32-bit, 64-bit
Byte-Reihenfolge:                Little Endian
Adressgrößen:                    39 bits physical, 48 bits virtual
CPU(s):                          12
Liste der Online-CPU(s):         0-11
Thread(s) pro Kern:              2
Kern(e) pro Sockel:              6
Sockel:                          1
NUMA-Knoten:                     1
Anbieterkennung:                 GenuineIntel
Prozessorfamilie:                6
Modell:                          158
Modellname:                      Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz
Stepping:                        10
CPU MHz:                         2200.000
Maximale Taktfrequenz der CPU:   4100,0000
Minimale Taktfrequenz der CPU:   800,0000
BogoMIPS:                        4401.32
Virtualisierung:                 VT-x
L1d Cache:                       192 KiB
L1i Cache:                       192 KiB
L2 Cache:                        1,5 MiB
L3 Cache:                        9 MiB
NUMA-Knoten0 CPU(s):             0-11

```