### PR TITLE
Loader: Fix machine hang when loading the hypervisor

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -2,9 +2,9 @@ name: CI Tests
 
 on:
   push:
-    branches: [ master ]
+    paths-ignore: ['**.md']
   pull_request:
-    branches: [ master ]
+    paths-ignore: ['**.md']
 
 jobs:
   Doxygen:

--- a/.gitignore
+++ b/.gitignore
@@ -77,6 +77,7 @@ loader/**/*.mod.cmd
 loader/**/*.o
 loader/**/*.o.cmd
 loader/**/*.cmd
+loader/**/*.dwo
 
 # Windows Loader
 loader/windows/x64/

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,7 @@ loader/**/*.o
 loader/**/*.o.cmd
 loader/**/*.cmd
 loader/**/*.dwo
+loader/linux/Makefile
 
 # Windows Loader
 loader/windows/x64/

--- a/cmake/depend/bsl.cmake
+++ b/cmake/depend/bsl.cmake
@@ -19,10 +19,12 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+set(GIT_TAG         4215efc76ff0997a44f39a16f6f84b487cef5bf6)
+
 FetchContent_Declare(
     bsl
     GIT_REPOSITORY  https://github.com/bareflank/bsl.git
-    GIT_TAG         4215efc76ff0997a44f39a16f6f84b487cef5bf6
+    GIT_TAG         ${GIT_TAG}
 )
 
 FetchContent_GetProperties(bsl)
@@ -33,3 +35,6 @@ if(NOT bsl_POPULATED)
     FetchContent_Populate(bsl)
     add_subdirectory(${bsl_SOURCE_DIR} ${bsl_BINARY_DIR})
 endif()
+
+include(${bsl_SOURCE_DIR}/cmake/function/bf_check_dependency.cmake)
+bf_check_dependency(bsl ${GIT_TAG})

--- a/cmake/target/loader_build.cmake
+++ b/cmake/target/loader_build.cmake
@@ -20,6 +20,12 @@
 # SOFTWARE.
 
 if(HYPERVISOR_BUILD_LOADER AND NOT HYPERVISOR_TARGET_ARCH STREQUAL "aarch64")
+    configure_file(
+        ${hypervisor_SOURCE_DIR}/loader/linux/Makefile.in
+        ${hypervisor_SOURCE_DIR}/loader/linux/Makefile
+        @ONLY
+    )
+
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
         add_custom_target(loader_build
             COMMAND ${CMAKE_COMMAND} -E chdir ${hypervisor_SOURCE_DIR}/loader/linux make CMAKE_BINARY_DIR='${CMAKE_BINARY_DIR}'

--- a/loader/linux/Makefile.in
+++ b/loader/linux/Makefile.in
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 TARGET_MODULE := bareflank_loader
-VENDOR_ID := $(shell lscpu | grep 'Vendor ID')
+VENDOR_ID := @HYPERVISOR_TARGET_ARCH@
 
 ifneq ($(KERNELRELEASE),)
 	obj-m := $(TARGET_MODULE).o

--- a/loader/src/x64/amd/check_cpu_configuration.c
+++ b/loader/src/x64/amd/check_cpu_configuration.c
@@ -84,17 +84,17 @@ check_for_amd(void) NOEXCEPT
     intrinsic_cpuid(&eax, &ebx, &ecx, &edx);
 
     if (CPUID_VENDOR_EBX != ebx) {
-        bferror_x32("cpu is vendor is not AuthenticAMD", ebx);
+        bferror_x32("cpu vendor is not AuthenticAMD", ebx);
         return LOADER_FAILURE;
     }
 
     if (CPUID_VENDOR_ECX != ecx) {
-        bferror_x32("cpu is vendor is not AuthenticAMD", ecx);
+        bferror_x32("cpu vendor is not AuthenticAMD", ecx);
         return LOADER_FAILURE;
     }
 
     if (CPUID_VENDOR_EDX != edx) {
-        bferror_x32("cpu is vendor is not AuthenticAMD", edx);
+        bferror_x32("cpu vendor is not AuthenticAMD", edx);
         return LOADER_FAILURE;
     }
 

--- a/loader/src/x64/intel/check_cpu_configuration.c
+++ b/loader/src/x64/intel/check_cpu_configuration.c
@@ -106,17 +106,17 @@ check_for_intel(void) NOEXCEPT
     intrinsic_cpuid(&eax, &ebx, &ecx, &edx);
 
     if (CPUID_VENDOR_EBX != ebx) {
-        bferror_x32("cpu is vendor is not GenuineIntel", ebx);
+        bferror_x32("cpu vendor is not GenuineIntel", ebx);
         return LOADER_FAILURE;
     }
 
     if (CPUID_VENDOR_ECX != ecx) {
-        bferror_x32("cpu is vendor is not GenuineIntel", ecx);
+        bferror_x32("cpu vendor is not GenuineIntel", ecx);
         return LOADER_FAILURE;
     }
 
     if (CPUID_VENDOR_EDX != edx) {
-        bferror_x32("cpu is vendor is not GenuineIntel", edx);
+        bferror_x32("cpu vendor is not GenuineIntel", edx);
         return LOADER_FAILURE;
     }
 


### PR DESCRIPTION
This patch fixes an issue where the machine would hang when trying to load the hypervisor. This would occur if the cmake `HYPERVISOR_TARGET_ARCH` variable is set to a different target architecture than the architecture of the machine it is being compiled and tested on, bypassing the CPU checks that are done in the loader.

This patch set also includes other minor improvements, such as:
- ability to trigger CI on any branch
- cmake will now warn if a dependency of this project is not at the expected git tag version. i.e. when cmake is configured with `-DFETCHCONTENT_SOURCE_DIR_BSL=<local_path_to_bsl>` 