### PR TITLE
Don't set reserved bits in MSR_FMASK

### DIFF
--- a/loader/src/x64/alloc_and_copy_mk_state.c
+++ b/loader/src/x64/alloc_and_copy_mk_state.c
@@ -160,7 +160,7 @@
 #define MK_MSR_STAR ((uint64_t)0x001B001000000000)
 
 /** @brief defines the FMASK MSR used by the microkernel */
-#define MK_MSR_FMASK ((uint64_t)0xFFFFFFFFFFFBFFFD)
+#define MK_MSR_FMASK ((uint64_t)0x00000000FFFBFFFD)
 
 /** @brief defines the CPUID leaf for extended state enumeration */
 #define CPUID_EXTENDED_STATE ((uint32_t)0xD)


### PR DESCRIPTION
Setting reserved bits causes loader to triple-fault when setting MSR_FMASK at least on Ryzen 4650 when running nested under QEMU/KVM.

With reserved bits cleared (upper half of register) the hypervisor can boot successfully.