### PR TITLE
Fix attribute ordering

### DIFF
--- a/kernel/src/main.cpp
+++ b/kernel/src/main.cpp
@@ -115,7 +115,7 @@ namespace mk
     ///   @return Returns bsl::errc_success on success, bsl::errc_failure
     ///     otherwise
     ///
-    [[nodiscard]] extern "C" auto
+    extern "C" [[nodiscard]] auto
     dispatch_syscall_trampoline(tls_t *const pmut_tls) noexcept -> bsl::uint64
     {
         bsl::expects(nullptr != pmut_tls);
@@ -145,7 +145,7 @@ namespace mk
     ///   @return Returns bsl::errc_success on success, bsl::errc_failure
     ///     otherwise
     ///
-    [[nodiscard]] extern "C" auto
+    extern "C" [[nodiscard]] auto
     mk_main(loader::mk_args_t *const pmut_args, tls_t *const pmut_tls) noexcept -> bsl::errc_type
     {
         bsl::expects(nullptr != pmut_tls);


### PR DESCRIPTION
When trying to build the hypervisor I got the following error:
```
main.cpp:118:5: error: an attribute list cannot appear here
  118 |     [[nodiscard]] extern "C" auto
      |     ^~~~~~~~~~~~~
```

Apparently putting an attribute list before `extern "C"` doesn't conform to the C++ standard and clang has stopped allowing this at some point:
https://reviews.llvm.org/D126061

This pr fixes the two declarations where the wrong order was used.
